### PR TITLE
Uint256 Integration for ERC20

### DIFF
--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -98,15 +98,15 @@ func _mint{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(recipient: felt, amount: Uint256):
-    alloc_locals
+    
     let (balance: Uint256) = balances.read(user=recipient)
     # the underscore is for the 1 bit carry
-    let (local new_balance, _: Uint256) = uint256_add(balance, amount)
+    let (new_balance, _: Uint256) = uint256_add(balance, amount)
     balances.write(recipient, new_balance)
 
     let (supply: Uint256) = total_supply.read()
     # the underscore is for the 1 bit carry
-    let (local new_supply, _: Uint256) = uint256_add(supply, amount)
+    let (new_supply, _: Uint256) = uint256_add(supply, amount)
     total_supply.write(new_supply)
     return ()
 end

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -217,8 +217,8 @@ func increase_allowance{
     let (local new_allowance, _: Uint256) = uint256_add(current_allowance, added_value)
 
     # validates current_allowance < new_allowance and returns 1 if true   
-    let (allowance_check) = uint256_lt(current_allowance, new_allowance)
-    assert_not_zero(allowance_check)
+    let (enough_allowance) = uint256_lt(current_allowance, new_allowance)
+    assert_not_zero(enough_allowance)
 
     _approve(caller, spender, new_allowance)
     return()

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -124,9 +124,8 @@ func _transfer{
     local pedersen_ptr: HashBuiltin* = pedersen_ptr
 
     # validates amount <= sender_balance and returns 1 if true
-    let (validate_le) = uint256_le(amount, sender_balance)
-    # fails if validate_le == 0
-    assert_not_zero(validate_le)
+    let (enough_balance) = uint256_le(amount, sender_balance)
+    assert_not_zero(enough_balance)
 
     # subtract from sender
     let (new_sender_balance: Uint256) = uint256_sub(sender_balance, amount)
@@ -178,9 +177,8 @@ func transfer_from{
     local pedersen_ptr: HashBuiltin* = pedersen_ptr
 
     # validates amount <= caller_allowance and returns 1 if true   
-    let (validate_le) = uint256_le(amount, caller_allowance)
-    # fails if validate_le == 0
-    assert_not_zero(validate_le)
+    let (enough_balance) = uint256_le(amount, caller_allowance)
+    assert_not_zero(enough_balance)
 
     _transfer(sender, recipient, amount)
 
@@ -219,9 +217,8 @@ func increase_allowance{
     let (local new_allowance, _: Uint256) = uint256_add(current_allowance, added_value)
 
     # validates current_allowance < new_allowance and returns 1 if true   
-    let (validate_lt) = uint256_lt(current_allowance, new_allowance)
-    # fails if validate_lt == 0
-    assert_not_zero(validate_lt)
+    let (allowance_check) = uint256_lt(current_allowance, new_allowance)
+    assert_not_zero(allowance_check)
 
     _approve(caller, spender, new_allowance)
     return()
@@ -244,9 +241,8 @@ func decrease_allowance{
     let (local new_allowance: Uint256) = uint256_sub(current_allowance, subtracted_value)
 
     # validates new_allowance < current_allowance and returns 1 if true   
-    let (validate_lt) = uint256_lt(new_allowance, current_allowance)
-    ## fails if validate_lt == 0
-    assert_not_zero(validate_lt)
+    let (enough_allowance) = uint256_lt(new_allowance, current_allowance)
+    assert_not_zero(enough_allowance)
 
     _approve(caller, spender, new_allowance)
     return()

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -99,9 +99,9 @@ func _mint{
         range_check_ptr
     }(recipient: felt, amount: Uint256):
     alloc_locals
-    let (res: Uint256) = balances.read(user=recipient)
+    let (balance: Uint256) = balances.read(user=recipient)
     # the underscore is for the 1 bit carry
-    let (local new_balance, _: Uint256) = uint256_add(res, amount)
+    let (local new_balance, _: Uint256) = uint256_add(balance, amount)
     balances.write(recipient, new_balance)
 
     let (supply: Uint256) = total_supply.read()

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -3,22 +3,25 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
-from starkware.cairo.common.math import assert_nn_le
+from starkware.cairo.common.math import assert_not_zero
+from starkware.cairo.common.uint256 import (
+    Uint256, uint256_add, uint256_sub, uint256_le, uint256_lt
+)
 
 #
 # Storage
 #
 
 @storage_var
-func balances(user: felt) -> (res: felt):
+func balances(user: felt) -> (res: Uint256):
 end
 
 @storage_var
-func allowances(owner: felt, spender: felt) -> (res: felt):
+func allowances(owner: felt, spender: felt) -> (res: Uint256):
 end
 
 @storage_var
-func total_supply() -> (res: felt):
+func total_supply() -> (res: Uint256):
 end
 
 @storage_var
@@ -38,7 +41,7 @@ func constructor{
     # get_caller_address() returns '0' in the constructor;
     # therefore, recipient parameter is included
     decimals.write(18)
-    _mint(recipient, 1000)
+    _mint(recipient, Uint256(1000, 0))
     return ()
 end
 
@@ -51,8 +54,8 @@ func get_total_supply{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }() -> (res: felt):
-    let (res) = total_supply.read()
+    }() -> (res: Uint256):
+    let (res: Uint256) = total_supply.read()
     return (res)
 end
 
@@ -71,8 +74,8 @@ func balance_of{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(user: felt) -> (res: felt):
-    let (res) = balances.read(user=user)
+    }(user: felt) -> (res: Uint256):
+    let (res: Uint256) = balances.read(user=user)
     return (res)
 end
 
@@ -81,8 +84,8 @@ func allowance{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(owner: felt, spender: felt) -> (res: felt):
-    let (res) = allowances.read(owner=owner, spender=spender)
+    }(owner: felt, spender: felt) -> (res: Uint256):
+    let (res: Uint256) = allowances.read(owner=owner, spender=spender)
     return (res)
 end
 
@@ -94,12 +97,17 @@ func _mint{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(recipient: felt, amount: felt):
-    let (res) = balances.read(user=recipient)
-    balances.write(recipient, res + amount)
+    }(recipient: felt, amount: Uint256):
+    alloc_locals
+    let (res: Uint256) = balances.read(user=recipient)
+    # the underscore is for the 1 bit carry
+    let (local new_balance, _: Uint256) = uint256_add(res, amount)
+    balances.write(recipient, new_balance)
 
-    let (supply) = total_supply.read()
-    total_supply.write(supply + amount)
+    let (supply: Uint256) = total_supply.read()
+    # the underscore is for the 1 bit carry
+    let (local new_supply, _: Uint256) = uint256_add(supply, amount)
+    total_supply.write(new_supply)
     return ()
 end
 
@@ -107,17 +115,27 @@ func _transfer{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(sender: felt, recipient: felt, amount: felt):
-    # validate sender has enough funds
-    let (sender_balance) = balances.read(user=sender)
-    assert_nn_le(amount, sender_balance)
+    }(sender: felt, recipient: felt, amount: Uint256):
+    alloc_locals
+    let (local sender_balance: Uint256) = balances.read(user=sender)
 
-    # substract from sender
-    balances.write(sender, sender_balance - amount)
+    # reassign syscall_ptr and pedersen_ptr to avoid revocation
+    local syscall_ptr: felt* = syscall_ptr
+    local pedersen_ptr: HashBuiltin* = pedersen_ptr
+
+    # validates amount <= sender_balance and returns 1 if true
+    let (validate_le) = uint256_le(amount, sender_balance)
+    # fails if validate_le == 0
+    assert_not_zero(validate_le)
+
+    # subtract from sender
+    let (new_sender_balance: Uint256) = uint256_sub(sender_balance, amount)
+    balances.write(sender, new_sender_balance)
 
     # add to recipient
-    let (res) = balances.read(user=recipient)
-    balances.write(recipient, res + amount)
+    let (recipient_balance: Uint256) = balances.read(user=recipient)
+    let (new_recipient_balance, _: Uint256) = uint256_add(recipient_balance, amount)
+    balances.write(recipient, new_recipient_balance)
     return ()
 end
 
@@ -125,7 +143,7 @@ func _approve{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(caller: felt, spender: felt, amount: felt):
+    }(caller: felt, spender: felt, amount: Uint256):
     allowances.write(caller, spender, amount)
     return ()
 end
@@ -139,7 +157,7 @@ func transfer{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(recipient: felt, amount: felt):
+    }(recipient: felt, amount: Uint256):
     let (sender) = get_caller_address()
     _transfer(sender, recipient, amount)
     return ()
@@ -150,12 +168,25 @@ func transfer_from{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(sender: felt, recipient: felt, amount: felt):
-    let (caller) = get_caller_address()
-    let (caller_allowance) = allowances.read(owner=sender, spender=caller)
-    assert_nn_le(amount, caller_allowance)
+    }(sender: felt, recipient: felt, amount: Uint256):
+    alloc_locals
+    let (local caller) = get_caller_address()
+    let (local caller_allowance: Uint256) = allowances.read(owner=sender, spender=caller)
+
+    # reassign syscall_ptr and pedersen_ptr to avoid revocation
+    local syscall_ptr: felt* = syscall_ptr
+    local pedersen_ptr: HashBuiltin* = pedersen_ptr
+
+    # validates amount <= caller_allowance and returns 1 if true   
+    let (validate_le) = uint256_le(amount, caller_allowance)
+    # fails if validate_le == 0
+    assert_not_zero(validate_le)
+
     _transfer(sender, recipient, amount)
-    allowances.write(sender, caller, caller_allowance - amount)
+
+    # subtract allowance
+    let (new_allowance: Uint256) = uint256_sub(caller_allowance, amount)
+    allowances.write(sender, caller, new_allowance)
     return ()
 end
 
@@ -164,7 +195,7 @@ func approve{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(spender: felt, amount: felt):
+    }(spender: felt, amount: Uint256):
     let (caller) = get_caller_address()
     _approve(caller, spender, amount)
     return ()
@@ -175,14 +206,24 @@ func increase_allowance{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(spender: felt, added_value: felt):
-    let (caller) = get_caller_address()
-    let (current_allowance) = allowances.read(caller, spender)
-    # using a tempvar for internal check
-    tempvar res = current_allowance + added_value
-    # overflow check
-    assert_nn_le(current_allowance + added_value, res)
-    _approve(caller, spender, res)
+    }(spender: felt, added_value: Uint256):
+    alloc_locals
+    let (local caller) = get_caller_address()
+    let (local current_allowance: Uint256) = allowances.read(caller, spender)
+
+    # reassign syscall_ptr and pedersen_ptr to avoid revocation
+    local syscall_ptr: felt* = syscall_ptr
+    local pedersen_ptr: HashBuiltin* = pedersen_ptr
+
+    # add allowance
+    let (local new_allowance, _: Uint256) = uint256_add(current_allowance, added_value)
+
+    # validates current_allowance < new_allowance and returns 1 if true   
+    let (validate_lt) = uint256_lt(current_allowance, new_allowance)
+    # fails if validate_lt == 0
+    assert_not_zero(validate_lt)
+
+    _approve(caller, spender, new_allowance)
     return()
 end
 
@@ -191,12 +232,23 @@ func decrease_allowance{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(spender: felt, subtracted_value: felt):
-    let (caller) = get_caller_address()
-    let (current_allowance) = allowances.read(owner=caller, spender=spender)
-    # checks that the decreased balance isn't below zero
-    assert_nn_le(subtracted_value, current_allowance)
-    _approve(caller, spender, current_allowance - subtracted_value)
+    }(spender: felt, subtracted_value: Uint256):
+    alloc_locals
+    let (local caller) = get_caller_address()
+    let (local current_allowance: Uint256) = allowances.read(owner=caller, spender=spender)
+    
+    # reassign syscall_ptr and pedersen_ptr to avoid revocation
+    local syscall_ptr: felt* = syscall_ptr
+    local pedersen_ptr: HashBuiltin* = pedersen_ptr
+
+    let (local new_allowance: Uint256) = uint256_sub(current_allowance, subtracted_value)
+
+    # validates new_allowance < current_allowance and returns 1 if true   
+    let (validate_lt) = uint256_lt(new_allowance, current_allowance)
+    ## fails if validate_lt == 0
+    assert_not_zero(validate_lt)
+
+    _approve(caller, spender, new_allowance)
     return()
 end
 

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -8,6 +8,10 @@ from utils.Signer import Signer
 signer = Signer(123456789987654321)
 
 
+def uint(a):
+    return(a, 0)
+
+
 @pytest.fixture(scope='module')
 def event_loop():
     return asyncio.new_event_loop()
@@ -20,7 +24,6 @@ async def erc20_factory():
         "contracts/Account.cairo",
         constructor_calldata=[signer.public_key]
     )
-
     await account.initialize(account.contract_address).invoke()
 
     erc20 = await starknet.deploy(
@@ -34,36 +37,36 @@ async def erc20_factory():
 async def test_constructor(erc20_factory):
     _, erc20, account = erc20_factory
     execution_info = await erc20.balance_of(account.contract_address).call()
-    assert execution_info.result == (1000,)
+    assert execution_info.result.res == uint(1000)
 
     execution_info = await erc20.get_total_supply().call()
-    assert execution_info.result == (1000,)
+    assert execution_info.result.res == uint(1000)
 
 
 @pytest.mark.asyncio
 async def test_transfer(erc20_factory):
     _, erc20, account = erc20_factory
     recipient = 123
-    amount = 100
+    amount = uint(100)
     execution_info = await erc20.get_total_supply().call()
-    previous_supply = execution_info.result
+    previous_supply = execution_info.result.res
 
     execution_info = await erc20.balance_of(account.contract_address).call()
-    assert execution_info.result == (1000,)
+    assert execution_info.result.res == uint(1000)
 
     execution_info = await erc20.balance_of(recipient).call()
-    assert execution_info.result == (0,)
+    assert execution_info.result.res == uint(0)
 
-    await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, amount])
+    await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, *amount])
 
     execution_info = await erc20.balance_of(account.contract_address).call()
-    assert execution_info.result == (900,)
+    assert execution_info.result.res == uint(900)
 
     execution_info = await erc20.balance_of(recipient).call()
-    assert execution_info.result == (100,)
+    assert execution_info.result.res == uint(100)
 
     execution_info = await erc20.get_total_supply().call()
-    assert execution_info.result == previous_supply
+    assert execution_info.result.res == previous_supply
 
 
 @pytest.mark.asyncio
@@ -74,7 +77,10 @@ async def test_insufficient_sender_funds(erc20_factory):
     balance = execution_info.result.res
 
     try:
-        await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, balance + 1])
+        await signer.send_transaction(account, erc20.contract_address, 'transfer', [
+            recipient,
+            *uint(balance[0] + 1)
+        ])
         assert False
     except StarkException as err:
         _, error = err.args
