### PR TITLE
CamelCased ERC20 Functions and Updated Return Value Names

### DIFF
--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -149,10 +149,6 @@ func execute{
         calldata: felt*,
         nonce: felt
     ) -> (response_len: felt, response: felt*):
-<<<<<<< HEAD
-
-=======
->>>>>>> OpenZeppelin-main
     alloc_locals
 
     let (__fp__, _) = get_fp_and_pc()

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -25,7 +25,7 @@ func _decimals() -> (res: felt):
 end
 
 @storage_var
-func _total_supply() -> (res: Uint256):
+func total_supply() -> (res: Uint256):
 end
 
 @storage_var
@@ -68,9 +68,9 @@ func name{
         syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }() -> (res: felt):
-    let (res) = _name.read()
-    return (res)
+    }() -> (name: felt):
+    let (name) = _name.read()
+    return (name)
 end
 
 @view
@@ -78,19 +78,19 @@ func symbol{
         syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }() -> (res: felt):
-    let (res) = _symbol.read()
-    return (res)
+    }() -> (symbol: felt):
+    let (symbol) = _symbol.read()
+    return (symbol)
 end
 
 @view
-func total_supply{
+func totalSupply{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }() -> (res: Uint256):
-    let (res: Uint256) = _total_supply.read()
-    return (res)
+    }() -> (totalSupply: Uint256):
+    let (totalSupply: Uint256) = total_supply.read()
+    return (totalSupply)
 end
 
 @view
@@ -98,19 +98,19 @@ func decimals{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }() -> (res: felt):
-    let (res) = _decimals.read()
-    return (res)
+    }() -> (decimals: felt):
+    let (decimals) = _decimals.read()
+    return (decimals)
 end
 
 @view
