### PR TITLE
Adding Account Documentation and Created docs folder

### DIFF
--- a/docs/Account.md
+++ b/docs/Account.md
@@ -13,7 +13,7 @@ Each transaction is validated for whether the Public Key is authenticated to per
 
 ## Signer
 
-Signer is used to perform transactions on an account. To use Signer, first make s Signer object with an initial parameter representing a public address.
+Signer is used to perform transactions on an account. To use Signer, first make a Signer object with a public address.
 
     from utils.Signer import Signer
 
@@ -119,7 +119,7 @@ get the current transaction count or nonce for the account
     (implicit) range_check_ptr
 
     $ Python
-    int: public_key
+    int: current_nonce
 
 #### set_public_key
 
@@ -151,12 +151,19 @@ transfer the account from one public key to another
 
 Note: execute is not called directly in workflows with the Account. Instead, the Signer object is used to send_transaction which calls the execute function. Thus, one can think of send_transaction as a wrapper around execute.
 
-execute takes a Message as its input parameter with a reference to the account. execute then:
+execute takes a transaction as its input parameters. 
+
+A transaction is composed of:
+1. a contract address;
+1. a string with the contract function selector name;
+1. a list of calldata - calldata are the parameters fed to the contract; and
+1. a list of length 2 with a signed response and the response size as the two elements.
+
+execute then:
 1. confirms that the Account has been initialized
-1. hashes the Message
-1. sends it to Starknet to validate the signature
+1. sends the transaction signatures to Starknet for validation
 1. increments the nonce
-1. calls the contract per the Message
+1. calls the contract per the transaction
 
 ##### Paramenters:
 
@@ -187,7 +194,7 @@ execute takes a Message as its input parameter with a reference to the account. 
 
 ## Code Sample
 