@@ -85,16 +91,16 @@ async def test_insufficient_sender_funds(erc20_factory):
 async def test_approve(erc20_factory):
     _, erc20, account = erc20_factory
     spender = 123
-    amount = 345
+    amount = uint(345)
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result == (0,)
+    assert execution_info.result.res == uint(0)
 
     # set approval
-    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, amount])
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result == (amount,)
+    assert execution_info.result.res == amount
 
 
 @pytest.mark.asyncio
@@ -107,23 +113,25 @@ async def test_transfer_from(erc20_factory):
     # we use the same signer to control the main and the spender accounts
     # this is ok since they're still two different accounts
     await spender.initialize(spender.contract_address).invoke()
-    amount = 345
+    amount = uint(345)
     recipient = 987
     execution_info = await erc20.balance_of(account.contract_address).call()
     previous_balance = execution_info.result.res
 
-    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, amount])
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *amount])
     await signer.send_transaction(spender, erc20.contract_address, 'transfer_from',
-                                  [account.contract_address, recipient, amount])
+                                  [account.contract_address, recipient, *amount])
 
     execution_info = await erc20.balance_of(account.contract_address).call()
-    assert execution_info.result == (previous_balance - amount,)
+    assert execution_info.result.res == (
+        uint(previous_balance[0] - amount[0])
+    )
 
     execution_info = await erc20.balance_of(recipient).call()
