### PR TITLE
ERC20 Return Bools

### DIFF
--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -148,7 +148,7 @@ func execute{
         calldata_len: felt,
         calldata: felt*,
         nonce: felt
-    ) -> (response : felt):
+    ) -> (response_len : felt, response : felt*):
     alloc_locals
 
     let (__fp__, _) = get_fp_and_pc()
@@ -180,7 +180,7 @@ func execute{
         calldata=message.calldata
     )
 
-    return (response=response.retdata_size)
+    return (response_len=response.retdata_size, response=response.retdata)
 end
 
 func hash_message{pedersen_ptr : HashBuiltin*}(message: Message*) -> (res: felt):

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -221,6 +221,7 @@ func transfer{
     }(recipient: felt, amount: Uint256) -> (is_success: felt):
     let (sender) = get_caller_address()
     _transfer(sender, recipient, amount)
+    
     tempvar is_success = 1
     return (is_success)
 end
@@ -257,6 +258,7 @@ func approve{
     }(spender: felt, amount: Uint256) -> (is_success: felt):
     let (caller) = get_caller_address()
     _approve(caller, spender, amount)
+
     tempvar is_success = 1
     return (is_success)
 end
@@ -276,6 +278,7 @@ func increase_allowance{
     assert (is_overflow) = 0
 
     _approve(caller, spender, new_allowance)
+
     tempvar is_success = 1
     return(is_success)
 end
@@ -296,6 +299,7 @@ func decrease_allowance{
     assert_not_zero(enough_allowance)
 
     _approve(caller, spender, new_allowance)
+
     tempvar is_success = 1
     return(is_success)
 end

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -187,6 +187,28 @@ func _approve{
     return ()
 end
 
+func _burn{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(account: felt, amount: Uint256):
+    alloc_locals
+    assert_not_zero(account)
+
+    let (balance: Uint256) = balances.read(account)
+    # validates amount <= balance and returns 1 if true
+    let (enough_balance) = uint256_le(amount, balance)
+    assert_not_zero(enough_balance)
+    
+    let (new_balance: Uint256) = uint256_sub(balance, amount)
+    balances.write(account, new_balance)
+
+    let (supply: Uint256) = total_supply.read()
+    let (new_supply: Uint256) = uint256_sub(supply, amount)
+    total_supply.write(new_supply)
+    return ()
+end
+
 #
 # Externals
 #
@@ -273,7 +295,7 @@ func decrease_allowance{
 end
 
 #
-# Test function — will remove once extensibility is resolved
+# Test functions — will remove once extensibility is resolved
 #
 
 @external
@@ -283,5 +305,15 @@ func mint{
         range_check_ptr
     }(recipient: felt, amount: Uint256):
     _mint(recipient, amount)
+    return()
+end
+
+@external
+func burn{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(user: felt, amount: Uint256):
+    _burn(user, amount)
     return()
 end

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -221,7 +221,7 @@ func transfer{
     }(recipient: felt, amount: Uint256) -> (is_success: felt):
     let (sender) = get_caller_address()
     _transfer(sender, recipient, amount)
-    
+
     tempvar is_success = 1
     return (is_success)
 end
@@ -231,7 +231,11 @@ func transfer_from{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(sender: felt, recipient: felt, amount: Uint256) -> (is_success: felt):
+    }(
+        sender: felt, 
+        recipient: felt, 
+        amount: Uint256
+    ) -> (is_success: felt):
     alloc_locals
     let (local caller) = get_caller_address()
     let (local caller_allowance: Uint256) = allowances.read(owner=sender, spender=caller)

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -284,7 +284,7 @@ func increase_allowance{
     _approve(caller, spender, new_allowance)
 
     # Cairo equivalent to 'return (true)'
-    return(1)
+    return (1)
 end
 
 @external
@@ -305,7 +305,7 @@ func decrease_allowance{
     _approve(caller, spender, new_allowance)
 
     # Cairo equivalent to 'return (true)'
-    return(1)
+    return (1)
 end
 
 #
@@ -319,7 +319,7 @@ func mint{
         range_check_ptr
     }(recipient: felt, amount: Uint256):
     _mint(recipient, amount)
-    return()
+    return ()
 end
 
 @external
@@ -329,5 +329,5 @@ func burn{
         range_check_ptr
     }(user: felt, amount: Uint256):
     _burn(user, amount)
-    return()
+    return ()
 end

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -218,12 +218,12 @@ func transfer{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(recipient: felt, amount: Uint256) -> (is_success: felt):
+    }(recipient: felt, amount: Uint256) -> (success: felt):
     let (sender) = get_caller_address()
     _transfer(sender, recipient, amount)
 
-    tempvar is_success = 1
-    return (is_success)
+    # Cairo equivalent to 'return (true)'
+    return (1)
 end
 
 @external
@@ -235,7 +235,7 @@ func transfer_from{
         sender: felt, 
         recipient: felt, 
         amount: Uint256
-    ) -> (is_success: felt):
+    ) -> (success: felt):
     alloc_locals
     let (local caller) = get_caller_address()
     let (local caller_allowance: Uint256) = allowances.read(owner=sender, spender=caller)
@@ -250,8 +250,8 @@ func transfer_from{
     let (new_allowance: Uint256) = uint256_sub(caller_allowance, amount)
     allowances.write(sender, caller, new_allowance)
 
-    tempvar is_success = 1
-    return (is_success)
+    # Cairo equivalent to 'return (true)'
+    return (1)
 end
 
 @external
@@ -259,12 +259,12 @@ func approve{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(spender: felt, amount: Uint256) -> (is_success: felt):
+    }(spender: felt, amount: Uint256) -> (success: felt):
     let (caller) = get_caller_address()
     _approve(caller, spender, amount)
 
-    tempvar is_success = 1
-    return (is_success)
+    # Cairo equivalent to 'return (true)'
+    return (1)
 end
 
 @external
@@ -272,7 +272,7 @@ func increase_allowance{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(spender: felt, added_value: Uint256) -> (is_success: felt):
+    }(spender: felt, added_value: Uint256) -> (success: felt):
     alloc_locals
     let (local caller) = get_caller_address()
     let (local current_allowance: Uint256) = allowances.read(caller, spender)
@@ -283,8 +283,8 @@ func increase_allowance{
 
     _approve(caller, spender, new_allowance)
 
-    tempvar is_success = 1
-    return(is_success)
+    # Cairo equivalent to 'return (true)'
+    return(1)
 end
 
 @external
@@ -292,7 +292,7 @@ func decrease_allowance{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(spender: felt, subtracted_value: Uint256) -> (is_success: felt):
+    }(spender: felt, subtracted_value: Uint256) -> (success: felt):
     alloc_locals
     let (local caller) = get_caller_address()
     let (local current_allowance: Uint256) = allowances.read(owner=caller, spender=spender)
@@ -304,8 +304,8 @@ func decrease_allowance{
 
     _approve(caller, spender, new_allowance)
 
-    tempvar is_success = 1
-    return(is_success)
+    # Cairo equivalent to 'return (true)'
+    return(1)
 end
 
 #

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -218,10 +218,11 @@ func transfer{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(recipient: felt, amount: Uint256):
+    }(recipient: felt, amount: Uint256) -> (is_success: felt):
     let (sender) = get_caller_address()
     _transfer(sender, recipient, amount)
-    return ()
+    tempvar is_success = 1
+    return (is_success)
 end
 
 @external
@@ -229,7 +230,7 @@ func transfer_from{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(sender: felt, recipient: felt, amount: Uint256):
+    }(sender: felt, recipient: felt, amount: Uint256) -> (is_success: felt):
     alloc_locals
     let (local caller) = get_caller_address()
     let (local caller_allowance: Uint256) = allowances.read(owner=sender, spender=caller)
@@ -243,7 +244,9 @@ func transfer_from{
     # subtract allowance
     let (new_allowance: Uint256) = uint256_sub(caller_allowance, amount)
     allowances.write(sender, caller, new_allowance)
-    return ()
+
+    tempvar is_success = 1
+    return (is_success)
 end
 
 @external
@@ -251,10 +254,11 @@ func approve{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(spender: felt, amount: Uint256):
+    }(spender: felt, amount: Uint256) -> (is_success: felt):
     let (caller) = get_caller_address()
     _approve(caller, spender, amount)
-    return ()
+    tempvar is_success = 1
+    return (is_success)
 end
 
 @external
@@ -262,7 +266,7 @@ func increase_allowance{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(spender: felt, added_value: Uint256):
+    }(spender: felt, added_value: Uint256) -> (is_success: felt):
     alloc_locals
     let (local caller) = get_caller_address()
     let (local current_allowance: Uint256) = allowances.read(caller, spender)
@@ -272,7 +276,8 @@ func increase_allowance{
     assert (is_overflow) = 0
 
     _approve(caller, spender, new_allowance)
-    return()
+    tempvar is_success = 1
+    return(is_success)
 end
 
 @external
@@ -280,7 +285,7 @@ func decrease_allowance{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(spender: felt, subtracted_value: Uint256):
+    }(spender: felt, subtracted_value: Uint256) -> (is_success: felt):
     alloc_locals
     let (local caller) = get_caller_address()
     let (local current_allowance: Uint256) = allowances.read(owner=caller, spender=spender)
@@ -291,7 +296,8 @@ func decrease_allowance{
     assert_not_zero(enough_allowance)
 
     _approve(caller, spender, new_allowance)
-    return()
+    tempvar is_success = 1
+    return(is_success)
 end
 
 #

--- a/contracts/token/IERC20.cairo
+++ b/contracts/token/IERC20.cairo
@@ -16,12 +16,16 @@ namespace IERC20:
     func allowance(owner: felt, spender: felt) -> (res: Uint256):
     end
 
-    func transfer(recipient: felt, amount: Uint256):
+    func transfer(recipient: felt, amount: Uint256) -> (is_success: felt):
     end
 
-    func transfer_from(sender: felt, recipient: felt, amount: Uint256):
+    func transfer_from(
+            sender: felt, 
+            recipient: felt, 
+            amount: Uint256
+        ) -> (is_success: felt):
     end
 
-    func approve(spender: felt, amount: Uint256):
+    func approve(spender: felt, amount: Uint256) -> (is_success: felt):
     end
 end

--- a/contracts/token/IERC20.cairo
+++ b/contracts/token/IERC20.cairo
@@ -16,16 +16,16 @@ namespace IERC20:
     func allowance(owner: felt, spender: felt) -> (res: Uint256):
     end
 
-    func transfer(recipient: felt, amount: Uint256) -> (is_success: felt):
+    func transfer(recipient: felt, amount: Uint256) -> (success: felt):
     end
 
     func transfer_from(
             sender: felt, 
             recipient: felt, 
             amount: Uint256
-        ) -> (is_success: felt):
+        ) -> (success: felt):
     end
 
-    func approve(spender: felt, amount: Uint256) -> (is_success: felt):
+    func approve(spender: felt, amount: Uint256) -> (success: felt):
     end
 end

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -82,7 +82,9 @@ async def test_transfer(erc20_factory):
     assert execution_info.result.res == uint(0)
 
     # transfer
-    await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, *amount])
+    res_bool = await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, *amount])
+    # check return value equals true ('1')
+    assert res_bool.result.response == [1]
 
     execution_info = await erc20.balance_of(account.contract_address).call()
     assert execution_info.result.res == uint(900)
@@ -122,7 +124,9 @@ async def test_approve(erc20_factory):
     assert execution_info.result.res == uint(0)
 
     # set approval
-    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
+    res_bool = await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
+    # check return value equals true ('1')
+    assert res_bool.result.response == [1]
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
     assert execution_info.result.res == amount
@@ -145,9 +149,11 @@ async def test_transfer_from(erc20_factory):
     # approve
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *amount])
     # transfer_from
-    await signer.send_transaction(
+    res_bool = await signer.send_transaction(
         spender, erc20.contract_address, 'transfer_from', [
             account.contract_address, recipient, *amount])
+    # check return value equals true ('1')
+    assert res_bool.result.response == [1]
 
     execution_info = await erc20.balance_of(account.contract_address).call()
     assert execution_info.result.res == (
@@ -178,7 +184,9 @@ async def test_increase_allowance(erc20_factory):
     assert execution_info.result.res == amount
 
     # increase allowance
-    await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, *amount])
+    res_bool = await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, *amount])
+    # check return value equals true ('1')
+    assert res_bool.result.response == [1]
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
     assert execution_info.result.res == (
@@ -204,7 +212,9 @@ async def test_decrease_allowance(erc20_factory):
     assert execution_info.result.res == init_amount
 
     # decrease allowance
-    await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, *subtract_amount])
+    res_bool = await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, *subtract_amount])
+    # check return value equals true ('1')
+    assert res_bool.result.response == [1]
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
     assert execution_info.result.res == (

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -82,9 +82,7 @@ async def test_transfer(erc20_factory):
     assert execution_info.result.res == uint(0)
 
     # transfer
-    return_bool = await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, *amount])
-    # check return boolean
-    assert return_bool.result == (1,)
+    await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, *amount])
 
     execution_info = await erc20.balance_of(account.contract_address).call()
     assert execution_info.result.res == uint(900)
