### PR TITLE
add protection against replay between accounts

### DIFF
--- a/contracts/Self.cairo
+++ b/contracts/Self.cairo
@@ -1,0 +1,9 @@
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+
+@view
+func get_self{ syscall_ptr: felt*}() -> (address: felt):
+    let (caller) = get_caller_address()
+    return (address=caller)
+end


### PR DESCRIPTION
Hey guys, super cool project!

I really like how you use the Accounts as a mechanism to separate and deal with authentication and replay attacks! 

I think there is a slight gap left which would allow for replay attacks. The vector is not insanely significant (it only affects people that re-use keys between accounts), and the repo is still experimental, which is why I'm making this pr out in the open. (It could be cool to add a disclosure policy in the security tab so that people know when it's okay/not okay to submit bugs out in the open)

When a user creates two Accounts with the same private key, then the signatures valid for one, will also be valid for the other. 

I think it's possible to harden the implementation by adding the address of the account to the message being signed. Unfortunately this isn't super easy with the current starknet interfaces. In this pr I've drafted a potential solution that creates a kind of "self()" precompile/library contract.

Lmk what you think!  