-    assert execution_info.result == (amount,)
+    assert execution_info.result.res == amount
 
     execution_info = await erc20.allowance(account.contract_address, spender.contract_address).call()
-    assert execution_info.result == (0,)
+    assert execution_info.result.res == uint(0)
 
 
 @pytest.mark.asyncio
@@ -131,22 +139,24 @@ async def test_increase_allowance(erc20_factory):
     _, erc20, account = erc20_factory
     # new spender, starting from zero
     spender = 234
-    amount = 345
+    amount = uint(345)
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result == (0,)
+    assert execution_info.result.res == uint(0)
 
     # set approve
-    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, amount])
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result == (amount,)
+    assert execution_info.result.res == amount
 
     # increase allowance
-    await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, amount])
+    await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, *amount])
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result == (amount * 2,)
+    assert execution_info.result.res == (
+        uint(amount[0] * 2)
+    )
 
 
 @pytest.mark.asyncio
@@ -154,23 +164,25 @@ async def test_decrease_allowance(erc20_factory):
     _, erc20, account = erc20_factory
     # new spender, starting from zero
     spender = 321
-    init_amount = 345
-    subtract_amount = 100
+    init_amount = uint(345)
+    subtract_amount = uint(100)
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result == (0,)
+    assert execution_info.result.res == uint(0)
 
     # set approve