-func balance_of{
+func balanceOf{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(account: felt) -> (res: Uint256):
-    let (res: Uint256) = balances.read(account=account)
-    return (res)
+    }(account: felt) -> (balance: Uint256):
+    let (balance: Uint256) = balances.read(account=account)
+    return (balance)
 end
 
 @view
@@ -118,9 +118,9 @@ func allowance{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(owner: felt, spender: felt) -> (res: Uint256):
-    let (res: Uint256) = allowances.read(owner=owner, spender=spender)
-    return (res)
+    }(owner: felt, spender: felt) -> (remaining: Uint256):
+    let (remaining: Uint256) = allowances.read(owner=owner, spender=spender)
+    return (remaining)
 end
 
 #
@@ -141,11 +141,11 @@ func _mint{
     let (new_balance, _: Uint256) = uint256_add(balance, amount)
     balances.write(recipient, new_balance)
 
-    let (local supply: Uint256) = _total_supply.read()
+    let (local supply: Uint256) = total_supply.read()
     let (local new_supply: Uint256, is_overflow) = uint256_add(supply, amount)
     assert (is_overflow) = 0
 
-    _total_supply.write(new_supply)
+    total_supply.write(new_supply)
     return ()
 end
 
@@ -203,9 +203,9 @@ func _burn{
     let (new_balance: Uint256) = uint256_sub(balance, amount)
     balances.write(account, new_balance)
 
-    let (supply: Uint256) = _total_supply.read()
+    let (supply: Uint256) = total_supply.read()
     let (new_supply: Uint256) = uint256_sub(supply, amount)
-    _total_supply.write(new_supply)
+    total_supply.write(new_supply)
     return ()
 end
 
@@ -227,7 +227,7 @@ func transfer{
 end
 
 @external
-func transfer_from{
+func transferFrom{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
@@ -268,7 +268,7 @@ func approve{
 end
 
 @external
-func increase_allowance{
+func increaseAllowance{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
@@ -288,7 +288,7 @@ func increase_allowance{
 end
 
 @external
-func decrease_allowance{
+func decreaseAllowance{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr

--- a/contracts/token/IERC20.cairo
+++ b/contracts/token/IERC20.cairo
@@ -4,28 +4,28 @@ from starkware.cairo.common.uint256 import Uint256
 
 @contract_interface
 namespace IERC20:
-    func name() -> (res: felt):
+    func name() -> (name: felt):
     end
 
-    func symbol() -> (res: felt):
+    func symbol() -> (symbol: felt):
     end
 
-    func decimals() -> (res: felt):
+    func decimals() -> (decimals: felt):
     end
 
-    func total_supply() -> (res: Uint256):
+    func totalSupply() -> (totalSupply: Uint256):
     end
 
-    func balance_of(account: felt) -> (res: Uint256):
+    func balanceOf(account: felt) -> (balance: Uint256):
     end
 
-    func allowance(owner: felt, spender: felt) -> (res: Uint256):
+    func allowance(owner: felt, spender: felt) -> (remaining: Uint256):
     end
 
     func transfer(recipient: felt, amount: Uint256) -> (success: felt):
     end
 
-    func transfer_from(
+    func transferFrom(
             sender: felt, 
             recipient: felt, 
             amount: Uint256
@@ -35,3 +35,4 @@ namespace IERC20:
     func approve(spender: felt, amount: Uint256) -> (success: felt):
     end
 end
+

--- a/docs/ERC20.md
+++ b/docs/ERC20.md
@@ -12,11 +12,11 @@ The ERC20 token standard is a specification for [fungible tokens](https://docs.o
   * [`name`](#-name-)
   * [`symbol`](#-symbol-)
   * [`decimals`](#-decimals-)
-  * [`total_supply`](#-total-supply-)
-  * [`balance_of`](#-balance-of-)
+  * [`totalSupply`](#-total-supply-)
+  * [`balanceOf`](#-balance-of-)
   * [`allowance`](#-allowance-)
   * [`transfer`](#-transfer-)
-  * [`transfer_from`](#-transfer-from-)
+  * [`transferFrom`](#-transfer-from-)
   * [`approve`](#-approve-)
 
 ## Interface
@@ -24,28 +24,28 @@ The ERC20 token standard is a specification for [fungible tokens](https://docs.o
 ```jsx
 @contract_interface
 namespace IERC20:
-    func name() -> (res: felt):
+    func name() -> (name: felt):
     end
 
-    func symbol() -> (res: felt):
+    func symbol() -> (symbol: felt):
     end
 
-    func decimals() -> (res: felt):
+    func decimals() -> (decimals: felt):
     end
 
-    func total_supply() -> (res: Uint256):
+    func totalSupply() -> (totalSupply: Uint256):
     end
 
-    func balance_of(account: felt) -> (res: Uint256):
+    func balanceOf(account: felt) -> (balance: Uint256):
     end
 
-    func allowance(owner: felt, spender: felt) -> (res: Uint256):
+    func allowance(owner: felt, spender: felt) -> (remaining: Uint256):
     end
 
     func transfer(recipient: felt, amount: Uint256) -> (success: felt):
     end
 
-    func transfer_from(
+    func transferFrom(
             sender: felt, 
             recipient: felt, 
             amount: Uint256
@@ -69,7 +69,7 @@ Although StarkNet is not EVM compatible, this implementation aims to be as close
 But some differences can still be found, such as:
 
 - `decimals` returns a 252-bit `felt`, meaning it can be much larger than the standard's 8-bit `uint8`. However, compliant implementations should not return a value that is not representable in `uint8`.
-- `transfer`, `transfer_from` and `approve` will never return anything different from true (`1`) because they will revert on any error
+- `transfer`, `transferFrom` and `approve` will never return anything different from true (`1`) because they will revert on any error
 - function selectors are calculated differently between [Cairo](https://github.com/starkware-libs/cairo-lang/blob/7712b21fc3b1cb02321a58d0c0579f5370147a8b/src/starkware/starknet/public/abi.py#L25) and [Solidity](https://solidity-by-example.org/function-selector/)
 
 ## Usage
@@ -129,28 +129,28 @@ For example, you could:
 ## API Specification
 
 ```jsx
-func name() -> (res: felt):
+func name() -> (name: felt):
 end
 
-func symbol() -> (res: felt):
+func symbol() -> (symbol: felt):
 end
 
-func decimals() -> (res: felt):
+func decimals() -> (decimals: felt):
 end
 
-func total_supply() -> (res: Uint256):
+func totalSupply() -> (totalSupply: Uint256):
 end
 
-func balance_of(account: felt) -> (res: Uint256):
+func balanceOf(account: felt) -> (balance: Uint256):
 end
 
-func allowance(owner: felt, spender: felt) -> (res: Uint256):
+func allowance(owner: felt, spender: felt) -> (remaining: Uint256):
 end
 
 func transfer(recipient: felt, amount: Uint256) -> (success: felt):
 end
 
-func transfer_from(
+func transferFrom(
         sender: felt, 
         recipient: felt, 
         amount: Uint256
@@ -197,7 +197,7 @@ Returns:
 decimals: felt
 ```
 
-### `total_supply`
+### `totalSupply`
 
 Returns the amount of tokens in existence.
 
@@ -206,10 +206,10 @@ Parameters: None.
 Returns:
 
 ```jsx
-total_supply: Uint256
+totalSupply: Uint256
 ```
 
-### `balance_of`
+### `balanceOf`
 
 Returns the amount of tokens owned by `account`.
 
@@ -222,14 +222,14 @@ account: felt
 Returns:
 
 ```jsx
-res: Uint256
+balance: Uint256
 ```
 
 ### `allowance`
 
-Returns the remaining number of tokens that `spender` will be allowed to spend on behalf of `owner` through `transfer_from`. This is zero by default.
+Returns the remaining number of tokens that `spender` will be allowed to spend on behalf of `owner` through `transferFrom`. This is zero by default.
 
-This value changes when `approve` or `transfer_from` are called.
+This value changes when `approve` or `transferFrom` are called.
 
 Parameters:
 
@@ -241,7 +241,7 @@ spender: felt
 Returns:
 
 ```jsx
-res: Uint256
+remaining: Uint256
 ```
 
 ### `transfer`
@@ -261,7 +261,7 @@ Returns:
 success: felt
 ```
 
-### `transfer_from`
+### `transferFrom`
 
 Moves `amount` tokens from `sender` to `recipient` using the allowance mechanism. `amount` is then deducted from the caller’s allowance. It returns `1` representing a bool if it succeeds.
 

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -46,11 +46,11 @@ async def erc20_factory():
 @pytest.mark.asyncio
 async def test_constructor(erc20_factory):
     _, erc20, account = erc20_factory
-    execution_info = await erc20.balance_of(account.contract_address).call()
-    assert execution_info.result.res == uint(1000)
+    execution_info = await erc20.balanceOf(account.contract_address).call()
+    assert execution_info.result.balance == uint(1000)
 
-    execution_info = await erc20.total_supply().call()
-    assert execution_info.result.res == uint(1000)
+    execution_info = await erc20.totalSupply().call()
+    assert execution_info.result.totalSupply == uint(1000)
 
 
 @pytest.mark.asyncio
@@ -72,36 +72,36 @@ async def test_transfer(erc20_factory):
     _, erc20, account = erc20_factory
     recipient = 123
     amount = uint(100)
-    execution_info = await erc20.total_supply().call()
-    previous_supply = execution_info.result.res
+    execution_info = await erc20.totalSupply().call()
+    previous_supply = execution_info.result.totalSupply
 
-    execution_info = await erc20.balance_of(account.contract_address).call()
-    assert execution_info.result.res == uint(1000)
+    execution_info = await erc20.balanceOf(account.contract_address).call()
+    assert execution_info.result.balance == uint(1000)
 
-    execution_info = await erc20.balance_of(recipient).call()
-    assert execution_info.result.res == uint(0)
+    execution_info = await erc20.balanceOf(recipient).call()
+    assert execution_info.result.balance == uint(0)
 
     # transfer
     return_bool = await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, *amount])
     # check return value equals true ('1')
     assert return_bool.result.response == [1]
 
-    execution_info = await erc20.balance_of(account.contract_address).call()
-    assert execution_info.result.res == uint(900)
+    execution_info = await erc20.balanceOf(account.contract_address).call()
+    assert execution_info.result.balance == uint(900)
 
-    execution_info = await erc20.balance_of(recipient).call()
-    assert execution_info.result.res == uint(100)
+    execution_info = await erc20.balanceOf(recipient).call()
+    assert execution_info.result.balance == uint(100)
 
-    execution_info = await erc20.total_supply().call()
-    assert execution_info.result.res == previous_supply
+    execution_info = await erc20.totalSupply().call()
+    assert execution_info.result.totalSupply == previous_supply
 
 
 @pytest.mark.asyncio
 async def test_insufficient_sender_funds(erc20_factory):
     _, erc20, account = erc20_factory
     recipient = 123
-    execution_info = await erc20.balance_of(account.contract_address).call()
-    balance = execution_info.result.res
+    execution_info = await erc20.balanceOf(account.contract_address).call()
+    balance = execution_info.result.balance
 
     try:
         await signer.send_transaction(account, erc20.contract_address, 'transfer', [
@@ -121,7 +121,7 @@ async def test_approve(erc20_factory):
     amount = uint(345)
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result.res == uint(0)
+    assert execution_info.result.remaining == uint(0)
 
     # set approval
     return_bool = await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
@@ -129,11 +129,11 @@ async def test_approve(erc20_factory):
     assert return_bool.result.response == [1]
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result.res == amount
+    assert execution_info.result.remaining == amount
 
 
 @pytest.mark.asyncio
-async def test_transfer_from(erc20_factory):
+async def test_transferFrom(erc20_factory):
     starknet, erc20, account = erc20_factory
     spender = await starknet.deploy(
         "contracts/Account.cairo",
@@ -143,59 +143,59 @@ async def test_transfer_from(erc20_factory):
     # this is ok since they're still two different accounts
     amount = uint(345)
     recipient = 987
-    execution_info = await erc20.balance_of(account.contract_address).call()
-    previous_balance = execution_info.result.res
+    execution_info = await erc20.balanceOf(account.contract_address).call()
+    previous_balance = execution_info.result.balance
 
     # approve
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *amount])
-    # transfer_from
+    # transferFrom
     return_bool = await signer.send_transaction(
-        spender, erc20.contract_address, 'transfer_from', [
+        spender, erc20.contract_address, 'transferFrom', [
             account.contract_address, recipient, *amount])
     # check return value equals true ('1')
     assert return_bool.result.response == [1]
 
-    execution_info = await erc20.balance_of(account.contract_address).call()
-    assert execution_info.result.res == (
+    execution_info = await erc20.balanceOf(account.contract_address).call()
+    assert execution_info.result.balance == (
         uint(previous_balance[0] - amount[0])
     )
 
-    execution_info = await erc20.balance_of(recipient).call()
-    assert execution_info.result.res == amount
+    execution_info = await erc20.balanceOf(recipient).call()
+    assert execution_info.result.balance == amount
 
     execution_info = await erc20.allowance(account.contract_address, spender.contract_address).call()
-    assert execution_info.result.res == uint(0)
+    assert execution_info.result.remaining == uint(0)
 
 
 @pytest.mark.asyncio
-async def test_increase_allowance(erc20_factory):
+async def test_increaseAllowance(erc20_factory):
     _, erc20, account = erc20_factory
     # new spender, starting from zero
     spender = 234
     amount = uint(345)
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result.res == uint(0)
+    assert execution_info.result.remaining == uint(0)
 
     # set approve
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result.res == amount
+    assert execution_info.result.remaining == amount
 
     # increase allowance
-    return_bool = await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, *amount])
+    return_bool = await signer.send_transaction(account, erc20.contract_address, 'increaseAllowance', [spender, *amount])
     # check return value equals true ('1')
     assert return_bool.result.response == [1]
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result.res == (
+    assert execution_info.result.remaining == (
         uint(amount[0] * 2)
     )
 
 
 @pytest.mark.asyncio
-async def test_decrease_allowance(erc20_factory):
+async def test_decreaseAllowance(erc20_factory):
     _, erc20, account = erc20_factory
     # new spender, starting from zero
     spender = 321
@@ -203,27 +203,27 @@ async def test_decrease_allowance(erc20_factory):
     subtract_amount = uint(100)
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result.res == uint(0)
+    assert execution_info.result.remaining == uint(0)
 
     # set approve
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *init_amount])
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result.res == init_amount
+    assert execution_info.result.remaining == init_amount
 
     # decrease allowance
-    return_bool = await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, *subtract_amount])
+    return_bool = await signer.send_transaction(account, erc20.contract_address, 'decreaseAllowance', [spender, *subtract_amount])
     # check return value equals true ('1')
     assert return_bool.result.response == [1]
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result.res == (
+    assert execution_info.result.remaining == (
         uint(init_amount[0] - subtract_amount[0])
     )
 
 
 @pytest.mark.asyncio
-async def test_decrease_allowance_underflow(erc20_factory):
+async def test_decreaseAllowance_underflow(erc20_factory):
     _, erc20, account = erc20_factory
     # new spender, starting from zero
     spender = 987
@@ -231,11 +231,11 @@ async def test_decrease_allowance_underflow(erc20_factory):
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *init_amount])
 
     execution_info = await erc20.allowance(account.contract_address, spender).call()
-    assert execution_info.result.res == init_amount
+    assert execution_info.result.remaining == init_amount
 
     try:
         # increasing the decreased allowance amount by more than the user's allowance
-        await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [
+        await signer.send_transaction(account, erc20.contract_address, 'decreaseAllowance', [
             spender,
             *uint(init_amount[0] + 1)
         ])
@@ -260,7 +260,7 @@ async def test_transfer_funds_greater_than_allowance(erc20_factory):
 
     try:
         # increasing the transfer amount above allowance
-        await signer.send_transaction(spender, erc20.contract_address, 'transfer_from', [
+        await signer.send_transaction(spender, erc20.contract_address, 'transferFrom', [
             account.contract_address,
             recipient,
             *uint(allowance[0] + 1)
@@ -272,7 +272,7 @@ async def test_transfer_funds_greater_than_allowance(erc20_factory):
 
 
 @pytest.mark.asyncio
-async def test_increase_allowance_overflow(erc20_factory):
+async def test_increaseAllowance_overflow(erc20_factory):
     _, erc20, account = erc20_factory
     # new spender, starting from zero
     spender = 234
@@ -283,7 +283,7 @@ async def test_increase_allowance_overflow(erc20_factory):
 
     try:
         # overflow check will revert the transaction
-        await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, *overflow_amount])
+        await signer.send_transaction(account, erc20.contract_address, 'increaseAllowance', [spender, *overflow_amount])
         assert False
     except StarkException as err:
         _, error = err.args
@@ -305,7 +305,7 @@ async def test_transfer_to_zero_address(erc20_factory):
 
 
 @pytest.mark.asyncio
-async def test_transfer_from_zero_address(erc20_factory):
+async def test_transferFrom_zero_address(erc20_factory):
     _, erc20, _ = erc20_factory
     recipient = 123
     amount = uint(1)
@@ -321,7 +321,7 @@ async def test_transfer_from_zero_address(erc20_factory):
 
 
 @pytest.mark.asyncio
-async def test_transfer_from_func_to_zero_address(erc20_factory):
+async def test_transferFrom_func_to_zero_address(erc20_factory):
     starknet, erc20, account = erc20_factory
     spender = await starknet.deploy(
         "contracts/Account.cairo",
@@ -336,7 +336,7 @@ async def test_transfer_from_func_to_zero_address(erc20_factory):
 
     try:
         await signer.send_transaction(
-            spender, erc20.contract_address, 'transfer_from',
+            spender, erc20.contract_address, 'transferFrom',
             [
                 account.contract_address,
                 zero_address,
@@ -349,7 +349,7 @@ async def test_transfer_from_func_to_zero_address(erc20_factory):
 
 
 @pytest.mark.asyncio
-async def test_transfer_from_func_from_zero_address(erc20_factory):
+async def test_transferFrom_func_from_zero_address(erc20_factory):
     starknet, erc20, account = erc20_factory
     spender = await starknet.deploy(
         "contracts/Account.cairo",
@@ -363,7 +363,7 @@ async def test_transfer_from_func_from_zero_address(erc20_factory):
 
     try:
         await signer.send_transaction(
-            spender, erc20.contract_address, 'transfer_from',
+            spender, erc20.contract_address, 'transferFrom',
             [
                 zero_address,
                 recipient,
@@ -423,10 +423,10 @@ async def test_mint_to_zero_address(erc20_factory):
 async def test_mint_overflow(erc20_factory):
     _, erc20, account = erc20_factory
     recipient = 789
-    # fetching the previously minted total_supply and verifying the overflow check
-    # (total_supply >= 2**256) should fail, (total_supply < 2**256) should pass
-    execution_info = await erc20.total_supply().call()
-    previous_supply = execution_info.result.res
+    # fetching the previously minted totalSupply and verifying the overflow check
+    # (totalSupply >= 2**256) should fail, (totalSupply < 2**256) should pass
+    execution_info = await erc20.totalSupply().call()
+    previous_supply = execution_info.result.totalSupply
 
     # pass_amount subtracts the already minted supply from MAX_AMOUNT in order for
     # the minted supply to equal MAX_AMOUNT
@@ -459,24 +459,24 @@ async def test_burn(erc20_factory):
     _, erc20, account = erc20_factory
     user = 789
     burn_amount = uint(500)
-    execution_info = await erc20.total_supply().call()
-    previous_supply = execution_info.result.res
+    execution_info = await erc20.totalSupply().call()
+    previous_supply = execution_info.result.totalSupply
 
-    execution_info = await erc20.balance_of(user).call()
-    previous_balance = execution_info.result.res
+    execution_info = await erc20.balanceOf(user).call()
+    previous_balance = execution_info.result.balance
 
     await signer.send_transaction(account, erc20.contract_address, 'burn', [user, *burn_amount])
 
     # total supply should reflect the burned amount
-    execution_info = await erc20.total_supply().call()
-    assert execution_info.result.res == (
+    execution_info = await erc20.totalSupply().call()
+    assert execution_info.result.totalSupply == (
         previous_supply[0] - burn_amount[0],
         previous_supply[1] - burn_amount[1]
     )
 
     # user balance should reflect the burned amount
-    execution_info = await erc20.balance_of(user).call()
-    assert execution_info.result.res == (
+    execution_info = await erc20.balanceOf(user).call()
+    assert execution_info.result.balance == (
         previous_balance[0] - burn_amount[0],
         previous_balance[1] - burn_amount[1]
     )
@@ -500,8 +500,8 @@ async def test_burn_zero_address(erc20_factory):
 async def test_burn_overflow(erc20_factory):
     _, erc20, account = erc20_factory
     user = 789
-    execution_info = await erc20.balance_of(user).call()
-    previous_balance = execution_info.result.res
+    execution_info = await erc20.balanceOf(user).call()
+    previous_balance = execution_info.result.balance
     # increasing the burn amount to more than the user's balance
     # should make the tx fail
     burn_amount = (previous_balance[0] + 1, previous_balance[1])


### PR DESCRIPTION
# CamelCased ERC20 Functions and Updated Return Value Names

## Summary 

This PR updates the nomenclature of the ERC20 functions to `camelCase`. Further, function return value names have also been changed from `res` to something more relevant and specific. _IERC20.cairo_, _test_ERC20.py_, and _ERC20.md_ also reflect the proposed changes. This PR resolves #86 .

## Future

Perhaps, we should reorganize the ERC20 Cairo contract to match [OZ's solidity implementation](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol); where, the external functions immediately proceed the getters and the internal functions are last. Not a pressing issue, just seems more appropriate.