@@ -124,9 +122,7 @@ async def test_approve(erc20_factory):
     assert execution_info.result.res == uint(0)
 
     # set approval
-    return_bool = await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
-    # check return boolean
-    assert return_bool.result == (1,)
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
     assert execution_info.result.res == amount
@@ -149,11 +145,9 @@ async def test_transfer_from(erc20_factory):
     # approve
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *amount])
     # transfer_from
-    return_bool = await signer.send_transaction(
+    await signer.send_transaction(
         spender, erc20.contract_address, 'transfer_from', [
             account.contract_address, recipient, *amount])
-    # check return boolean
-    assert return_bool.result == (1,)
 
     execution_info = await erc20.balance_of(account.contract_address).call()
     assert execution_info.result.res == (
@@ -184,9 +178,7 @@ async def test_increase_allowance(erc20_factory):
     assert execution_info.result.res == amount
 
     # increase allowance
-    return_bool = await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, *amount])
-    # check return boolean
-    assert return_bool.result == (1,)
+    await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, *amount])
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
     assert execution_info.result.res == (
@@ -212,9 +204,7 @@ async def test_decrease_allowance(erc20_factory):
     assert execution_info.result.res == init_amount
 
     # decrease allowance
-    return_bool = await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, *subtract_amount])
-    # check return boolean
-    assert return_bool.result == (1,)
+    await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, *subtract_amount])
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
     assert execution_info.result.res == (

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -82,9 +82,9 @@ async def test_transfer(erc20_factory):
     assert execution_info.result.res == uint(0)
 
     # transfer
-    res_bool = await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, *amount])
+    return_bool = await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, *amount])
     # check return value equals true ('1')
