### PR TITLE
Updated Message Hashing with Cairo's `hash_state`

### DIFF
--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -1,7 +1,6 @@
 %lang starknet
 %builtins pedersen range_check ecdsa
 
-from starkware.cairo.common.hash import hash2
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.signature import verify_ecdsa_signature
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin

--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -6,6 +6,9 @@ from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.signature import verify_ecdsa_signature
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.starknet.common.syscalls import call_contract, get_caller_address, get_tx_signature
+from starkware.cairo.common.hash_state import (
+    hash_init, hash_finalize, hash_update, hash_update_single
+)
 
 #
 # Structs
@@ -234,31 +237,42 @@ end
 
 func hash_message{pedersen_ptr : HashBuiltin*}(message: Message*) -> (res: felt):
     alloc_locals
-    let (res) = hash2{hash_ptr=pedersen_ptr}(message.sender, message.to)
-    let (res) = hash2{hash_ptr=pedersen_ptr}(res, message.selector)
-    # we need to make `res` local
+    # we need to make `res_calldata` local
     # to prevent the reference from being revoked
-    local res = res
-    let (res_calldata) = hash_calldata(message.calldata, message.calldata_size)
-    let (res) = hash2{hash_ptr=pedersen_ptr}(res, res_calldata)
-    let (res) = hash2{hash_ptr=pedersen_ptr}(res, message.nonce)
+    let (local res_calldata) = hash_calldata(message.calldata, message.calldata_size)
+    let hash_ptr = pedersen_ptr
+    with hash_ptr:
+        let (hash_state_ptr) = hash_init()
+        # first three iterations are 'sender', 'to', and 'selector'
+        let (hash_state_ptr) = hash_update(
+            hash_state_ptr, 
+            message, 
+            3
+        )
+        let (hash_state_ptr) = hash_update_single(
+            hash_state_ptr, res_calldata)
+        let (hash_state_ptr) = hash_update_single(
+            hash_state_ptr, message.nonce)
+        let (res) = hash_finalize(hash_state_ptr)
+        let pedersen_ptr = hash_ptr
     return (res=res)
+    end
 end
 
 func hash_calldata{pedersen_ptr: HashBuiltin*}(
         calldata: felt*,
         calldata_size: felt
     ) -> (res: felt):
-    if calldata_size == 0:
-        return (res=0)
+    let hash_ptr = pedersen_ptr
+    with hash_ptr:
+        let (hash_state_ptr) = hash_init()
+        let (hash_state_ptr) = hash_update(
+            hash_state_ptr,
+            calldata,
+            calldata_size
+        )
+        let (res) = hash_finalize(hash_state_ptr)
+        let pedersen_ptr = hash_ptr
+        return (res=res)
     end
-
-    if calldata_size == 1:
-        return (res=[calldata])
-    end
-
-    let _calldata = [calldata]
-    let (res) = hash_calldata(calldata + 1, calldata_size - 1)
-    let (res) = hash2{hash_ptr=pedersen_ptr}(res, _calldata)
-    return (res=res)
 end

--- a/tests/utils/Signer.py
+++ b/tests/utils/Signer.py
@@ -1,5 +1,6 @@
-from starkware.crypto.signature.signature import pedersen_hash, private_to_stark_key, sign
+from starkware.crypto.signature.signature import private_to_stark_key, sign
 from starkware.starknet.public.abi import get_selector_from_name
+from starkware.cairo.common.hash_state import compute_hash_on_elements
 
 
 class Signer():
@@ -24,17 +25,11 @@ class Signer():
 
 
 def hash_message(sender, to, selector, calldata, nonce):
-    res = pedersen_hash(sender, to)
-    res = pedersen_hash(res, selector)
-    res_calldata = hash_calldata(calldata)
-    res = pedersen_hash(res, res_calldata)
-    return pedersen_hash(res, nonce)
-
-
-def hash_calldata(calldata):
-    if len(calldata) == 0:
-        return 0
-    elif len(calldata) == 1:
-        return calldata[0]
-    else:
-        return pedersen_hash(hash_calldata(calldata[1:]), calldata[0])
+    message = [
+        sender,
+        to,
+        selector,
+        compute_hash_on_elements(calldata),
+        nonce
+    ]
+    return compute_hash_on_elements(message)


### PR DESCRIPTION
# Updated Message Hashing with Cairo's `hash_state`

## Summary

This PR includes the Account contract's [custom hash_message and hash_calldata](https://github.com/andrew-fleming/cairo-contracts/blob/main/contracts/Account.cairo#L235-L264) functions refactored to include Cairo's [hash_state](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/hash_state.cairo) as referenced in #37 . The `hash_message()` function first invokes `hash_calldata()` and saves the reference locally before utilizing `hash_state_ptr` to iterate through the rest of the message. 

Cairo's [hash_state.py](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/hash_state.py) provides `compute_hash_on_elements()` to greatly simplify testing. The _Signer.py_ module is updated with this function accordingly. 

## Implementation
- Removed all `hash2()` functions from [Account.cairo](https://github.com/OpenZeppelin/cairo-contracts/blob/main/contracts/Account.cairo) and [Signer.py](https://github.com/OpenZeppelin/cairo-contracts/blob/main/tests/utils/Signer.py)
- Utilized Cairo's `hash_state` in both `hash_message()` and `hash_calldata()`
- Implemented `compute_hash_on_elements()` appropriately in the _Signer.py_ module

## Future
- Perhaps, we can further distill the process and remove `hash_calldata()` from the Account contract altogether