### PR TITLE
Implement ERC721.cairo

### DIFF
--- a/contracts/token/ERC721.cairo
+++ b/contracts/token/ERC721.cairo
@@ -3,7 +3,6 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
-from starkware.starknet.common.storage import Storage
 from starkware.cairo.common.math import assert_not_equal, assert_not_zero
 
 # Missing:
@@ -32,10 +31,24 @@ end
 func initialized() -> (res : felt):
 end
 
+@storage_var
+func name_() -> (res : felt):
+end
+
+@storage_var
+func symbol_() -> (res : felt):
+end
+
+@storage_var
+func token_uri_() -> (res : felt):
+end
+
+# eip155:chainID/erc721:contract/tokenID
+# eip155:chainID/erc1155:contract/tokenID
+# felt    felt   felt     2 felt   3 felt
+
 @external
-func initialize{
-        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-        ):
+func initialize{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}():
     let (_initialized) = initialized.read()
     assert _initialized = 0
     initialized.write(1)
@@ -44,8 +57,7 @@ func initialize{
 end
 
 @view
-func balance_of{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        owner : felt) -> (res : felt):
+func balance_of{pedersen_ptr : HashBuiltin*, range_check_ptr}(owner : felt) -> (res : felt):
     assert_not_zero(owner)
 
     let (res) = balances.read(owner=owner)
@@ -53,24 +65,21 @@ func balance_of{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check
 end
 
 @view
-func owner_of{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        token_id : felt) -> (res : felt):
+func owner_of{pedersen_ptr : HashBuiltin*, range_check_ptr}(token_id : felt) -> (res : felt):
     let (res) = owners.read(token_id=token_id)
     assert_not_zero(res)
 
     return (res)
 end
 
-func _approve{
-        syscall_ptr : felt*, storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+func _approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         to : felt, token_id : felt):
     token_approvals.write(token_id=token_id, value=to)
     return ()
 end
 
 @external
-func approve{
-        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+func approve{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
         to : felt, token_id : felt):
     let (owner) = owners.read(token_id)
 
@@ -83,8 +92,7 @@ func approve{
     return ()
 end
 
-func _is_operator_or_owner{
-        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+func _is_operator_or_owner{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
         address : felt) -> (res : felt):
     let (caller) = get_caller_address()
 
@@ -96,8 +104,7 @@ func _is_operator_or_owner{
     return (is_approved_for_all)
 end
 
-func _is_approved_or_owner{
-        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+func _is_approved_or_owner{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
         spender : felt, token_id : felt) -> (res : felt):
     alloc_locals
 
@@ -122,8 +129,7 @@ func _is_approved_or_owner{
     return (0)
 end
 
-func _exists{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        token_id : felt) -> (res : felt):
+func _exists{pedersen_ptr : HashBuiltin*, range_check_ptr}(token_id : felt) -> (res : felt):
     let (res) = owners.read(token_id)
 
     if res == 0:
@@ -134,8 +140,7 @@ func _exists{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_pt
 end
 
 @view
-func get_approved{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        token_id : felt) -> (res : felt):
+func get_approved{pedersen_ptr : HashBuiltin*, range_check_ptr}(token_id : felt) -> (res : felt):
     let (exists) = _exists(token_id)
     assert exists = 1
 
@@ -144,14 +149,13 @@ func get_approved{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_che
 end
 
 @view
-func is_approved_for_all{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+func is_approved_for_all{pedersen_ptr : HashBuiltin*, range_check_ptr}(
         owner : felt, operator : felt) -> (res : felt):
     let (res) = operator_approvals.read(owner=owner, operator=operator)
     return (res)
 end
 
-func _mint{
-        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+func _mint{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
         to : felt, token_id : felt):
     assert_not_zero(to)
 
@@ -166,9 +170,7 @@ func _mint{
     return ()
 end
 
-func _burn{
-        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-        token_id : felt):
+func _burn{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(token_id : felt):
     alloc_locals
 
     let (local owner) = owner_of(token_id)
@@ -186,8 +188,7 @@ func _burn{
     return ()
 end
 
-func _transfer{
-        syscall_ptr : felt*, storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+func _transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         _from : felt, to : felt, token_id : felt):
     let (_owner_of) = owner_of(token_id)
     assert _owner_of = _from
@@ -211,7 +212,7 @@ func _transfer{
     return ()
 end
 
-func _set_approval_for_all{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+func _set_approval_for_all{pedersen_ptr : HashBuiltin*, range_check_ptr}(
         owner : felt, operator : felt, approved : felt):
     assert_not_equal(owner, operator)
 
@@ -223,8 +224,7 @@ func _set_approval_for_all{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, 
 end
 
 @external
-func set_approval_for_all{
-        syscall_ptr : felt*, storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+func set_approval_for_all{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         operator : felt, approved : felt):
     let (caller) = get_caller_address()
 
@@ -233,8 +233,7 @@ func set_approval_for_all{
 end
 
 @external
-func transfer_from{
-        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+func transfer_from{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
         _from : felt, to : felt, token_id : felt):
     let (caller) = get_caller_address()
     _is_approved_or_owner(caller, token_id=token_id)

--- a/contracts/token/ERC721.cairo
+++ b/contracts/token/ERC721.cairo
@@ -158,8 +158,6 @@ func _mint{
     let (exists) = _exists(token_id)
     assert exists = 0
 
-    _beforeTokenTransfer(0, to, token_id)
-
     let (balance) = balances.read(to)
     balances.write(to, balance + 1)
 
@@ -174,8 +172,6 @@ func _burn{
     alloc_locals
 
     let (local owner) = owner_of(token_id)
-
-    _beforeTokenTransfer(owner, 0, token_id)
 
     # Clear approvals
     _approve(0, token_id)
@@ -197,8 +193,6 @@ func _transfer{
     assert _owner_of = _from
 
     assert_not_zero(to)
-
-    _beforeTokenTransfer(_from, to, token_id)
 
     # Clear approvals
     _approve(0, token_id)
@@ -246,11 +240,5 @@ func transfer_from{
     _is_approved_or_owner(caller, token_id=token_id)
 
     _transfer(_from, to, token_id)
-    return ()
-end
-
-func _beforeTokenTransfer{
-        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-        _from : felt, to : felt, token_id : felt):
     return ()
 end

--- a/contracts/token/ERC721.cairo
+++ b/contracts/token/ERC721.cairo
@@ -4,164 +4,246 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
 from starkware.starknet.common.storage import Storage
-from starkware.cairo.common.math import assert_nn_le
+from starkware.cairo.common.math import assert_not_equal, assert_not_zero
+
+# Missing:
+# symbol
+# name
+# tokenURI
+# _baseURI
 
 @storage_var
-func owner(token_id: felt) -> (res: felt):
+func owners(token_id : felt) -> (res : felt):
 end
 
 @storage_var
-func balance(owner: felt) -> (res: felt):
+func balances(owner : felt) -> (res : felt):
 end
 
 @storage_var
-func token_approvals(token_id: felt) -> (res: felt):
+func token_approvals(token_id : felt) -> (res : felt):
 end
 
 @storage_var
-func operator_approvals(owner: felt, operator: felt) -> (res: felt):
+func operator_approvals(owner : felt, operator : felt) -> (res : felt):
 end
 
 @storage_var
-func initialized() -> (res: felt):
+func initialized() -> (res : felt):
 end
 
 @external
 func initialize{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } ():
+        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        ):
     let (_initialized) = initialized.read()
     assert _initialized = 0
     initialized.write(1)
 
-    let (sender) = get_caller_address()
-    _mint(sender, 1000)
     return ()
 end
 
 @view
-func balance_of{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (owner: felt) -> (res: felt):
-    let (res) = balance.read(owner=owner)
+func balance_of{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        owner : felt) -> (res : felt):
+    assert_not_zero(owner)
+
+    let (res) = balances.read(owner=owner)
     return (res)
 end
 
 @view
-func owner_of{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (token_id: felt) -> (res: felt):
-    let (res) = owner.read(token_id=token_id)
+func owner_of{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        token_id : felt) -> (res : felt):
+    let (res) = owners.read(token_id=token_id)
+    assert_not_zero(res)
+
     return (res)
+end
+
+func _approve{
+        syscall_ptr : felt*, storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        to : felt, token_id : felt):
+    token_approvals.write(token_id=token_id, value=to)
+    return ()
 end
 
 @external
 func approve{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (to: felt, token_id: felt):
-    let (_owner) = owner.read(token_id)
+        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        to : felt, token_id : felt):
+    let (owner) = owners.read(token_id)
 
-    if _owner == to:
-        assert 1 = 0
-    end
+    assert_not_equal(owner, to)
 
-    _is_approved_or_owner()
-    token_approvals.write(token_id=token_id, to)
+    let (is_operator_or_owner) = _is_operator_or_owner(owner)
+    assert_not_zero(is_operator_or_owner)
+
+    _approve(to, token_id)
     return ()
 end
 
-func _is_approved_or_owner{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (to: felt, token_id: felt):
+func _is_operator_or_owner{
+        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        address : felt) -> (res : felt):
     let (caller) = get_caller_address()
-    let (_owner) = owner.read(token_id)
 
-    if caller == _owner:
-        return ()
+    if caller == address:
+        return (1)
     end
 
-    let (res) = token_approvals(token_id)
-    assert res = caller
+    let (is_approved_for_all) = operator_approvals.read(owner=caller, operator=address)
+    return (is_approved_for_all)
+end
+
+func _is_approved_or_owner{
+        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        spender : felt, token_id : felt) -> (res : felt):
+    let (exists) = _exists(token_id)
+    assert exists = 1
+
+    let (owner) = owner_of(token_id)
+    if owner == spender:
+        return (1)
+    end
+
+    let (approved_addr) = get_approved(token_id)
+    if approved_addr == spender:
+        return (1)
+    end
+
+    # Temporary workaround for `owner` because of revoked reference
+    let (owner) = owner_of(token_id)
+
+    let (is_operator) = is_approved_for_all(owner, spender)
+    if is_operator == 1:
+        return (1)
+    end
+
+    return (0)
+end
+
+func _exists{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        token_id : felt) -> (res : felt):
+    let (res) = owners.read(token_id)
+
+    if res == 0:
+        return (0)
+    else:
+        return (1)
+    end
 end
 
 @view
-func get_approved{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (token_id: felt) -> (res: felt):
+func get_approved{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        token_id : felt) -> (res : felt):
+    let (exists) = _exists(token_id)
+    assert exists = 1
+
     let (res) = token_approvals.read(token_id=token_id)
     return (res)
 end
 
-func _mint{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (recipient: felt, amount: felt):
-    let (res) = balances.read(user=recipient)
-    balances.write(recipient, res + amount)
+@view
+func is_approved_for_all{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        owner : felt, operator : felt) -> (res : felt):
+    let (res) = operator_approvals.read(owner=owner, operator=operator)
+    return (res)
+end
 
-    let (supply) = total_supply.read()
-    total_supply.write(supply + amount)
+func _mint{
+        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        to : felt, token_id : felt):
+    assert_not_zero(to)
+
+    let (exists) = _exists(token_id)
+    assert_not_zero(exists)
+
+    # beforeTokenTransfer should be here
+
+    let (balance) = balances.read(to)
+    balances.write(to, balance + 1)
+
+    owners.write(token_id, to)
+
+    return ()
+end
+
+func _burn{
+        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        token_id : felt):
+    let (owner) = owner_of(token_id)
+
+    # beforeTokenTransfer should be here
+
+    # Clear approvals
+    _approve(0, token_id)
+
+    # Decrease owner balance
+    let (balance) = balances.read(owner)
+    balances.write(owner, balance - 1)
+
+    # Delete owner
+    owners.write(token_id, 0)
+
     return ()
 end
 
 func _transfer{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (sender: felt, recipient: felt, amount: felt):
-    # validate sender has enough funds
-    let (sender_balance) = balances.read(user=sender)
-    assert_nn_le(amount, sender_balance)
+        syscall_ptr : felt*, storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        _from : felt, to : felt, token_id : felt):
+    let (_owner_of) = owner_of(token_id)
+    assert _owner_of = _from
 
-    # substract from sender
-    balances.write(sender, sender_balance - amount)
+    assert_not_zero(to)
 
-    # add to recipient
-    let (res) = balances.read(user=recipient)
-    balances.write(recipient, res + amount)
+    # beforeTokenTransfer should be here
+
+    # Clear approvals
+    _approve(0, token_id)
+
+    # Decrease owner balance
+    let (owner_bal) = balances.read(_from)
+    balances.write(owner=_from, value=(owner_bal - 1))
+
+    # Increase receiver balance
+    let (receiver_bal) = balances.read(to)
+    balances.write(owner=to, value=(receiver_bal + 1))
+
+    # Update token_id owner
+    owners.write(token_id=token_id, value=to)
+
+    return ()
+end
+
+func _set_approval_for_all{storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        owner : felt, operator : felt, approved : felt):
+    assert_not_equal(owner, operator)
+
+    # Make sure `approved` is a boolean (0 or 1)
+    assert approved * (1 - approved) = 0
+
+    operator_approvals.write(owner=owner, operator=operator, value=approved)
     return ()
 end
 
 @external
-func transfer{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (recipient: felt, amount: felt):
-    let (sender) = get_caller_address()
-    _transfer(sender, recipient, amount)
+func set_approval_for_all{
+        syscall_ptr : felt*, storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        operator : felt, approved : felt):
+    let (caller) = get_caller_address()
+
+    _set_approval_for_all(caller, operator, approved)
     return ()
 end
 
 @external
 func transfer_from{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (sender: felt, recipient: felt, amount: felt):
+        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        _from : felt, to : felt, token_id : felt):
     let (caller) = get_caller_address()
-    let (caller_allowance) = allowances.read(owner=sender, spender=caller)
-    assert_nn_le(amount, caller_allowance)
-    _transfer(sender, recipient, amount)
-    allowances.write(sender, caller, caller_allowance - amount)
+    _is_approved_or_owner(caller, token_id=token_id)
+
+    _transfer(_from, to, token_id)
     return ()
 end

--- a/contracts/token/ERC721.cairo
+++ b/contracts/token/ERC721.cairo
@@ -156,7 +156,7 @@ func _mint{
     assert_not_zero(to)
 
     let (exists) = _exists(token_id)
-    assert_not_zero(exists)
+    assert exists = 0
 
     _beforeTokenTransfer(0, to, token_id)
 

--- a/contracts/token/ERC721.cairo
+++ b/contracts/token/ERC721.cairo
@@ -159,7 +159,7 @@ func _mint{
     let (exists) = _exists(token_id)
     assert_not_zero(exists)
 
-    # beforeTokenTransfer should be here
+    _beforeTokenTransfer(0, to, token_id)
 
     let (balance) = balances.read(to)
     balances.write(to, balance + 1)
@@ -174,10 +174,13 @@ func _burn{
         token_id : felt):
     let (owner) = owner_of(token_id)
 
-    # beforeTokenTransfer should be here
+    _beforeTokenTransfer(owner, 0, token_id)
 
     # Clear approvals
     _approve(0, token_id)
+
+    # Temporary workaround for revoked reference
+    let (owner) = owner_of(token_id)
 
     # Decrease owner balance
     let (balance) = balances.read(owner)
@@ -197,7 +200,7 @@ func _transfer{
 
     assert_not_zero(to)
 
-    # beforeTokenTransfer should be here
+    _beforeTokenTransfer(_from, to, token_id)
 
     # Clear approvals
     _approve(0, token_id)
@@ -245,5 +248,11 @@ func transfer_from{
     _is_approved_or_owner(caller, token_id=token_id)
 
     _transfer(_from, to, token_id)
+    return ()
+end
+
+func _beforeTokenTransfer{
+        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        _from : felt, to : felt, token_id : felt):
     return ()
 end

--- a/contracts/token/ERC721.cairo
+++ b/contracts/token/ERC721.cairo
@@ -99,10 +99,12 @@ end
 func _is_approved_or_owner{
         storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
         spender : felt, token_id : felt) -> (res : felt):
+    alloc_locals
+
     let (exists) = _exists(token_id)
     assert exists = 1
 
-    let (owner) = owner_of(token_id)
+    let (local owner) = owner_of(token_id)
     if owner == spender:
         return (1)
     end
@@ -111,9 +113,6 @@ func _is_approved_or_owner{
     if approved_addr == spender:
         return (1)
     end
-
-    # Temporary workaround for `owner` because of revoked reference
-    let (owner) = owner_of(token_id)
 
     let (is_operator) = is_approved_for_all(owner, spender)
     if is_operator == 1:
@@ -172,15 +171,14 @@ end
 func _burn{
         storage_ptr : Storage*, pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
         token_id : felt):
-    let (owner) = owner_of(token_id)
+    alloc_locals
+
+    let (local owner) = owner_of(token_id)
 
     _beforeTokenTransfer(owner, 0, token_id)
 
     # Clear approvals
     _approve(0, token_id)
-
-    # Temporary workaround for revoked reference
-    let (owner) = owner_of(token_id)
 
     # Decrease owner balance
     let (balance) = balances.read(owner)


### PR DESCRIPTION
This PR implements ther [ERC721](https://eips.ethereum.org/EIPS/eip-721) standard for starknet contracts written in [Cairo](https://www.cairo-lang.org/).

The implementation here tries to be as close as a literal translation of [OpenZeppelin's ERC721.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol) contract.

The `initialize` function should be similar to the `constructor` function in solidity.

Missing feature are:
- _symbol
- _name
- tokenURI
- _baseURI

- `symbol` and `name` have not been implemented because cairo currently doesn't have a `string` type.
- `tokenURI` and `baseURI` are WIP (by WIP I mean more like R&D at this point :))

Note: I'm not familiar with the hook `_beforeTokenTransfer` so the implementation in Cairo might be a little bit naive.