-    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, init_amount])
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *init_amount])
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result == (init_amount,)
+    assert execution_info.result.res == init_amount
 
     # decrease allowance
-    await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, subtract_amount])
+    await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, *subtract_amount])
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result == (init_amount - subtract_amount,)
+    assert execution_info.result.res == (
+        uint(init_amount[0] - subtract_amount[0])
+    )
 
 
 @pytest.mark.asyncio
@@ -178,15 +190,18 @@ async def test_decrease_allowance_below_zero(erc20_factory):
     _, erc20, account = erc20_factory
     # new spender, starting from zero
     spender = 987
-    init_amount = 345
-    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, init_amount])
+    init_amount = uint(345)
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *init_amount])
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result == (init_amount,)
+    assert execution_info.result.res == init_amount
 
     try:
         # increasing the decreased allowance amount by more than the user's allowance
-        await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, init_amount + 1])
+        await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [
+            spender,
+            *uint(init_amount[0] + 1)
+        ])
         assert False
     except StarkException as err:
         _, error = err.args
@@ -204,12 +219,16 @@ async def test_transfer_funds_greater_than_allowance(erc20_factory):
     # this is ok since they're still two different accounts
     await spender.initialize(spender.contract_address).invoke()
     recipient = 222
-    allowance = 111
-    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, allowance])
+    allowance = uint(111)
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *allowance])
 
     try:
         # increasing the transfer amount above allowance