-    assert res_bool.result.response == [1]
+    assert return_bool.result.response == [1]
 
     execution_info = await erc20.balance_of(account.contract_address).call()
     assert execution_info.result.res == uint(900)
@@ -124,9 +124,9 @@ async def test_approve(erc20_factory):
     assert execution_info.result.res == uint(0)
 
     # set approval
-    res_bool = await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
+    return_bool = await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
     # check return value equals true ('1')
-    assert res_bool.result.response == [1]
+    assert return_bool.result.response == [1]
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
     assert execution_info.result.res == amount
@@ -149,11 +149,11 @@ async def test_transfer_from(erc20_factory):
     # approve
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *amount])
     # transfer_from
-    res_bool = await signer.send_transaction(
+    return_bool = await signer.send_transaction(
         spender, erc20.contract_address, 'transfer_from', [
             account.contract_address, recipient, *amount])
     # check return value equals true ('1')
-    assert res_bool.result.response == [1]
+    assert return_bool.result.response == [1]
 
     execution_info = await erc20.balance_of(account.contract_address).call()
     assert execution_info.result.res == (
@@ -184,9 +184,9 @@ async def test_increase_allowance(erc20_factory):
     assert execution_info.result.res == amount
 
     # increase allowance
-    res_bool = await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, *amount])
+    return_bool = await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, *amount])
     # check return value equals true ('1')
