### PR TITLE
Added `_burn()`

### DIFF
--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -159,20 +159,16 @@ func _burn{
     alloc_locals
     assert_not_zero(account)
 
-    let (local balance: Uint256) = balances.read(account)
+    let (balance: Uint256) = balances.read(account)
     # validates amount <= balance and returns 1 if true
     let (enough_balance) = uint256_le(amount, balance)
     assert_not_zero(enough_balance)
     
-    let (local new_balance: Uint256) = uint256_sub(balance, amount)
+    let (new_balance: Uint256) = uint256_sub(balance, amount)
     balances.write(account, new_balance)
 
-    let (local supply: Uint256) = total_supply.read()
-    # validates amount <= supply and returns 1 if true
-    let (enough_supply) = uint256_le(amount, supply)
-    assert_not_zero(enough_supply)
-
-    let (local new_supply: Uint256) = uint256_sub(supply, amount)
+    let (supply: Uint256) = total_supply.read()
+    let (new_supply: Uint256) = uint256_sub(supply, amount)
     total_supply.write(new_supply)
     return ()
 end

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -151,6 +151,32 @@ func _approve{
     return ()
 end
 
+func _burn{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(account: felt, amount: Uint256):
+    alloc_locals
+    assert_not_zero(account)
+
+    let (balance: Uint256) = balances.read(account)
+    let (local new_balance: Uint256) = uint256_sub(balance, amount)
+
+    # validates new_balance < balance and returns 1 if true   
+    let (enough_balance) = uint256_lt(new_balance, balance)
+    assert_not_zero(enough_balance)
+    balances.write(account, new_balance)
+
+    let (supply: Uint256) = total_supply.read()
+    let (local new_supply: Uint256) = uint256_sub(supply, amount)
+
+    # underflow check
+    let (is_underflow) = uint256_lt(new_supply, supply)
+    assert_not_zero(is_underflow)
+    total_supply.write(new_supply)
+    return ()
+end
+
 #
 # Externals
 #
@@ -237,7 +263,7 @@ func decrease_allowance{
 end
 
 #
-# Test function — will remove once extensibility is resolved
+# Test functions — will remove once extensibility is resolved
 #
 
 @external
@@ -247,5 +273,15 @@ func mint{
         range_check_ptr
     }(recipient: felt, amount: Uint256):
     _mint(recipient, amount)
+    return()
+end
+
+@external
+func burn{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(user: felt, amount: Uint256):
+    _burn(user, amount)
     return()
 end

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -159,20 +159,20 @@ func _burn{
     alloc_locals
     assert_not_zero(account)
 
-    let (balance: Uint256) = balances.read(account)
-    let (local new_balance: Uint256) = uint256_sub(balance, amount)
-
-    # validates new_balance < balance and returns 1 if true   
-    let (enough_balance) = uint256_lt(new_balance, balance)
+    let (local balance: Uint256) = balances.read(account)
+    # validates amount <= balance and returns 1 if true
+    let (enough_balance) = uint256_le(amount, balance)
     assert_not_zero(enough_balance)
+    
+    let (local new_balance: Uint256) = uint256_sub(balance, amount)
     balances.write(account, new_balance)
 
-    let (supply: Uint256) = total_supply.read()
-    let (local new_supply: Uint256) = uint256_sub(supply, amount)
+    let (local supply: Uint256) = total_supply.read()
+    # validates amount <= supply and returns 1 if true
+    let (enough_supply) = uint256_le(amount, supply)
+    assert_not_zero(enough_supply)
 
-    # underflow check
-    let (is_underflow) = uint256_lt(new_supply, supply)
-    assert_not_zero(is_underflow)
+    let (local new_supply: Uint256) = uint256_sub(supply, amount)
     total_supply.write(new_supply)
     return ()
 end

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -435,12 +435,14 @@ async def test_burn(erc20_factory):
 
     await signer.send_transaction(account, erc20.contract_address, 'burn', [user, *burn_amount])
 
+    # total supply should reflect the burned amount
     execution_info = await erc20.get_total_supply().call()
     assert execution_info.result.res == (
         previous_supply[0] - burn_amount[0],
         previous_supply[1] - burn_amount[1]
     )
 
+    # user balance should reflect the burned amount
     execution_info = await erc20.balance_of(user).call()
     assert execution_info.result.res == (
         previous_balance[0] - burn_amount[0],

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -465,7 +465,7 @@ async def test_burn_zero_address(erc20_factory):
 
 
 @pytest.mark.asyncio
-async def test_burn_underflow(erc20_factory):
+async def test_burn_overflow(erc20_factory):
     _, erc20, account = erc20_factory
     user = 789
     execution_info = await erc20.balance_of(user).call()

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -420,3 +420,61 @@ async def test_mint_overflow(erc20_factory):
 
     # should pass
     await signer.send_transaction(account, erc20.contract_address, 'mint', [recipient, *pass_amount])
+
+
+@pytest.mark.asyncio
+async def test_burn(erc20_factory):
+    _, erc20, account = erc20_factory
+    user = 789
+    burn_amount = uint(500)
+    execution_info = await erc20.get_total_supply().call()
+    previous_supply = execution_info.result.res
+
+    execution_info = await erc20.balance_of(user).call()
+    previous_balance = execution_info.result.res
+
+    await signer.send_transaction(account, erc20.contract_address, 'burn', [user, *burn_amount])
+
+    execution_info = await erc20.get_total_supply().call()
+    assert execution_info.result.res == (
+        previous_supply[0] - burn_amount[0],
+        previous_supply[1] - burn_amount[1]
+    )
+
+    execution_info = await erc20.balance_of(user).call()
+    assert execution_info.result.res == (
+        previous_balance[0] - burn_amount[0],
+        previous_balance[1] - burn_amount[1]
+    )
+
+
+@pytest.mark.asyncio
+async def test_burn_zero_address(erc20_factory):
+    _, erc20, account = erc20_factory
+    user = 0
+    burn_amount = uint(1)
+
+    try:
+        await signer.send_transaction(account, erc20.contract_address, 'burn', [user, *burn_amount])
+        assert False
+    except StarkException as err:
+        _, error = err.args
+        assert error['code'] == StarknetErrorCode.TRANSACTION_FAILED
+
+
+@pytest.mark.asyncio
+async def test_burn_underflow(erc20_factory):
+    _, erc20, account = erc20_factory
+    user = 789
+    execution_info = await erc20.balance_of(user).call()
+    previous_balance = execution_info.result.res
+    # increasing the burn amount to more than the user's balance
+    # should make the tx fail
+    burn_amount = (previous_balance[0] + 1, previous_balance[1])
+
+    try:
+        await signer.send_transaction(account, erc20.contract_address, 'burn', [user, *burn_amount])
+        assert False
+    except StarkException as err:
+        _, error = err.args
+        assert error['code'] == StarknetErrorCode.TRANSACTION_FAILED

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -451,11 +451,11 @@ async def test_burn(erc20_factory):
 @pytest.mark.asyncio
 async def test_burn_zero_address(erc20_factory):
     _, erc20, account = erc20_factory
-    user = 0
+    zero_address = 0
     burn_amount = uint(1)
 
     try:
-        await signer.send_transaction(account, erc20.contract_address, 'burn', [user, *burn_amount])
+        await signer.send_transaction(account, erc20.contract_address, 'burn', [zero_address, *burn_amount])
         assert False
     except StarkException as err:
         _, error = err.args


### PR DESCRIPTION
# Added `_burn()` Function

## Summary 

This PR, referenced in #43 , includes the `_burn()` function implemented along with the `burn()` wrapper function to make it accessible for testing. Further, the function provides checks on the burn amount relative to the burn account's balance as well as the total supply. `_burn()` also ensures the burn account is not the zero address.

## Implementation
- checks that the burn account is not the zero address
- subtracts the specified amount in both the burn account and total supply
- checks that `amount` is less than or equal to the burn account's balance
- checks that `amount` is less than or equal to `total_supply`

## Future
- Extensibility and removing the 'test functions' would be a huge upgrade
