### PR TITLE
cairo-0.5.0 compatibility for Account and ERC20

### DIFF
--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -6,19 +6,18 @@ from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.signature import verify_ecdsa_signature
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.starknet.common.syscalls import call_contract, get_caller_address
-from starkware.starknet.common.storage import Storage
 
 #
 # Structs
 #
 
 struct Message:
-    member sender: felt
-    member to: felt
-    member selector: felt
-    member calldata: felt*
-    member calldata_size: felt
-    member nonce: felt
+    member sender : felt
+    member to : felt
+    member selector : felt
+    member calldata : felt*
+    member calldata_size : felt
+    member nonce : felt
 end
 
 #
@@ -26,19 +25,19 @@ end
 #
 
 @storage_var
-func current_nonce() -> (res: felt):
+func current_nonce() -> (res : felt):
 end
 
 @storage_var
-func public_key() -> (res: felt):
+func public_key() -> (res : felt):
 end
 
 @storage_var
-func initialized() -> (res: felt):
+func initialized() -> (res : felt):
 end
 
 @storage_var
-func address() -> (res: felt):
+func address() -> (res : felt):
 end
 
 #
@@ -46,12 +45,7 @@ end
 #
 
 @view
-func assert_only_self{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    }():
+func assert_only_self{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}():
     let (self) = address.read()
     let (caller) = get_caller_address()
     assert self = caller