-    assert res_bool.result.response == [1]
+    assert return_bool.result.response == [1]
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
     assert execution_info.result.res == (
@@ -212,9 +212,9 @@ async def test_decrease_allowance(erc20_factory):
     assert execution_info.result.res == init_amount
 
     # decrease allowance
-    res_bool = await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, *subtract_amount])
+    return_bool = await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, *subtract_amount])
     # check return value equals true ('1')
-    assert res_bool.result.response == [1]
+    assert return_bool.result.response == [1]
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
     assert execution_info.result.res == (

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -81,7 +81,10 @@ async def test_transfer(erc20_factory):
     execution_info = await erc20.balance_of(recipient).call()
     assert execution_info.result.res == uint(0)
 
-    await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, *amount])
+    # transfer
+    return_bool = await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, *amount])
+    # check return boolean
+    assert return_bool.result == (1,)
 
     execution_info = await erc20.balance_of(account.contract_address).call()
     assert execution_info.result.res == uint(900)
@@ -121,7 +124,9 @@ async def test_approve(erc20_factory):
     assert execution_info.result.res == uint(0)
 
     # set approval
-    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
+    return_bool = await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
+    # check return boolean
+    assert return_bool.result == (1,)
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
     assert execution_info.result.res == amount
@@ -141,9 +146,14 @@ async def test_transfer_from(erc20_factory):
     execution_info = await erc20.balance_of(account.contract_address).call()
     previous_balance = execution_info.result.res
 
