### PR TITLE
Fix account's execute to return full response

### DIFF
--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -148,7 +148,7 @@ func execute{
         calldata_len: felt,
         calldata: felt*,
         nonce: felt
-    ) -> (response : felt):
+    ) -> (response_len: felt, response: felt*):
     alloc_locals
 
     let (__fp__, _) = get_fp_and_pc()
@@ -180,7 +180,7 @@ func execute{
         calldata=message.calldata
     )
 
-    return (response=response.retdata_size)
+    return (response_len=response.retdata_size, response=response.retdata)
 end
 
 func hash_message{pedersen_ptr : HashBuiltin*}(message: Message*) -> (res: felt):

--- a/contracts/IAccount.cairo
+++ b/contracts/IAccount.cairo
@@ -26,6 +26,6 @@ namespace IAccount:
             calldata_len: felt,
             calldata: felt*,
             nonce: felt
-        ) -> (response: felt):
+        ) -> (response_len: felt, response: felt*):
     end
 end

--- a/docs/Account.md
+++ b/docs/Account.md
@@ -76,7 +76,7 @@ namespace IAccount:
             calldata_len: felt,
             calldata: felt*,
             nonce: felt
-        ) -> (response: felt):
+        ) -> (response_len: felt, response: felt*):
     end
 end
 ```
@@ -256,7 +256,8 @@ signature: felt*
 
 ##### Returns:
 ```
-response: felt
+response_len: felt
+response: felt*
 ```
 
 ## Extending the Account contract

--- a/tests/test_Account.py
+++ b/tests/test_Account.py
@@ -52,13 +52,13 @@ async def test_return_value(account_factory):
     starknet, account = account_factory
     initializable = await starknet.deploy("contracts/Initializable.cairo")
 
-    execution_info = await initializable.initialized().call()
-    assert execution_info.result == (0,)
-
+    # initialize, set `initialized = 1`
     await signer.send_transaction(account, initializable.contract_address, 'initialize', [])
 
     read_info = await signer.send_transaction(account, initializable.contract_address, 'initialized', [])
-    assert [1] == read_info.result.response
+    call_info = await initializable.initialized().call()
+    (call_result, ) = call_info.result
+    assert read_info.result.response == [call_result]  # 1
 
 
 @ pytest.mark.asyncio

--- a/tests/test_Account.py
+++ b/tests/test_Account.py
@@ -48,6 +48,20 @@ async def test_execute(account_factory):
 
 
 @pytest.mark.asyncio
+async def test_return_value(account_factory):
+    starknet, account = account_factory
+    initializable = await starknet.deploy("contracts/Initializable.cairo")
+
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result == (0,)
+
+    await signer.send_transaction(account, initializable.contract_address, 'initialize', [])
+
+    read_info = await signer.send_transaction(account, initializable.contract_address, 'initialized', [])
+    assert [1] == read_info.result.response
+
+
+@ pytest.mark.asyncio
 async def test_nonce(account_factory):
     starknet, account = account_factory
     initializable = await starknet.deploy("contracts/Initializable.cairo")


### PR DESCRIPTION
Long overdue, fixing the `execute` method on Account so it returns response data, not only length. Unblocks https://github.com/OpenZeppelin/cairo-contracts/pull/78.