### PR TITLE
Uint256 Integration

### DIFF
--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -6,7 +6,6 @@ from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.signature import verify_ecdsa_signature
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.starknet.common.syscalls import call_contract, get_caller_address
-from starkware.starknet.common.storage import Storage
 
 #
 # Structs
@@ -47,11 +46,8 @@ end
 
 @view
 func assert_only_self{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    }():
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} ():
     let (self) = address.read()
     let (caller) = get_caller_address()
     assert self = caller
@@ -60,10 +56,8 @@ end
 
 @view
 func assert_initialized{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }():
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}():
     let (_initialized) = initialized.read()
     assert _initialized = 1
     return ()
@@ -74,19 +68,24 @@ end
 #
 
 @view
-func get_public_key{ storage_ptr: Storage*, pedersen_ptr: HashBuiltin*, range_check_ptr }() -> (res: felt):
+func get_public_key{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}() -> (res: felt):
     let (res) = public_key.read()
     return (res=res)
 end
 
 @view
-func get_address{ storage_ptr: Storage*, pedersen_ptr: HashBuiltin*, range_check_ptr }() -> (res: felt):
+func get_address{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} () -> (res: felt):
     let (res) = address.read()
     return (res=res)
 end
 
 @view
-func get_nonce{ storage_ptr: Storage*, pedersen_ptr: HashBuiltin*, range_check_ptr }() -> (res: felt):
+func get_nonce{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} () -> (res: felt):
     let (res) = current_nonce.read()
     return (res=res)
 end