+    # approve
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *amount])
-    await signer.send_transaction(spender, erc20.contract_address, 'transfer_from',
-                                  [account.contract_address, recipient, *amount])
+    # transfer_from
+    return_bool = await signer.send_transaction(
+        spender, erc20.contract_address, 'transfer_from', [
+            account.contract_address, recipient, *amount])
+    # check return boolean
+    assert return_bool.result == (1,)
 
     execution_info = await erc20.balance_of(account.contract_address).call()
     assert execution_info.result.res == (
@@ -174,7 +184,9 @@ async def test_increase_allowance(erc20_factory):
     assert execution_info.result.res == amount
 
     # increase allowance
-    await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, *amount])
+    return_bool = await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, *amount])
+    # check return boolean
+    assert return_bool.result == (1,)
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
     assert execution_info.result.res == (
@@ -200,7 +212,9 @@ async def test_decrease_allowance(erc20_factory):
     assert execution_info.result.res == init_amount
 
     # decrease allowance
-    await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, *subtract_amount])
+    return_bool = await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, *subtract_amount])
+    # check return boolean
+    assert return_bool.result == (1,)
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
     assert execution_info.result.res == (


### PR DESCRIPTION
# ERC20 Return Bools

## Summary

This PR resolves #76 and includes return booleans for ERC20 functions in an effort to be as compliant as possible with said standard. Cairo represents boolean values in binary; therefore, `return true` is expressed as:
```
tempvar is_success = 1
return(is_success)
```

_contracts/token/IERC20.cairo_ is updated with return booleans as well.

# Implementation

- The following `@external` functions now return a boolean value upon success:
    * `approve()`
    * `increase_allowance()`
    * `decrease_allowance()`
    * `transfer()`
    * `transfer_from()`
- Tests confirm these functions return `(1,)`
