### PR TITLE
Added `name` and `symbol` to ERC20

### DIFF
--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -45,7 +45,11 @@ func constructor{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(name: felt, symbol: felt, recipient: felt):
+    }(
+        name: felt,
+        symbol: felt,
+        recipient: felt
+    ):
     # get_caller_address() returns '0' in the constructor;
     # therefore, recipient parameter is included
     _name.write(name)

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -13,6 +13,14 @@ from starkware.cairo.common.uint256 import (
 #
 
 @storage_var
+func _name() -> (res: felt):
+end
+
+@storage_var
+func _symbol() -> (res: felt):
+end
+
+@storage_var
 func balances(account: felt) -> (res: Uint256):
 end
 
@@ -37,9 +45,11 @@ func constructor{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(recipient: felt):
+    }(name: felt, symbol: felt, recipient: felt):
     # get_caller_address() returns '0' in the constructor;
     # therefore, recipient parameter is included
+    _name.write(name)
+    _symbol.write(symbol)
     decimals.write(18)
     _mint(recipient, Uint256(1000, 0))
     return ()
@@ -48,6 +58,26 @@ end
 #
 # Getters
 #
+
+@view
+func name{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (res: felt):
+    let (res) = _name.read()
+    return (res)
+end
+
+@view
+func symbol{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (res: felt):
+    let (res) = _symbol.read()
+    return (res)
+end
 
 @view
 func get_total_supply{

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -36,8 +36,8 @@ async def erc20_factory():
     erc20 = await starknet.deploy(
         "contracts/token/ERC20.cairo",
         constructor_calldata=[
-            str_to_felt('Token'),  # name
-            str_to_felt('TKN'),  # symbol
+            str_to_felt("Token"),  # name
+            str_to_felt("TKN"),  # symbol
             account.contract_address
         ]
     )

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -19,11 +19,6 @@ def str_to_felt(text):
     return int.from_bytes(b_text, "big")
 
 
-tmp_name = 12345
-
-tmp_symbol = 54321
-
-
 @pytest.fixture(scope='module')
 def event_loop():
     return asyncio.new_event_loop()

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -14,6 +14,16 @@ def uint(a):
     return(a, 0)
 
 
+def str_to_felt(text):
+    b_text = bytes(text, 'UTF-8')
+    return int.from_bytes(b_text, "big")
+
+
+tmp_name = 12345
+
+tmp_symbol = 54321
+
+
 @pytest.fixture(scope='module')
 def event_loop():
     return asyncio.new_event_loop()
@@ -30,7 +40,11 @@ async def erc20_factory():
 
     erc20 = await starknet.deploy(
         "contracts/token/ERC20.cairo",
-        constructor_calldata=[account.contract_address]
+        constructor_calldata=[
+            str_to_felt('Token'),  # name
+            str_to_felt('TKN'),  # symbol
+            account.contract_address
+        ]
     )
     return starknet, erc20, account
 
@@ -43,6 +57,20 @@ async def test_constructor(erc20_factory):
 
     execution_info = await erc20.get_total_supply().call()
     assert execution_info.result.res == uint(1000)
+
+
+@pytest.mark.asyncio
+async def test_name(erc20_factory):
+    _, erc20, _ = erc20_factory
+    execution_info = await erc20.name().call()
+    assert execution_info.result == (str_to_felt("Token"),)
+
+
+@pytest.mark.asyncio
+async def test_symbol(erc20_factory):
+    _, erc20, _ = erc20_factory
+    execution_info = await erc20.symbol().call()
+    assert execution_info.result == (str_to_felt("TKN"),)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Added `name` and `symbol` to ERC20

## Summary 

This PR, in reference to #59  , adds `name` and `symbol` functions to the ERC20 implementation. The two storage variables `_name` and `_symbol`, to which these functions fetch, are set in the constructor. Cairo, however, does not accept short string arguments because the compiler expects an `int` type; therefore, the tests include a helper function `str_to_felt()`. This helper function follows how Cairo interprets short string literals. If it's preferable to temporarily hardcode `_name` and `_symbol`, the helper function will be much more helpful in testing.

## Implementation
- Added `storage_vars` for `_name` and `_symbol`
- Added `view` functions `name()` and `symbol()`
- Inserted two more parameters in the ERC20 constructor
- Created helper function `str_to_felt()` for testing
- Set in "Token" and "TKN" as `_name` and `_symbol` arguments in testing constructor