### PR TITLE
Add multicall

### DIFF
--- a/tests/utils/Signer.py
+++ b/tests/utils/Signer.py
@@ -48,7 +48,10 @@ class Signer():
             account.contract_address, to, selector, calldata, nonce)
         sig_r, sig_s = self.sign(message_hash)
 
-        return await account.execute(to, selector, calldata, nonce).invoke(signature=[sig_r, sig_s])
+        message_a = [to, selector, calldata, nonce]
+        messages = [message_a, message_a]
+
+        return await account.execute(messages).invoke(signature=[sig_r, sig_s])
 
 
 def hash_message(sender, to, selector, calldata, nonce):


### PR DESCRIPTION
Since this feature requires a list of messages `[Message]` and each `Message` contains a list of arguments as `calldata`, it cannot be completed until Cairo supports passing an array of structs or at a least nested array simulating one to external functions.