### PR TITLE
Remove Unnecessary References from `execute()`

### DIFF
--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -201,11 +201,7 @@ func execute{
 
     let (__fp__, _) = get_fp_and_pc()
     let (_address) = address.read()
-    let (_current_nonce) = current_nonce.read()
-
-    local syscall_ptr : felt* = syscall_ptr
-    local range_check_ptr = range_check_ptr
-    local _current_nonce = _current_nonce
+    let (local _current_nonce) = current_nonce.read()
 
     local message: Message = Message(
         _address,

--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -201,7 +201,7 @@ func execute{
 
     let (__fp__, _) = get_fp_and_pc()
     let (_address) = address.read()
-    let (local _current_nonce) = current_nonce.read()
+    let (_current_nonce) = current_nonce.read()
 
     local message: Message = Message(
         _address,


### PR DESCRIPTION
We can omit these references (from [Cairo 0.5.2](https://github.com/starkware-libs/cairo-lang/releases/tag/v0.5.2)) and `_current_nonce` does not get revoked.