@@ -97,11 +96,8 @@ end
 
 @external
 func set_public_key{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    }(new_public_key: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (new_public_key: felt):
     assert_only_self()
     public_key.write(new_public_key)
     return ()
@@ -113,10 +109,8 @@ end
 
 @external
 func initialize{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (_public_key: felt, _address: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (_public_key: felt, _address: felt):
     let (_initialized) = initialized.read()
     assert _initialized = 0
     initialized.write(1)
@@ -131,12 +125,8 @@ end
 
 @view
 func is_valid_signature{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        ecdsa_ptr: SignatureBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr, ecdsa_ptr: SignatureBuiltin*} (
         hash: felt,
         signature_len: felt,
         signature: felt*
@@ -160,12 +150,8 @@ end
 
 @external
 func execute{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        ecdsa_ptr: SignatureBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr, ecdsa_ptr: SignatureBuiltin*} (
         to: felt,
         selector: felt,
         calldata_len: felt,
@@ -180,7 +166,7 @@ func execute{
     let (_address) = address.read()
     let (_current_nonce) = current_nonce.read()
 
-    local storage_ptr : Storage* = storage_ptr
+    local syscall_ptr : felt* = syscall_ptr
     local range_check_ptr = range_check_ptr
     local _current_nonce = _current_nonce
 

--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -131,10 +131,8 @@ func is_valid_signature{
         signature_len: felt,
         signature: felt*
     ) -> ():
-    #alloc_locals
     assert_initialized()
     let (_public_key) = public_key.read()
-    #local syscall_ptr : felt* = syscall_ptr
 
     # This interface expects a signature pointer and length to make
     # no assumption about signature validation schemes.

--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -131,8 +131,11 @@ func is_valid_signature{
         signature_len: felt,
         signature: felt*
     ) -> ():
+    #alloc_locals
     assert_initialized()
     let (_public_key) = public_key.read()
+    #local syscall_ptr : felt* = syscall_ptr
+
     # This interface expects a signature pointer and length to make
     # no assumption about signature validation schemes.
     # But this implementation does, and it expects a (sig_r, sig_s) pair.

--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -5,7 +5,7 @@ from starkware.cairo.common.hash import hash2
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.signature import verify_ecdsa_signature
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
-from starkware.starknet.common.syscalls import call_contract, get_caller_address
+from starkware.starknet.common.syscalls import call_contract, get_caller_address, get_tx_signature
 
 #
 # Structs
@@ -104,17 +104,28 @@ func set_public_key{
 end
 
 #
-# Initializer
+# Constructor
 #
+
+@constructor
+func constructor{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (_public_key: felt):
+    public_key.write(_public_key)
+    return()
+end
+
+#
+# Initializer—will remove once this.address is available for the constructor
+#             to set the contract address
 
 @external
 func initialize{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr} (_public_key: felt, _address: felt):
+        range_check_ptr} (_address: felt):
     let (_initialized) = initialized.read()
     assert _initialized = 0
     initialized.write(1)
-    public_key.write(_public_key)
     address.write(_address)
     return ()
 end
@@ -156,9 +167,7 @@ func execute{
         to: felt,
         selector: felt,
         calldata_len: felt,
-        calldata: felt*,
-        signature_len: felt,
-        signature: felt*
+        calldata: felt*
     ) -> (response : felt):
     alloc_locals
     assert_initialized()
@@ -182,6 +191,7 @@ func execute{
 
     # validate transaction
     let (hash) = hash_message(&message)
+    let (signature_len, signature) = get_tx_signature()
     is_valid_signature(hash, signature_len, signature)
 
     # bump nonce

--- a/contracts/AddressRegistry.cairo
+++ b/contracts/AddressRegistry.cairo
@@ -3,7 +3,6 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
-from starkware.starknet.common.storage import Storage
 
 @storage_var
 func L1_address(L2_address: felt) -> (res: felt):
@@ -11,21 +10,16 @@ end
 
 @external
 func get_L1_address{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }(L2_address: felt) -> (res: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (L2_address: felt) -> (res: felt):
     let (res) = L1_address.read(L2_address)
     return (res=res)
 end
 
 @external
 func set_L1_address{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    }(new_L1_address: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (new_L1_address: felt):
     let (caller) = get_caller_address()
     L1_address.write(caller, new_L1_address)
     return ()

--- a/contracts/Initializable.cairo
+++ b/contracts/Initializable.cairo
@@ -2,7 +2,6 @@
 %builtins pedersen range_check
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-#from starkware.starknet.common.storage import Storage
 
 @storage_var
 func _initialized() -> (res: felt):

--- a/contracts/Initializable.cairo
+++ b/contracts/Initializable.cairo
@@ -2,20 +2,24 @@
 %builtins pedersen range_check
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-from starkware.starknet.common.storage import Storage
+#from starkware.starknet.common.storage import Storage
 
 @storage_var
 func _initialized() -> (res: felt):
 end
 
 @external
-func initialized{ storage_ptr: Storage*, pedersen_ptr: HashBuiltin*, range_check_ptr }() -> (res: felt):
+func initialized{ 
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} () -> (res: felt):
     let (res) = _initialized.read()
     return (res=res)
 end
 
 @external
-func initialize{ storage_ptr: Storage*, pedersen_ptr: HashBuiltin*, range_check_ptr }():
+func initialize{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} ():
     let (initialized) = _initialized.read()
     assert initialized = 0
     _initialized.write(1)

--- a/contracts/Ownable.cairo
+++ b/contracts/Ownable.cairo
@@ -1,7 +1,6 @@
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-#from starkware.starknet.common.storage import Storage
 from starkware.starknet.common.syscalls import get_caller_address
 from contracts.Initializable import initialized, initialize
 

--- a/contracts/Ownable.cairo
+++ b/contracts/Ownable.cairo
@@ -1,7 +1,7 @@
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-from starkware.starknet.common.storage import Storage
+#from starkware.starknet.common.storage import Storage
 from starkware.starknet.common.syscalls import get_caller_address
 from contracts.Initializable import initialized, initialize
 
@@ -11,18 +11,16 @@ end
 
 
 @view
-func get_owner{ storage_ptr: Storage*, pedersen_ptr: HashBuiltin*, range_check_ptr }() -> (res: felt):
+func get_owner{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}() -> (res: felt):
     let (res) = _owner.read()
     return (res=res)
 end
 
 @view
 func only_owner{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    }():
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} ():
     let (owner) = _owner.read()
     let (caller) = get_caller_address()
     assert owner = caller
@@ -31,10 +29,8 @@ end
 
 @external
 func initialize_ownable{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (initial_owner: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (initial_owner: felt):
     initialize()
     _owner.write(initial_owner)
     return ()
@@ -42,11 +38,8 @@ end
 
 @external
 func transfer_ownership{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (new_owner: felt) -> (new_owner: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (new_owner: felt) -> (new_owner: felt):
     only_owner()
     _owner.write(new_owner)
     return (new_owner=new_owner)

--- a/contracts/Ownable.cairo
+++ b/contracts/Ownable.cairo
@@ -26,11 +26,10 @@ func only_owner{
     return ()
 end
 
-@external
-func initialize_ownable{
+@constructor
+func constructor{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
         range_check_ptr} (initial_owner: felt):
-    initialize()
     _owner.write(initial_owner)
     return ()
 end

--- a/contracts/contract.cairo
+++ b/contracts/contract.cairo
@@ -4,7 +4,6 @@
 %builtins pedersen range_check
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-from starkware.starknet.common.storage import Storage
 
 # Define a storage variable.
 @storage_var
@@ -14,8 +13,8 @@ end
 # Increases the balance by the given amount.
 @external
 func increase_balance{
-        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}(amount : felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (amount : felt):
     let (res) = balance.read()
     balance.write(res + amount)
     return ()
@@ -24,8 +23,8 @@ end
 # Returns the current balance.
 @view
 func get_balance{
-        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}() -> (res : felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} () -> (res : felt):
     let (res) = balance.read()
     return (res)
 end

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -3,7 +3,6 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
-from starkware.starknet.common.storage import Storage
 from starkware.cairo.common.math import assert_nn_le
 
 #
@@ -36,40 +35,32 @@ end
 
 @view
 func get_total_supply{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } () -> (res: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} () -> (res: felt):
     let (res) = total_supply.read()
     return (res)
 end
 
 @view
 func get_decimals{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } () -> (res: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} () -> (res: felt):
     let (res) = decimals.read()
     return (res)
 end
 
 @view
 func balance_of{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (user: felt) -> (res: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (user: felt) -> (res: felt):
     let (res) = balances.read(user=user)
     return (res)
 end
 
 @view
 func allowance{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (owner: felt, spender: felt) -> (res: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (owner: felt, spender: felt) -> (res: felt):
     let (res) = allowances.read(owner=owner, spender=spender)
     return (res)
 end
@@ -80,11 +71,8 @@ end
 
 @external
 func initialize{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } ():
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} ():
     let (_initialized) = initialized.read()
     assert _initialized = 0
     initialized.write(1)
@@ -96,11 +84,8 @@ func initialize{
 end
 
 func _mint{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (recipient: felt, amount: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (recipient: felt, amount: felt):
     let (res) = balances.read(user=recipient)
     balances.write(recipient, res + amount)
 
@@ -110,10 +95,8 @@ func _mint{
 end
 
 func _transfer{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (sender: felt, recipient: felt, amount: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}(sender: felt, recipient: felt, amount: felt):
     # validate sender has enough funds
     let (sender_balance) = balances.read(user=sender)
     assert_nn_le(amount, sender_balance)
@@ -128,22 +111,16 @@ func _transfer{
 end
 
 func _approve{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (caller: felt, spender: felt, amount: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}(caller: felt, spender: felt, amount: felt):
     allowances.write(caller, spender, amount)
     return ()
 end
 
 @external
 func transfer{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (recipient: felt, amount: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}(recipient: felt, amount: felt):
     let (sender) = get_caller_address()
     _transfer(sender, recipient, amount)
     return ()
@@ -151,11 +128,8 @@ end
 
 @external
 func transfer_from{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (sender: felt, recipient: felt, amount: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}(sender: felt, recipient: felt, amount: felt):
     let (caller) = get_caller_address()
     let (caller_allowance) = allowances.read(owner=sender, spender=caller)
     assert_nn_le(amount, caller_allowance)
@@ -166,11 +140,8 @@ end
 
 @external
 func approve{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (spender: felt, amount: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}(spender: felt, amount: felt):
     let (caller) = get_caller_address()
     _approve(caller, spender, amount)
     return ()
@@ -178,11 +149,8 @@ end
 
 @external
 func increase_allowance{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (spender: felt, added_value: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}(spender: felt, added_value: felt):
     let (caller) = get_caller_address()
     let (current_allowance) = allowances.read(caller, spender)
     # using a tempvar for internal check
@@ -195,11 +163,8 @@ end
 
 @external
 func decrease_allowance{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (spender: felt, subtracted_value: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (spender: felt, subtracted_value: felt):
     let (caller) = get_caller_address()
     let (current_allowance) = allowances.read(owner=caller, spender=spender)
     # checks that the decreased balance isn't below zero

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -25,8 +25,17 @@ end
 func decimals() -> (res: felt):
 end
 
-@storage_var
-func initialized() -> (res: felt):
+#
+# Constructor
+#
+
+@constructor
+func constructor{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}(deployer: felt):
+    decimals.write(18)
+    _mint(deployer, 1000)
+    return ()
 end
 
 #
@@ -66,22 +75,8 @@ func allowance{
 end
 
 #
-# Initializer
+# Internals
 #
-
-@external
-func initialize{
-        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr} ():
-    let (_initialized) = initialized.read()
-    assert _initialized = 0
-    initialized.write(1)
-    decimals.write(18)
-
-    let (sender) = get_caller_address()
-    _mint(sender, 1000)
-    return ()
-end
 
 func _mint{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
@@ -116,6 +111,10 @@ func _approve{
     allowances.write(caller, spender, amount)
     return ()
 end
+
+#
+# Externals
+#
 
 @external
 func transfer{

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -35,9 +35,9 @@ end
 @constructor
 func constructor{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}(deployer: felt):
+        range_check_ptr}(sender: felt):
     decimals.write(18)
-    _mint(deployer, Uint256(1000,0))
+    _mint(sender, Uint256(1000,0))
     return ()
 end
 
@@ -102,8 +102,7 @@ func _transfer{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
         range_check_ptr}(sender: felt, recipient: felt, amount: Uint256):
     alloc_locals    
-    let (sender_balance: Uint256) = balances.read(user=sender)
-    local sender_balance: Uint256 = sender_balance
+    let (local sender_balance: Uint256) = balances.read(user=sender)
 
     # reassign syscall_ptr and pedersen_ptr to avoid revocation
     local syscall_ptr: felt* = syscall_ptr
@@ -150,17 +149,12 @@ func transfer_from{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
         range_check_ptr}(sender: felt, recipient: felt, amount: Uint256):
     alloc_locals
-    let (caller) = get_caller_address()
-    local caller = caller
-
-    let (caller_allowance: Uint256) = allowances.read(owner=sender, spender=caller)
-    local caller_allowance: Uint256 = caller_allowance
+    let (local caller) = get_caller_address()
+    let (local caller_allowance: Uint256) = allowances.read(owner=sender, spender=caller)
 
     # reassign syscall_ptr and pedersen_ptr to avoid revocation
     local syscall_ptr: felt* = syscall_ptr
     local pedersen_ptr: HashBuiltin* = pedersen_ptr
-
-    local amount: Uint256 = amount
 
     # validates amount <= caller_allowance and returns 1 if true   
     let (validate_le) = uint256_le(amount, caller_allowance)
@@ -189,19 +183,15 @@ func increase_allowance{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
         range_check_ptr}(spender: felt, added_value: Uint256):
     alloc_locals
-    let (caller) = get_caller_address()
-    local caller = caller
-
+    let (local caller) = get_caller_address()
     let (current_allowance: Uint256) = allowances.read(caller, spender)
-
-    local added_value: Uint256 = added_value
 
     # reassign syscall_ptr and pedersen_ptr to avoid revocation
     local syscall_ptr: felt* = syscall_ptr
     local pedersen_ptr: HashBuiltin* = pedersen_ptr
 
-    let (new_allowance, _: Uint256) = uint256_add(current_allowance, added_value)
-    local new_allowance: Uint256 = new_allowance
+    # add allowance
+    let (local new_allowance, _: Uint256) = uint256_add(current_allowance, added_value)
 
     # validates current_allowance < new_allowance and returns 1 if true   
     let (validate_lt) = uint256_lt(current_allowance, new_allowance)
@@ -217,17 +207,15 @@ func decrease_allowance{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
         range_check_ptr} (spender: felt, subtracted_value: Uint256):
     alloc_locals
-    let (caller) = get_caller_address()
-    local caller = caller
-
+    let (local caller) = get_caller_address()
     let (current_allowance: Uint256) = allowances.read(owner=caller, spender=spender)
 
     # reassign syscall_ptr and pedersen_ptr to avoid revocation
     local syscall_ptr: felt* = syscall_ptr
     local pedersen_ptr: HashBuiltin* = pedersen_ptr
 
-    let (new_allowance: Uint256) = uint256_sub(current_allowance, subtracted_value)
-    local new_allowance: Uint256 = new_allowance
+    # subtract allowance
+    let (local new_allowance: Uint256) = uint256_sub(current_allowance, subtracted_value)
 
     # validates new_allowance < current_allowance and returns 1 if true   
     let (validate_lt) = uint256_lt(new_allowance, current_allowance)

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -3,22 +3,25 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
-from starkware.cairo.common.math import assert_nn_le
+from starkware.cairo.common.math import assert_not_zero
+from starkware.cairo.common.uint256 import (
+    Uint256, uint256_add, uint256_sub, uint256_le, uint256_lt
+)
 
 #
 # Storage
 #
 
 @storage_var
-func balances(user: felt) -> (res: felt):
+func balances(user: felt) -> (res: Uint256):
 end
 
 @storage_var
-func allowances(owner: felt, spender: felt) -> (res: felt):
+func allowances(owner: felt, spender: felt) -> (res: Uint256):
 end
 
 @storage_var
-func total_supply() -> (res: felt):
+func total_supply() -> (res: Uint256):
 end
 
 @storage_var
@@ -34,7 +37,7 @@ func constructor{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
         range_check_ptr}(deployer: felt):
     decimals.write(18)
-    _mint(deployer, 1000)
+    _mint(deployer, Uint256(1000,0))
     return ()
 end
 
@@ -44,9 +47,9 @@ end
 
 @view
 func get_total_supply{
-        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr} () -> (res: felt):
-    let (res) = total_supply.read()
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr} () -> (res : Uint256):
+    let (res: Uint256) = total_supply.read()
     return (res)
 end
 
@@ -61,16 +64,16 @@ end
 @view
 func balance_of{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr} (user: felt) -> (res: felt):
-    let (res) = balances.read(user=user)
+        range_check_ptr} (user: felt) -> (res: Uint256):
+    let (res: Uint256) = balances.read(user=user)
     return (res)
 end
 
 @view
 func allowance{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr} (owner: felt, spender: felt) -> (res: felt):
-    let (res) = allowances.read(owner=owner, spender=spender)
+        range_check_ptr} (owner: felt, spender: felt) -> (res: Uint256):
+    let (res: Uint256) = allowances.read(owner=owner, spender=spender)
     return (res)
 end
 
@@ -80,34 +83,51 @@ end
 
 func _mint{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr} (recipient: felt, amount: felt):
-    let (res) = balances.read(user=recipient)
-    balances.write(recipient, res + amount)
+        range_check_ptr} (recipient: felt, amount: Uint256):
+    alloc_locals
+    let (res: Uint256) = balances.read(user=recipient)
+    # the underscore is for the 1 bit carry
+    local to_add, _: Uint256 = uint256_add(res, amount)
+    balances.write(recipient, to_add)
 
-    let (supply) = total_supply.read()
-    total_supply.write(supply + amount)
+    let (supply: Uint256) = total_supply.read()
+    local to_add, _: Uint256 = uint256_add(supply, amount)
+    total_supply.write(to_add)
     return ()
 end
 
 func _transfer{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}(sender: felt, recipient: felt, amount: felt):
+        range_check_ptr}(sender: felt, recipient: felt, amount: Uint256):
+    alloc_locals
+
     # validate sender has enough funds
-    let (sender_balance) = balances.read(user=sender)
-    assert_nn_le(amount, sender_balance)
+    let (sender_balance: Uint256) = balances.read(user=sender)
+    local sender_balance: Uint256 = sender_balance
+
+    # reassign syscall_ptr and pedersen_ptr to avoid revocation
+    local syscall_ptr: felt* = syscall_ptr
+    local pedersen_ptr: HashBuiltin* = pedersen_ptr
+
+    # validates amount <= sender_balance and returns 1 if true
+    let (validate_le) = uint256_le(amount, sender_balance)
+    # fails if validate_le == 0
+    assert_not_zero(validate_le)
 
     # substract from sender
-    balances.write(sender, sender_balance - amount)
+    let (new_sender_bal: Uint256) = uint256_sub(sender_balance, amount)
+    balances.write(sender, new_sender_bal)
 
     # add to recipient
-    let (res) = balances.read(user=recipient)
-    balances.write(recipient, res + amount)
+    let (recipient_bal: Uint256) = balances.read(user=recipient)
+    let (new_recipient_bal, _: Uint256) = uint256_add(recipient_bal, amount)
+    balances.write(recipient, new_recipient_bal)
     return ()
 end
 
 func _approve{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}(caller: felt, spender: felt, amount: felt):
+        range_check_ptr}(caller: felt, spender: felt, amount: Uint256):
     allowances.write(caller, spender, amount)
     return ()
 end
@@ -119,7 +139,7 @@ end
 @external
 func transfer{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}(recipient: felt, amount: felt):
+        range_check_ptr}(recipient: felt, amount: Uint256):
     let (sender) = get_caller_address()
     _transfer(sender, recipient, amount)
     return ()

--- a/contracts/token/ERC721.cairo
+++ b/contracts/token/ERC721.cairo
@@ -3,7 +3,6 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
-from starkware.starknet.common.storage import Storage
 from starkware.cairo.common.math import assert_nn_le
 
 @storage_var
@@ -11,7 +10,7 @@ func owner(token_id: felt) -> (res: felt):
 end
 
 @storage_var
-func balance(owner: felt) -> (res: felt):
+func balances(owner: felt) -> (res: felt):
 end
 
 @storage_var
@@ -28,11 +27,8 @@ end
 
 @external
 func initialize{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } ():
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} ():
     let (_initialized) = initialized.read()
     assert _initialized = 0
     initialized.write(1)
@@ -44,31 +40,24 @@ end
 
 @view
 func balance_of{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (owner: felt) -> (res: felt):
-    let (res) = balance.read(owner=owner)
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (owner: felt) -> (res: felt):
+    let (res) = balances.read(owner=owner)
     return (res)
 end
 
 @view
 func owner_of{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (token_id: felt) -> (res: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (token_id: felt) -> (res: felt):
     let (res) = owner.read(token_id=token_id)
     return (res)
 end
 
 @external
 func approve{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (to: felt, token_id: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (to: felt, token_id: felt):
     let (_owner) = owner.read(token_id)
 
     if _owner == to:
@@ -81,11 +70,8 @@ func approve{
 end
 
 func _is_approved_or_owner{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (to: felt, token_id: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (to: felt, token_id: felt):
     let (caller) = get_caller_address()
     let (_owner) = owner.read(token_id)
 
@@ -99,20 +85,15 @@ end
 
 @view
 func get_approved{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (token_id: felt) -> (res: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (token_id: felt) -> (res: felt):
     let (res) = token_approvals.read(token_id=token_id)
     return (res)
 end
 
 func _mint{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (recipient: felt, amount: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (recipient: felt, amount: felt):
     let (res) = balances.read(user=recipient)
     balances.write(recipient, res + amount)
 
@@ -122,10 +103,8 @@ func _mint{
 end
 
 func _transfer{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (sender: felt, recipient: felt, amount: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (sender: felt, recipient: felt, amount: felt):
     # validate sender has enough funds
     let (sender_balance) = balances.read(user=sender)
     assert_nn_le(amount, sender_balance)
@@ -141,11 +120,8 @@ end
 
 @external
 func transfer{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (recipient: felt, amount: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (recipient: felt, amount: felt):
     let (sender) = get_caller_address()
     _transfer(sender, recipient, amount)
     return ()
@@ -153,11 +129,8 @@ end
 
 @external
 func transfer_from{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (sender: felt, recipient: felt, amount: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (sender: felt, recipient: felt, amount: felt):
     let (caller) = get_caller_address()
     let (caller_allowance) = allowances.read(owner=sender, spender=caller)
     assert_nn_le(amount, caller_allowance)

--- a/test/Account.py
+++ b/test/Account.py
@@ -17,8 +17,14 @@ def event_loop():
 @pytest.fixture(scope='module')
 async def account_factory():
     starknet = await Starknet.empty()
-    account = await starknet.deploy("contracts/Account.cairo")
-    await account.initialize(signer.public_key, account.contract_address).invoke()
+    account = await starknet.deploy(
+        source="contracts/Account.cairo",
+        constructor_calldata=[signer.public_key]
+    )
+
+    # Keeping the initialize function to set the contract_address
+    # until `this.address` is available
+    await account.initialize(account.contract_address).invoke()
     return starknet, account
 
 

--- a/test/Account.py
+++ b/test/Account.py
@@ -25,8 +25,12 @@ async def account_factory():
 @pytest.mark.asyncio
 async def test_initializer(account_factory):
     _, account = account_factory
-    assert await account.get_public_key().call() == (signer.public_key,)
-    assert await account.get_address().call() == (account.contract_address,)
+
+    execution_info = await account.get_public_key().call()
+    assert execution_info.result == (signer.public_key,)
+
+    execution_info = await account.get_address().call()
+    assert execution_info.result == (account.contract_address,)
 
 
 @pytest.mark.asyncio
@@ -34,9 +38,14 @@ async def test_execute(account_factory):
     starknet, account = account_factory
     initializable = await starknet.deploy("contracts/Initializable.cairo")
 
-    assert await initializable.initialized().call() == (0,)
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result == (0,)
+
+    # initialize
     await signer.send_transaction(account, initializable.contract_address, 'initialize', [])
-    assert await initializable.initialized().call() == (1,)
+
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result.res == (1,)
 
 
 @pytest.mark.asyncio
@@ -69,6 +78,12 @@ async def test_nonce(account_factory):
 @pytest.mark.asyncio
 async def test_public_key_setter(account_factory):
     _, account = account_factory
-    assert await account.get_public_key().call() == (signer.public_key,)
+
+    execution_info = await account.get_public_key().call()
+    assert execution_info.result == (signer.public_key,)
+
+    # set new pubkey
     await signer.send_transaction(account, account.contract_address, 'set_public_key', [other.public_key])
-    assert await account.get_public_key().call() == (other.public_key,)
+
+    execution_info = await account.get_public_key().call()
+    assert execution_info.result == (other.public_key,)

--- a/test/AddressRegistry.py
+++ b/test/AddressRegistry.py
@@ -27,7 +27,9 @@ async def test_set_address(account_factory):
     _, account, registry = account_factory
 
     await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [L1_ADDRESS])
-    assert await registry.get_L1_address(account.contract_address).call() == (L1_ADDRESS,)
+
+    execution_info = await registry.get_l1_address(account.contract_address).call()
+    assert execution_info.result == (L1_ADDRESS,)
 
 
 @pytest.mark.asyncio
@@ -35,7 +37,12 @@ async def test_update_address(account_factory):
     _, account, registry = account_factory
 
     await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [L1_ADDRESS])
-    assert await registry.get_L1_address(account.contract_address).call() == (L1_ADDRESS,)
 
+    execution_info = await registry.get_l1_address(account.contract_address).call()
+    assert execution_info.result == (L1_ADDRESS,)
+
+    # set new address
     await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [ANOTHER_ADDRESS])
-    assert await registry.get_L1_address(account.contract_address).call() == (ANOTHER_ADDRESS,)
+
+    execution_info = await registry.get_l1_address(account.contract_address).call()
+    assert execution_info.result == (ANOTHER_ADDRESS,)

--- a/test/AddressRegistry.py
+++ b/test/AddressRegistry.py
@@ -27,8 +27,8 @@ async def test_set_address(account_factory):
     _, account, registry = account_factory
 
     await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [L1_ADDRESS])
-
-    execution_info = await registry.get_l1_address(account.contract_address).call()
+    # assert await registry.get_L1_address(account.contract_address).call() == (L1_ADDRESS,)
+    execution_info = await registry.get_L1_address(account.contract_address).call()
     assert execution_info.result == (L1_ADDRESS,)
 
 
@@ -38,11 +38,11 @@ async def test_update_address(account_factory):
 
     await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [L1_ADDRESS])
 
-    execution_info = await registry.get_l1_address(account.contract_address).call()
+    execution_info = await registry.get_L1_address(account.contract_address).call()
     assert execution_info.result == (L1_ADDRESS,)
 
     # set new address
     await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [ANOTHER_ADDRESS])
 
-    execution_info = await registry.get_l1_address(account.contract_address).call()
+    execution_info = await registry.get_L1_address(account.contract_address).call()
     assert execution_info.result == (ANOTHER_ADDRESS,)

--- a/test/AddressRegistry.py
+++ b/test/AddressRegistry.py
@@ -17,8 +17,12 @@ def event_loop():
 async def account_factory():
     starknet = await Starknet.empty()
     registry = await starknet.deploy("contracts/AddressRegistry.cairo")
-    account = await starknet.deploy("contracts/Account.cairo")
-    await account.initialize(signer.public_key, account.contract_address).invoke()
+    account = await starknet.deploy(
+        source="contracts/Account.cairo",
+        constructor_calldata=[signer.public_key]
+    )
+
+    await account.initialize(account.contract_address).invoke()
     return starknet, account, registry
 
 
@@ -27,7 +31,6 @@ async def test_set_address(account_factory):
     _, account, registry = account_factory
 
     await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [L1_ADDRESS])
-    # assert await registry.get_L1_address(account.contract_address).call() == (L1_ADDRESS,)
     execution_info = await registry.get_L1_address(account.contract_address).call()
     assert execution_info.result == (L1_ADDRESS,)
 

--- a/test/ERC20.py
+++ b/test/ERC20.py
@@ -38,7 +38,8 @@ async def test_transfer(erc20_factory):
     _, erc20, account = erc20_factory
     recipient = 123
     amount = 100
-    (previous_supply,) = await erc20.get_total_supply().call()
+    execution_info = await erc20.get_total_supply().call()
+    previous_supply = execution_info.result
 
     execution_info = await erc20.balance_of(account.contract_address).call()
     assert execution_info.result == (1000,)
@@ -55,14 +56,15 @@ async def test_transfer(erc20_factory):
     assert execution_info.result == (100,)
 
     execution_info = await erc20.get_total_supply().call()
-    assert execution_info.result == (previous_supply,)
+    assert execution_info.result == previous_supply
 
 
 @pytest.mark.asyncio
 async def test_insufficient_sender_funds(erc20_factory):
     _, erc20, account = erc20_factory
     recipient = 123
-    (balance,) = await erc20.balance_of(account.contract_address).call()
+    execution_info = await erc20.balance_of(account.contract_address).call()
+    balance = execution_info.result.res
 
     try:
         await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, balance + 1])
@@ -97,7 +99,8 @@ async def test_transfer_from(erc20_factory):
     await spender.initialize(signer.public_key, spender.contract_address).invoke()
     amount = 345
     recipient = 987
-    (previous_balance,) = await erc20.balance_of(account.contract_address).call()
+    execution_info = await erc20.balance_of(account.contract_address).call()
+    previous_balance = execution_info.result.res
 
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, amount])
     await signer.send_transaction(spender, erc20.contract_address, 'transfer_from',
@@ -125,6 +128,7 @@ async def test_increase_allowance(erc20_factory):
 
     # set approve
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, amount])
+
     execution_info = await erc20.allowance(account.contract_address, spender).call()
     assert execution_info.result == (amount,)
 

--- a/test/ERC20.py
+++ b/test/ERC20.py
@@ -26,8 +26,11 @@ async def erc20_factory():
 @pytest.mark.asyncio
 async def test_initializer(erc20_factory):
     _, erc20, account = erc20_factory
-    assert await erc20.balance_of(account.contract_address).call() == (1000,)
-    assert await erc20.get_total_supply().call() == (1000,)
+    execution_info = await erc20.balance_of(account.contract_address).call()
+    assert execution_info.result == (1000,)
+
+    execution_info = await erc20.get_total_supply().call()
+    assert execution_info.result == (1000,)
 
 
 @pytest.mark.asyncio
@@ -36,12 +39,23 @@ async def test_transfer(erc20_factory):
     recipient = 123
     amount = 100
     (previous_supply,) = await erc20.get_total_supply().call()
-    assert await erc20.balance_of(account.contract_address).call() == (1000,)
-    assert await erc20.balance_of(recipient).call() == (0,)
+
+    execution_info = await erc20.balance_of(account.contract_address).call()
+    assert execution_info.result == (1000,)
+
+    execution_info = await erc20.balance_of(recipient).call()
+    assert execution_info.result == (0,)
+
     await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, amount])
-    assert await erc20.balance_of(account.contract_address).call() == (900,)
-    assert await erc20.balance_of(recipient).call() == (100,)
-    assert (previous_supply,) == await erc20.get_total_supply().call()
+
+    execution_info = await erc20.balance_of(account.contract_address).call()
+    assert execution_info.result == (900,)
+
+    execution_info = await erc20.balance_of(recipient).call()
+    assert execution_info.result == (100,)
+
+    execution_info = await erc20.get_total_supply().call()
+    assert execution_info.result == (previous_supply,)
 
 
 @pytest.mark.asyncio
@@ -63,9 +77,15 @@ async def test_approve(erc20_factory):
     _, erc20, account = erc20_factory
     spender = 123
     amount = 345
-    assert await erc20.allowance(account.contract_address, spender).call() == (0,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (0,)
+
+    # set approval
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, amount])
-    assert await erc20.allowance(account.contract_address, spender).call() == (amount,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (amount,)
 
 
 @pytest.mark.asyncio
@@ -83,9 +103,14 @@ async def test_transfer_from(erc20_factory):
     await signer.send_transaction(spender, erc20.contract_address, 'transfer_from',
                                   [account.contract_address, recipient, amount])
 
-    assert await erc20.balance_of(account.contract_address).call() == (previous_balance - amount,)
-    assert await erc20.balance_of(recipient).call() == (amount,)
-    assert await erc20.allowance(account.contract_address, spender.contract_address).call() == (0,)
+    execution_info = await erc20.balance_of(account.contract_address).call()
+    assert execution_info.result == (previous_balance - amount,)
+
+    execution_info = await erc20.balance_of(recipient).call()
+    assert execution_info.result == (amount,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender.contract_address).call()
+    assert execution_info.result == (0,)
 
 
 @pytest.mark.asyncio
@@ -94,13 +119,20 @@ async def test_increase_allowance(erc20_factory):
     # new spender, starting from zero
     spender = 234
     amount = 345
-    assert await erc20.allowance(account.contract_address, spender).call() == (0,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (0,)
+
+    # set approve
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, amount])
-    assert await erc20.allowance(account.contract_address, spender).call() == (amount,)
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (amount,)
 
     # increase allowance
     await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, amount])
-    assert await erc20.allowance(account.contract_address, spender).call() == (amount * 2,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (amount * 2,)
 
 
 @pytest.mark.asyncio
@@ -111,12 +143,21 @@ async def test_decrease_allowance(erc20_factory):
     init_amount = 345
     subtract_amount = 100
     new_amount = 245
-    assert await erc20.allowance(account.contract_address, spender).call() == (0,)
-    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, init_amount])
-    assert await erc20.allowance(account.contract_address, spender).call() == (init_amount,)
 
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (0,)
+
+    # set approve
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, init_amount])
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (init_amount,)
+
+    # decrease allowance
     await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, subtract_amount])
-    assert await erc20.allowance(account.contract_address, spender).call() == (new_amount,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (init_amount - subtract_amount,)
 
 
 @pytest.mark.asyncio
@@ -126,7 +167,9 @@ async def test_decrease_allowance_below_zero(erc20_factory):
     spender = 987
     init_amount = 345
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, init_amount])
-    assert await erc20.allowance(account.contract_address, spender).call() == (345,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (init_amount,)
 
     try:
         # increasing the decreased allowance amount by more than the user's allowance
@@ -146,10 +189,9 @@ async def test_transfer_funds_greater_than_allowance(erc20_factory):
     await spender.initialize(signer.public_key, spender.contract_address).invoke()
     recipient = 222
     allowance = 111
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, allowance])
 
-    # executing the same transactions with transfer amount greater than allowance
     try:
-        await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, allowance])
         # increasing the transfer amount above allowance
         await signer.send_transaction(spender, erc20.contract_address, 'transfer_from', [account.contract_address, recipient, allowance + 1])
         assert False

--- a/test/ERC20.py
+++ b/test/ERC20.py
@@ -177,4 +177,3 @@ async def test_overflow_increase_allowance(erc20_factory):
     except StarkException as err:
         _, error = err.args
         assert error['code'] == StarknetErrorCode.TRANSACTION_FAILED
- 

--- a/test/ERC20.py
+++ b/test/ERC20.py
@@ -146,7 +146,6 @@ async def test_decrease_allowance(erc20_factory):
     spender = 321
     init_amount = 345
     subtract_amount = 100
-    new_amount = 245
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
     assert execution_info.result == (0,)

--- a/test/ERC20.py
+++ b/test/ERC20.py
@@ -16,12 +16,16 @@ def event_loop():
 @pytest.fixture(scope='module')
 async def erc20_factory():
     starknet = await Starknet.empty()
-    account = await starknet.deploy("contracts/Account.cairo")
+    account = await starknet.deploy(
+        source="contracts/Account.cairo",
+        constructor_calldata=[signer.public_key]
+    )
+    await account.initialize(account.contract_address).invoke()
+
     erc20 = await starknet.deploy(
         source="contracts/token/ERC20.cairo",
         constructor_calldata=[account.contract_address]
     )
-    await account.initialize(signer.public_key, account.contract_address).invoke()
     return starknet, erc20, account
 
 
@@ -95,10 +99,13 @@ async def test_approve(erc20_factory):
 @pytest.mark.asyncio
 async def test_transfer_from(erc20_factory):
     starknet, erc20, account = erc20_factory
-    spender = await starknet.deploy("contracts/Account.cairo")
+    spender = await starknet.deploy(
+        source="contracts/Account.cairo",
+        constructor_calldata=[signer.public_key]
+    )
     # we use the same signer to control the main and the spender accounts
     # this is ok since they're still two different accounts
-    await spender.initialize(signer.public_key, spender.contract_address).invoke()
+    await spender.initialize(spender.contract_address).invoke()
     amount = (345, 0)
     recipient = 987
     execution_info = await erc20.balance_of(account.contract_address).call()
@@ -194,10 +201,13 @@ async def test_decrease_allowance_below_zero(erc20_factory):
 @pytest.mark.asyncio
 async def test_transfer_funds_greater_than_allowance(erc20_factory):
     starknet, erc20, account = erc20_factory
-    spender = await starknet.deploy("contracts/Account.cairo")
+    spender = await starknet.deploy(
+        source="contracts/Account.cairo",
+        constructor_calldata=[signer.public_key]
+    )
     # we use the same signer to control the main and the spender accounts
     # this is ok since they're still two different accounts
-    await spender.initialize(signer.public_key, spender.contract_address).invoke()
+    await spender.initialize(spender.contract_address).invoke()
     recipient = 222
     allowance = (111, 0)
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *allowance])

--- a/test/Initializable.py
+++ b/test/Initializable.py
@@ -6,6 +6,10 @@ from starkware.starknet.testing.starknet import Starknet
 async def test_initializer():
     starknet = await Starknet.empty()
     initializable = await starknet.deploy("contracts/Initializable.cairo")
-    assert await initializable.initialized().call() == (0,)
+    expected = await initializable.initialized().call()
+    assert expected.result == (0,)
+
     await initializable.initialize().invoke()
-    assert await initializable.initialized().call() == (1,)
+
+    expected = await initializable.initialized().call()
+    assert expected.result == (1,)

--- a/test/Ownable.py
+++ b/test/Ownable.py
@@ -24,12 +24,18 @@ async def ownable_factory():
 @pytest.mark.asyncio
 async def test_initializer(ownable_factory):
     _, ownable, owner = ownable_factory
-    assert await ownable.get_owner().call() == (owner.contract_address,)
+    expected = await ownable.get_owner().call()
+    assert expected.result.res == owner.contract_address
+    print("fffffff ", owner)
 
 
 @pytest.mark.asyncio
 async def test_transfer_ownership(ownable_factory):
     _, ownable, owner = ownable_factory
     new_owner = 123
-    await signer.send_transaction(owner, ownable.contract_address, 'transfer_ownership', [new_owner])
-    assert await ownable.get_owner().call() == (new_owner,)
+    print(signer)
+    # await signer.send_transaction(owner, ownable.contract_address, 'transfer_ownership', [new_owner])
+    # assert await ownable.get_owner().call() == (new_owner,)
+    # expected = await ownable.get_owner().call()
+    # print(expected)
+    #assert expected.result.res == (new_owner,)

--- a/test/Ownable.py
+++ b/test/Ownable.py
@@ -33,9 +33,6 @@ async def test_initializer(ownable_factory):
 async def test_transfer_ownership(ownable_factory):
     _, ownable, owner = ownable_factory
     new_owner = 123
-    print(signer)
-    # await signer.send_transaction(owner, ownable.contract_address, 'transfer_ownership', [new_owner])
-    # assert await ownable.get_owner().call() == (new_owner,)
-    # expected = await ownable.get_owner().call()
-    # print(expected)
-    #assert expected.result.res == (new_owner,)
+    await signer.send_transaction(owner, ownable.contract_address, 'transfer_ownership', [new_owner])
+    executed_info = await ownable.get_owner().call()
+    assert executed_info.result == (new_owner,)

--- a/test/Ownable.py
+++ b/test/Ownable.py
@@ -14,10 +14,16 @@ def event_loop():
 @pytest.fixture(scope='module')
 async def ownable_factory():
     starknet = await Starknet.empty()
-    owner = await starknet.deploy("contracts/Account.cairo")
-    ownable = await starknet.deploy("contracts/Ownable.cairo")
-    await owner.initialize(signer.public_key, owner.contract_address).invoke()
-    await ownable.initialize_ownable(owner.contract_address).invoke()
+    owner = await starknet.deploy(
+        source="contracts/Account.cairo",
+        constructor_calldata=[signer.public_key]
+    )
+    await owner.initialize(owner.contract_address).invoke()
+
+    ownable = await starknet.deploy(
+        source="contracts/Ownable.cairo",
+        constructor_calldata=[owner.contract_address]
+    )
     return starknet, ownable, owner
 
 
@@ -26,7 +32,6 @@ async def test_initializer(ownable_factory):
     _, ownable, owner = ownable_factory
     expected = await ownable.get_owner().call()
     assert expected.result.res == owner.contract_address
-    print("fffffff ", owner)
 
 
 @pytest.mark.asyncio

--- a/test/utils/Signer.py
+++ b/test/utils/Signer.py
@@ -12,7 +12,8 @@ class Signer():
 
     async def send_transaction(self, account, to, selector_name, calldata, nonce=None):
         if nonce is None:
-            nonce, = await account.get_nonce().call()
+            res = await account.get_nonce().call()
+            nonce, = res.result
 
         selector = get_selector_from_name(selector_name)
         message_hash = hash_message(

--- a/test/utils/Signer.py
+++ b/test/utils/Signer.py
@@ -12,8 +12,8 @@ class Signer():
 
     async def send_transaction(self, account, to, selector_name, calldata, nonce=None):
         if nonce is None:
-            res = await account.get_nonce().call()
-            nonce, = res.result
+            execution_info = await account.get_nonce().call()
+            nonce, = execution_info.result
 
         selector = get_selector_from_name(selector_name)
         message_hash = hash_message(

--- a/test/utils/Signer.py
+++ b/test/utils/Signer.py
@@ -19,8 +19,9 @@ class Signer():
         message_hash = hash_message(
             account.contract_address, to, selector, calldata, nonce)
         sig_r, sig_s = self.sign(message_hash)
+        signatures = [sig_r, sig_s]
 
-        return await account.execute(to, selector, calldata, [sig_r, sig_s]).invoke()
+        return await account.execute(to, selector, calldata).invoke(signature=signatures)
 
 
 def hash_message(sender, to, selector, calldata, nonce):


### PR DESCRIPTION
# Uint256 Integration

## Summary

This PR includes a complete refactoring of the ERC20 contract; whereby, the balances, total supply, and allowances now track 256 bit unsigned integers for seamless Solidity integration. The ERC20 contract uses Cairo's [Uint256](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/uint256.cairo) library which holds uint256 as a struct of two 252bit field elements (felts). One of the initial issues with this integration consisted of passing structs as function arguments. Cairo's 0.5.0 update solved this issue. It should be noted that when passing a Uint256 object as an argument without an account contract abstraction, the expected type is a tuple. When using an account abstraction, however, the expected type is an integer (specifically, `*int`). In other words, when a function expects a Uint256 arg, the values should be unpacked.

This PR also mirrors the Cairo 0.5.0 Update PR. This should remain a draft until #42 is finalized and merged.

## Implementation
- Storage variables updated to Uint256
- Parameter types and return types updated to Uint256
- Addition and Subtraction operators removed in favor of Uint256 library's `uint256_add()` and `uint256_sub()` functions
- Overflow checks changed to Uint256 library's `uint256_le()` and `uint256_lt()` in conjunction with Cairo's `assert_not_zero()` from their [math](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/math.cairo) library

## Files

`contracts/token/ERC20.cairo`
`test/ERC20.py`
<br>
*additional files mirror the 0.5.0 update

## Future
- Include `uint256_check()` for all relevant external functions to ensure Uint256 parameters (felts) do not exceed 2**128 - 1 (seems more appropriate to include in security checks)
- Burner address (zero address) protection
- Mint overflow protection