-Note: Starknet is stil under development and this Cairo Contracts project is still experimental. This example is designed to work in a test environment. Code samples that are more representative of a production implementation will be added when available.
+Note: Starknet is stil under development and this Cairo Contracts project is still experimental. This example is designed to work in a test environment. Code samples that are more representative of a production implementation may be added in the future.
 
     starknet = await Starknet.empty()
     account = await starknet.[deploy("contracts/Account.cairo")

--- a/docs/Account.md
+++ b/docs/Account.md
@@ -6,34 +6,34 @@ OpenZepplin Cairo Contracts Account Contract provides a mechanism to account aut
 
 The general workflow is three simple steps: 
 1. Acccount contract is deployed to Starknet; 
-1. Account is iitialized with a public key; and
-1. Transactions are executed on the account via the Signer with each validated that the account is authenticated to perform the transaction and that the transaction is not subject to a replay attack.
+1. Account is initialized with a public key; and
+1. Transactions are executed on the Account via a Signer utility.
 
-### Signer
+Each transaction is validated for whether the Public Key is authenticated to perform the transaction and whether the transaction is subject to a replay attack.
 
-Signer is used to perform transactions on an account. To use Signer, first register a public address with the signer object.
+## Signer
+
+Signer is used to perform transactions on an account. To use Signer, first make s Signer object with an initial parameter representing a public address.
 
     from utils.Signer import Signer
 
     signer = Signer(123456789987654321)
 
-Then send transactions with the signer object that need to be authenticated by StarkNet.
+Then send transactions with the Signer object that need to be authenticated by StarkNet.
 
     await signer.send_transaction(account, contract_address, 'account_command', [])
 
-## Core
-
-### Account
+## Account
 
     account = await starknet.deploy("contracts/Account.cairo")
     
 An account initialized with a public key. Accounts are transferable.
 
-Execution of the account proof on StarkNet will validate the signature of the Account.
+Execution of the account proof on StarkNet will validate the signature of the Account and whether the transaction is subject to a replay attack.
 
-#### Functions
+### Functions
 
-##### initialize
+#### initialize
 
     $ Cairo
     func initialize (_public_key: felt, _address: felt)
@@ -43,13 +43,13 @@ Execution of the account proof on StarkNet will validate the signature of the Ac
 
 Provide the initial settings for the Account to be validatied.
 
-###### Parameters:
+##### Parameters:
 
-_public key: felt - Pointer to Accounter Holder Public Key
+    _public key: felt - Pointer to Accounter Holder Public Key
 
-_address: felt - Pointer to Account Contract Address
+    _address: felt - Pointer to Account Contract Address
 
-###### Return:
+##### Return:
 
     $ Cairo
     (implicit) storage_ptr: Storage*
@@ -59,17 +59,17 @@ _address: felt - Pointer to Account Contract Address
     $ Python
     None
 
-##### get_public_key
+#### get_public_key
 
     assert account.get_public_key() == signer.public_key 
 
 get the public key associated with the Account
 
-###### Paramenters:
+##### Paramenters:
 
     None
 
-###### Return:
+##### Return:
 
     $ Cairo
     (implicit) storage_ptr: Storage*
@@ -80,17 +80,17 @@ get the public key associated with the Account
     $ Python
     int: public_key
 
-##### get_address
+#### get_address
 
     assert await account.get_address().call() == (account.contract_address,)
 
 get the contract address associated with the Account
 
-###### Paramenters:
+##### Paramenters:
 
     None
 
-###### Return:
+##### Return:
 
     $ Cairo
     (implicit) storage_ptr: Storage*
@@ -101,17 +101,17 @@ get the contract address associated with the Account
     $ Python
     int: contract_address
 
-##### get_nonce
+#### get_nonce
 
     assert await account.get_nonce().call() == (account.nonce)
 
 get the current transaction count or nonce for the account
 
-###### Paramenters:
+##### Paramenters:
 
     None
 
-###### Return:
+##### Return:
 
     $ Cairo
     (implicit) storage_ptr: Storage*
@@ -121,7 +121,7 @@ get the current transaction count or nonce for the account
     $ Python
     int: public_key
 
-##### set_public_key
+#### set_public_key
 
     assert await account.get_public_key().call() == (signer.public_key,)
     await signer.send_transaction(account, account.contract_address, 'set_public_key', [other.public_key])
@@ -129,11 +129,11 @@ get the current transaction count or nonce for the account
 
 transfer the account from one public key to another
 
-###### Paramenters:
+##### Paramenters:
 
     int: public_key
 
-###### Return:
+##### Return:
 
     $ Cairo
     (implicit) storage_ptr: Storage*
@@ -143,11 +143,11 @@ transfer the account from one public key to another
     $ Python
     None
 
-##### is_valid_signature
+#### is_valid_signature
 
 *This function is not directly used by clients. See func execute.
 
-##### execute
+#### execute
 
 Note: execute is not called directly in workflows with the Account. Instead, the Signer object is used to send_transaction which calls the execute function. Thus, one can think of send_transaction as a wrapper around execute.
 
@@ -158,7 +158,7 @@ execute takes a Message as its input parameter with a reference to the account. 
 1. increments the nonce
 1. calls the contract per the Message
 
-###### Paramenters:
+##### Paramenters:
 
     $ Cairo
     to: felt,
@@ -174,7 +174,7 @@ execute takes a Message as its input parameter with a reference to the account. 
     list: calldata, 
     list of length 2: [sig_r, sig_s]
 
-###### Return:
+##### Return:
 
     $ Cairo
     (implicit) storage_ptr: Storage*
@@ -185,7 +185,7 @@ execute takes a Message as its input parameter with a reference to the account. 
     int: system_response_return_data_size
 
 
-#### Code Sample
+## Code Sample
 
 Note: Starknet is stil under development and this Cairo Contracts project is still experimental. This example is designed to work in a test environment. Code samples that are more representative of a production implementation will be added when available.
 

--- a/docs/Account.md
+++ b/docs/Account.md
@@ -1,0 +1,54 @@
+# Accounts
+
+This set of contracts and utilities implement an Account on [Starknet](https://www.cairo-lang.org/docs/hello_starknet/intro.html) using [Cairo](https://www.cairo-lang.org/docs/hello_cairo/index.html#hello-cairo).
+
+## Core
+
+### Account
+
+    account = await starknet.deploy("contracts/Account.cairo")
+    
+An account initialized with a public key. Accounts are transferable.
+
+
+
+#### Functions
+
+initialize
+
+get_public_key
+
+get_address
+
+get_nonce
+
+set_public_key
+
+is_valid_signature
+
+execute
+
+
+#### Code Sample
+
+    starknet = await Starknet.empty()
+    account = await starknet.[deploy("contracts/Account.cairo")
+    await account.initialize({public_key}, account.contract_address).invoke()
+
+    # transfer account
+    assert await account.get_public_key().call() == (signer.public_key,)
+    await signer.send_transaction(account, account.contract_address, 'set_public_key', [other.public_key])
+
+## Extensions
+
+### Initializable
+
+    initializable = await starknet.deploy("contracts/Initializable.cairo")
+
+An account that can have an initialized state that is set once
+
+#### Functions
+
+initialized
+
+initialize

--- a/docs/Account.md
+++ b/docs/Account.md
@@ -10,23 +10,140 @@ This set of contracts and utilities implement an Account on [Starknet](https://w
     
 An account initialized with a public key. Accounts are transferable.
 
-
+Execution of the account proof on StarkNet will validate the signature of the Account.
 
 #### Functions
 
-initialize
+##### initialize
 
-get_public_key
+    $ Cairo
+    func initialize (_public_key: felt, _address: felt)
 
-get_address
+    $ Python
+    await account.initialize(signer.public_key, account.contract_address).invoke()
 
-get_nonce
+Provide the initial settings for the Account to be validatied.
 
-set_public_key
+###### Parameters:
 
-is_valid_signature
+_public key: felt - Pointer to Accounter Holder Public Key
 
-execute
+_address: felt - Pointer to Account Contract Address
+
+###### Return:
+
+    $ Cairo
+    (implicit) storage_ptr: Storage*
+    (implicit) pedersen_ptr: HashBuiltin*
+    (implicit) range_check_ptr
+
+    $ Python
+    None
+
+##### get_public_key
+
+    assert account.get_public_key() == signer.public_key 
+
+get the public key associated with the Account
+
+###### Paramenters:
+
+    None
+
+###### Return:
+
+    $ Cairo
+    (implicit) storage_ptr: Storage*
+    (implicit) pedersen_ptr: HashBuiltin*
+    (implicit) range_check_ptr
+    public_key: int
+
+    $ Python
+    int: public_key
+
+##### get_address
+
+    assert await account.get_address().call() == (account.contract_address,)
+
+get the contract address associated with the Account
+
+###### Paramenters:
+
+    None
+
+###### Return:
+
+    $ Cairo
+    (implicit) storage_ptr: Storage*
+    (implicit) pedersen_ptr: HashBuiltin*
+    (implicit) range_check_ptr
+
+    $ Python
+    int: public_key
+
+##### get_nonce
+
+###### Paramenters:
+
+    None
+
+###### Return:
+
+    $ Cairo
+    (implicit) storage_ptr: Storage*
+    (implicit) pedersen_ptr: HashBuiltin*
+    (implicit) range_check_ptr
+
+    $ Python
+    int: public_key
+
+##### set_public_key
+
+###### Paramenters:
+
+    None
+
+###### Return:
+
+    $ Cairo
+    (implicit) storage_ptr: Storage*
+    (implicit) pedersen_ptr: HashBuiltin*
+    (implicit) range_check_ptr
+
+    $ Python
+    int: public_key
+
+##### is_valid_signature
+
+###### Paramenters:
+
+    None
+
+###### Return:
+
+    $ Cairo
+    (implicit) storage_ptr: Storage*
+    (implicit) pedersen_ptr: HashBuiltin*
+    (implicit) range_check_ptr
+
+    $ Python
+    int: public_key
+
+##### execute
+
+###### Paramenters:
+
+    None
+
+###### Return:
+
+    $ Cairo
+    (implicit) storage_ptr: Storage*
+    (implicit) pedersen_ptr: HashBuiltin*
+    (implicit) range_check_ptr
+
+    $ Python
+    int: public_key
 
 
 #### Code Sample

--- a/test/utils/Signer.py
+++ b/test/utils/Signer.py
@@ -1,8 +1,40 @@
+"""
+Signer
+----------
+A utility for sending signed transactions to an Account on Starknet.
+
+"""
+
+
 from starkware.crypto.signature.signature import pedersen_hash, private_to_stark_key, sign
 from starkware.starknet.public.abi import get_selector_from_name
 
 
 class Signer():
+    """
+    Utility for sending signed transactions to an Account on Starknet.
+
+    Parameters
+    ----------
+
+    private_key : int
+
+    Examples
+    ---------
+    Constructing a Singer object
+
+    >>> my_txn_signer = Signer(1234)
+
+    Sending a transaction
+
+    >>> await signer.send_transaction(account, 
+                                      account.contract_address, 
+                                      'set_public_key', 
+                                      [other.public_key]
+                                     )
+
+
+    """
     def __init__(self, private_key):
         self.private_key = private_key
         self.public_key = private_to_stark_key(private_key)


### PR DESCRIPTION
Created a docs folder to store documentation on individual contracts and concepts.

Added account documentation via acccount.md in docs folder.

Added initial documentation to Signer.py to align with Accounts documentation.