@@ -59,11 +53,7 @@ func assert_only_self{
 end
 
 @view
-func assert_initialized{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }():
+func assert_initialized{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}():
     let (_initialized) = initialized.read()
     assert _initialized = 1
     return ()
@@ -74,19 +64,21 @@ end
 #
 
 @view
-func get_public_key{ storage_ptr: Storage*, pedersen_ptr: HashBuiltin*, range_check_ptr }() -> (res: felt):
+func get_public_key{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
+        res : felt):
     let (res) = public_key.read()
     return (res=res)
 end
 
 @view
-func get_address{ storage_ptr: Storage*, pedersen_ptr: HashBuiltin*, range_check_ptr }() -> (res: felt):
+func get_address{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
+        res : felt):
     let (res) = address.read()
     return (res=res)
 end
 
 @view
-func get_nonce{ storage_ptr: Storage*, pedersen_ptr: HashBuiltin*, range_check_ptr }() -> (res: felt):
+func get_nonce{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (res : felt):
     let (res) = current_nonce.read()
     return (res=res)
 end
@@ -96,12 +88,8 @@ end
 #
 
 @external
-func set_public_key{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    }(new_public_key: felt):
+func set_public_key{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        new_public_key : felt):
     assert_only_self()
     public_key.write(new_public_key)
     return ()
@@ -112,11 +100,8 @@ end
 #
 
 @external
-func initialize{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (_public_key: felt, _address: felt):
+func initialize{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        _public_key : felt, _address : felt):
     let (_initialized) = initialized.read()
     assert _initialized = 0
     initialized.write(1)
@@ -131,18 +116,12 @@ end
 
 @view
 func is_valid_signature{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        ecdsa_ptr: SignatureBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (
-        hash: felt,
-        signature_len: felt,
-        signature: felt*
-    ) -> ():
+        pedersen_ptr : HashBuiltin*, ecdsa_ptr : SignatureBuiltin*, syscall_ptr : felt*,
+        range_check_ptr}(hash : felt, signature_len : felt, signature : felt*) -> ():
+    alloc_locals
     assert_initialized()
     let (_public_key) = public_key.read()
+    local syscall_ptr : felt* = syscall_ptr
     # This interface expects a signature pointer and length to make
     # no assumption about signature validation schemes.
     # But this implementation does, and it expects a (sig_r, sig_s) pair.
@@ -150,29 +129,17 @@ func is_valid_signature{
     let sig_s = signature[1]
 
     verify_ecdsa_signature(
-        message=hash,
-        public_key=_public_key,
-        signature_r=sig_r,
-        signature_s=sig_s)
+        message=hash, public_key=_public_key, signature_r=sig_r, signature_s=sig_s)
 
     return ()
 end
 
 @external
 func execute{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        ecdsa_ptr: SignatureBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (
-        to: felt,
-        selector: felt,
-        calldata_len: felt,
-        calldata: felt*,
-        signature_len: felt,
-        signature: felt*
-    ) -> (response : felt):
+        pedersen_ptr : HashBuiltin*, ecdsa_ptr : SignatureBuiltin*, syscall_ptr : felt*,
+        range_check_ptr}(
+        to : felt, selector : felt, calldata_len : felt, calldata : felt*, signature_len : felt,
+        signature : felt*) -> (response : felt):
     alloc_locals
     assert_initialized()
 
@@ -180,18 +147,18 @@ func execute{
     let (_address) = address.read()
     let (_current_nonce) = current_nonce.read()
 
-    local storage_ptr : Storage* = storage_ptr
+    local syscall_ptr : felt* = syscall_ptr
     local range_check_ptr = range_check_ptr
     local _current_nonce = _current_nonce
 
-    local message: Message = Message(
+    local message : Message = Message(
         _address,
         to,
         selector,
         calldata,
         calldata_size=calldata_len,
         _current_nonce
-    )
+        )
 
     # validate transaction
     let (hash) = hash_message(&message)
@@ -205,13 +172,12 @@ func execute{
         contract_address=message.to,
         function_selector=message.selector,
         calldata_size=message.calldata_size,
-        calldata=message.calldata
-    )
+        calldata=message.calldata)
 
     return (response=response.retdata_size)
 end
 
-func hash_message{pedersen_ptr : HashBuiltin*}(message: Message*) -> (res: felt):
+func hash_message{pedersen_ptr : HashBuiltin*}(message : Message*) -> (res : felt):
     alloc_locals
     let (res) = hash2{hash_ptr=pedersen_ptr}(message.sender, message.to)
     let (res) = hash2{hash_ptr=pedersen_ptr}(res, message.selector)
@@ -224,10 +190,8 @@ func hash_message{pedersen_ptr : HashBuiltin*}(message: Message*) -> (res: felt)
     return (res=res)
 end
 
-func hash_calldata{pedersen_ptr: HashBuiltin*}(
-        calldata: felt*,
-        calldata_size: felt
-    ) -> (res: felt):
+func hash_calldata{pedersen_ptr : HashBuiltin*}(calldata : felt*, calldata_size : felt) -> (
+        res : felt):
     if calldata_size == 0:
         return (res=0)
     end

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -3,7 +3,6 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
-from starkware.starknet.common.storage import Storage
 from starkware.cairo.common.math import assert_nn_le
 
 #
@@ -11,23 +10,23 @@ from starkware.cairo.common.math import assert_nn_le
 #
 
 @storage_var
-func balances(user: felt) -> (res: felt):
+func balances(user : felt) -> (res : felt):
 end
 
 @storage_var
-func allowances(owner: felt, spender: felt) -> (res: felt):
+func allowances(owner : felt, spender : felt) -> (res : felt):
 end
 
 @storage_var
-func total_supply() -> (res: felt):
+func total_supply() -> (res : felt):
 end
 
 @storage_var
-func decimals() -> (res: felt):
+func decimals() -> (res : felt):
 end
 
 @storage_var
-func initialized() -> (res: felt):
+func initialized() -> (res : felt):
 end
 
 #
@@ -35,41 +34,29 @@ end
 #
 
 @view
-func get_total_supply{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } () -> (res: felt):
+func get_total_supply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+        res : felt):
     let (res) = total_supply.read()
     return (res)
 end
 
 @view
-func get_decimals{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } () -> (res: felt):
+func get_decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+        res : felt):
     let (res) = decimals.read()
     return (res)
 end
 
 @view
-func balance_of{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (user: felt) -> (res: felt):
+func balance_of{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(user : felt) -> (
+        res : felt):
     let (res) = balances.read(user=user)
     return (res)
 end
 
 @view
-func allowance{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (owner: felt, spender: felt) -> (res: felt):
+func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        owner : felt, spender : felt) -> (res : felt):
     let (res) = allowances.read(owner=owner, spender=spender)
     return (res)
 end
@@ -79,12 +66,7 @@ end
 #
 
 @external
-func initialize{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } ():
+func initialize{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}():
     let (_initialized) = initialized.read()
     assert _initialized = 0
     initialized.write(1)
@@ -95,12 +77,8 @@ func initialize{
     return ()
 end
 
-func _mint{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (recipient: felt, amount: felt):
+func _mint{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        recipient : felt, amount : felt):
     let (res) = balances.read(user=recipient)
     balances.write(recipient, res + amount)
 
@@ -109,11 +87,8 @@ func _mint{
     return ()
 end
 
-func _transfer{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (sender: felt, recipient: felt, amount: felt):
+func _transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        sender : felt, recipient : felt, amount : felt):
     # validate sender has enough funds
     let (sender_balance) = balances.read(user=sender)
     assert_nn_le(amount, sender_balance)
@@ -127,35 +102,23 @@ func _transfer{
     return ()
 end
 
-func _approve{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (caller: felt, spender: felt, amount: felt):
+func _approve{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        caller : felt, spender : felt, amount : felt):
     allowances.write(caller, spender, amount)
     return ()
 end
 
 @external
-func transfer{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (recipient: felt, amount: felt):
+func transfer{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        recipient : felt, amount : felt):
     let (sender) = get_caller_address()
     _transfer(sender, recipient, amount)
     return ()
 end
 
 @external
-func transfer_from{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (sender: felt, recipient: felt, amount: felt):
+func transfer_from{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        sender : felt, recipient : felt, amount : felt):
     let (caller) = get_caller_address()
     let (caller_allowance) = allowances.read(owner=sender, spender=caller)
     assert_nn_le(amount, caller_allowance)
@@ -165,24 +128,16 @@ func transfer_from{
 end
 
 @external
-func approve{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (spender: felt, amount: felt):
+func approve{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        spender : felt, amount : felt):
     let (caller) = get_caller_address()
     _approve(caller, spender, amount)
     return ()
 end
 
 @external
-func increase_allowance{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (spender: felt, added_value: felt):
+func increase_allowance{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        spender : felt, added_value : felt):
     let (caller) = get_caller_address()
     let (current_allowance) = allowances.read(caller, spender)
     # using a tempvar for internal check
@@ -190,21 +145,16 @@ func increase_allowance{
     # overflow check
     assert_nn_le(current_allowance + added_value, res)
     _approve(caller, spender, res)
-    return()
+    return ()
 end
 
 @external
-func decrease_allowance{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (spender: felt, subtracted_value: felt):
+func decrease_allowance{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+        spender : felt, subtracted_value : felt):
     let (caller) = get_caller_address()
     let (current_allowance) = allowances.read(owner=caller, spender=spender)
     # checks that the decreased balance isn't below zero
     assert_nn_le(subtracted_value, current_allowance)
     _approve(caller, spender, current_allowance - subtracted_value)
-    return()
+    return ()
 end
-


### PR DESCRIPTION
Changes are minimal to get compilation working in cairo-0.5.0:
(1) Remove `StorageBuiltin` and `storage_ptr` implicit args, because they were merged into `syscall_ptr`
(2) Add `syscall_ptr` implicit arg where necessary and use locals to prevent it from being revoked
(3) In `Signer`, update `send_transaction` to account for the new cairo-0.5.0 return values of `call` and `invoke`.

Limitations of this PR:
- Apologies: my local `cairo-format` tool automatically munged the pretty formatting you had.
- This PR doesn't update every cairo contract in the repository (only Account.cairo and ERC20.cairo).
- This PR doesn't update `tests/`: it will be necessary to adjust these to account for starkware's changes to the return values of `call` and `invoke` as in item (3).

Due to the limitations, this PR may be more helpful as a reference for making your own changes. No pressure to merge it — feel free to add on top of it, close it, whatever is most helpful!