### PR TITLE
Uint256 Implementation Check

### DIFF
--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -422,31 +422,6 @@ async def test_mint_overflow(erc20_factory):
     await signer.send_transaction(account, erc20.contract_address, 'mint', [recipient, *pass_amount])
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize('break_vals', [
-    (MAX_AMOUNT[0], MAX_AMOUNT[1] + 1),
-    (MAX_AMOUNT[0] + 1, MAX_AMOUNT[0]),
-    (0, MAX_AMOUNT[1] + 1),
-    (MAX_AMOUNT[0] + 1, 0)
-])
-async def test_break_decrease_allowance(erc20_factory, break_vals):
-    _, erc20, account = erc20_factory
-    spender = 321
-    init_amount = (MAX_AMOUNT)
-
-    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *init_amount])
-
-    execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result.res == init_amount
-
-    try:
-        await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, *break_vals])
-        assert False
-    except StarkException as err:
-        _, error = err.args
-        assert error['code'] == StarknetErrorCode.TRANSACTION_FAILED
-
-
 #
 # The following tests were attempts to break the current ERC20 implementation; whereby,
 # the function arguments exceed one of the uint's 128 bit-limit values.


### PR DESCRIPTION
# Uint256 Implementation Check

## Preface
This PR, in reference to #52 , includes test cases that attempt to break the ERC20 implementation (at the time of this writing). It should be understood that inserting overflowing arguments in functions such as `approve()` and `increase_allowance()` will not return an error because of said overflow. Prior to reaching the uint256 arithmetic functions, which include a check on the uint256 values themselves, these values simply overflow. For example: if you attempt to call `approve()` with the arguments `2**128 + 2, 0`, the transaction will not revert because the value is interpreted as `1, 0`. This does not break the ERC20 implementation because the integers overflow prior to reaching the ERC20 state. 


## Summary

This PR includes three tests that check for potential vulnerabilities regarding overflow/underflow in respect to ERC20 functions accepting uint256 arguments from Cairo's [Uint256 library](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/uint256.cairo). `decrease_allowance()` proves to be the most straight-forward function to check. The function is displayed below for reference. 
```
@external
func decrease_allowance{
        syscall_ptr : felt*, 
        pedersen_ptr : HashBuiltin*,
        range_check_ptr
    }(spender: felt, subtracted_value: Uint256):
    alloc_locals
    let (local caller) = get_caller_address()
    let (local current_allowance: Uint256) = allowances.read(owner=caller, spender=spender)
    let (local new_allowance: Uint256) = uint256_sub(current_allowance, subtracted_value)

    # validates new_allowance < current_allowance and returns 1 if true   
    let (enough_allowance) = uint256_lt(new_allowance, current_allowance)
    assert_not_zero(enough_allowance)

    _approve(caller, spender, new_allowance)
    return()
end
```
Notice, the `enough_allowance` check occurs _after_ `current_allownace - subtracted_value`. If the ERC20 implementation can be corrupted, this particular spot is the most vulnerable. The test first approves `MAX_AMOUNT` (2**256 - 1), and then proceeds to test whether our implementation will behave in an unsuspecting manner via single felt overflows. This test fails each iteration of overflowing parameters.

Further, this PR also includes the same type of test for `transfer()` and `transfer_from()`. Being that their respective function logic has a few more moving parts than `decrease_allowance()`, it seemed apropos to include them. Perhaps, testing `decrease_allowance()` is enough for the sake of brevity.

## Implementation
- Approved the maximum integer to prove that any number within that range would _not_ fail the test
- Tested the functions with the following arguments:
-- `2^128 - 1, 2^128`
-- `2^128, 2^128 - 1`
-- `0, 2^128 + 2`
-- `2^128 + 2, 0`
