### PR TITLE
Account nonce lockout problem

### DIFF
--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -164,13 +164,15 @@ func execute{
         _current_nonce
     )
 
+    # bump nonce before signature validation
+    # prevents StarkNet from locking you out of your transaction
+    # see: https://www.cairo-lang.org/docs/hello_starknet/user_auth.html#what-if-we-have-an-invalid-signature
+    current_nonce.write(_current_nonce + 1)
+
     # validate transaction
     let (hash) = hash_message(&message)
     let (signature_len, signature) = get_tx_signature()
     is_valid_signature(hash, signature_len, signature)
-
-    # bump nonce
-    current_nonce.write(_current_nonce + 1)
 
     # execute call
     let response = call_contract(


### PR DESCRIPTION
WARNING: this PR should not be merged as it doesn't fix the core problem

Problem: Buggy signing code or a malicious actor can prevent an Account contract from being used by submitting a StarkNet transaction that fails due to invalid signature. Because StarkNet Alpha v4 does not allow resubmitting/updating a previously submitted transaction hash, a failed signature contract calls can guarantee future failures, even for properly signed calls

Solution: In this PR I reorder when the account nonce gets incremented in order to optimistically increment the nonce to prevent lockout. Edit: This won't actually fix the problem because the nonce will not get updated if the transaction is rejected. The real solution to this problem should be to allow rejected transactions to be processed multiple times on StarkNet or allow for nonces > current_nonce 