### PR TITLE
Upgrade to cairo 0.6.0

### DIFF
--- a/tests/test_Account.py
+++ b/tests/test_Account.py
@@ -22,21 +22,15 @@ async def account_factory():
         constructor_calldata=[signer.public_key]
     )
 
-    # Keeping the initialize function to set the contract_address
-    # until `this.address` is available
-    await account.initialize(account.contract_address).invoke()
     return starknet, account
 
 
 @pytest.mark.asyncio
-async def test_initializer(account_factory):
+async def test_constructor(account_factory):
     _, account = account_factory
 
     execution_info = await account.get_public_key().call()
     assert execution_info.result == (signer.public_key,)
-
-    execution_info = await account.get_address().call()
-    assert execution_info.result == (account.contract_address,)
 
 
 @pytest.mark.asyncio
@@ -47,7 +41,6 @@ async def test_execute(account_factory):
     execution_info = await initializable.initialized().call()
     assert execution_info.result == (0,)
 
-    # initialize
     await signer.send_transaction(account, initializable.contract_address, 'initialize', [])
 
     execution_info = await initializable.initialized().call()

--- a/tests/test_AddressRegistry.py
+++ b/tests/test_AddressRegistry.py
@@ -22,7 +22,6 @@ async def account_factory():
         constructor_calldata=[signer.public_key]
     )
 
-    await account.initialize(account.contract_address).invoke()
     return starknet, account, registry
 
 

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -26,7 +26,6 @@ async def erc20_factory():
         "contracts/Account.cairo",
         constructor_calldata=[signer.public_key]
     )
-    await account.initialize(account.contract_address).invoke()
 
     erc20 = await starknet.deploy(
         "contracts/token/ERC20.cairo",
@@ -114,7 +113,6 @@ async def test_transfer_from(erc20_factory):
     )
     # we use the same signer to control the main and the spender accounts
     # this is ok since they're still two different accounts
-    await spender.initialize(spender.contract_address).invoke()
     amount = uint(345)
     recipient = 987
     execution_info = await erc20.balance_of(account.contract_address).call()
@@ -219,7 +217,6 @@ async def test_transfer_funds_greater_than_allowance(erc20_factory):
     )
     # we use the same signer to control the main and the spender accounts
     # this is ok since they're still two different accounts
-    await spender.initialize(spender.contract_address).invoke()
     recipient = 222
     allowance = uint(111)
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *allowance])
@@ -295,7 +292,6 @@ async def test_transfer_from_func_to_zero_address(erc20_factory):
     )
     # we use the same signer to control the main and the spender accounts
     # this is ok since they're still two different accounts
-    await spender.initialize(spender.contract_address).invoke()
     amount = uint(1)
     zero_address = 0
 
@@ -324,7 +320,6 @@ async def test_transfer_from_func_from_zero_address(erc20_factory):
     )
     # we use the same signer to control the main and the spender accounts
     # this is ok since they're still two different accounts
-    await spender.initialize(spender.contract_address).invoke()
     zero_address = 0
     recipient = 123
     amount = uint(1)

--- a/tests/test_Ownable.py
+++ b/tests/test_Ownable.py
@@ -18,7 +18,6 @@ async def ownable_factory():
         "contracts/Account.cairo",
         constructor_calldata=[signer.public_key]
     )
-    await owner.initialize(owner.contract_address).invoke()
 
     ownable = await starknet.deploy(
         "contracts/Ownable.cairo",


### PR DESCRIPTION
Drop Account initializer and address storage var in favor of `get_contract_address`