-        await signer.send_transaction(spender, erc20.contract_address, 'transfer_from', [account.contract_address, recipient, allowance + 1])
+        await signer.send_transaction(spender, erc20.contract_address, 'transfer_from', [
+            account.contract_address,
+            recipient,
+            *uint(allowance[0] + 1)
+        ])
         assert False
     except StarkException as err:
         _, error = err.args
@@ -221,12 +240,12 @@ async def test_overflow_increase_allowance(erc20_factory):
     _, erc20, account = erc20_factory
     # new spender, starting from zero
     spender = 234
-    amount = 2**200
-    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, amount])
+    amount = uint(2**200)
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
 
     try:
         # overflow check will revert the transaction
-        await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, amount])
+        await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, *amount])
         assert False
     except StarkException as err:
         _, error = err.args


### PR DESCRIPTION
# Uint256 Integration for ERC20

## Summary

This PR includes a complete refactoring of the ERC20 contract; whereby, the balances, total supply, and allowances now track 256 bit unsigned integers for seamless Solidity integration. The ERC20 contract uses Cairo's [Uint256](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/uint256.cairo) library which holds uint256 as a struct of two 252bit field elements (felts). One of the initial issues with this integration consisted of passing structs as function arguments. Cairo's 0.5.0 update solved this issue. It should be noted that when passing a Uint256 object as an argument without an account contract abstraction, the expected type is a tuple. When using an account abstraction, however, the expected type is an integer (specifically, `*int`). In other words, when a function expects a Uint256 arg, the values should be unpacked.

## Implementation
- Storage variables updated to Uint256
- Parameter types and return types updated to Uint256
- Addition and Subtraction operators removed in favor of Uint256 library's `uint256_add()` and `uint256_sub()` functions
- Overflow checks changed to Uint256 library's `uint256_le()` and `uint256_lt()` in conjunction with Cairo's `assert_not_zero()` from their [math](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/math.cairo) library

## Files

`contracts/token/ERC20.cairo`
`test/ERC20.py`

## Future
- Include `uint256_check()` for all relevant external functions to ensure Uint256 parameters (felts) do not exceed 2**128 - 1 (seems more appropriate to include in security checks)
- Burner address (zero address) protection
- Mint overflow protection
- Maybe consider cleaner ways to test Uints