### PR TITLE
`assert_revert` Fix

### DIFF
--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -91,10 +91,12 @@ async def test_insufficient_sender_funds(erc20_factory):
     execution_info = await erc20.balanceOf(account.contract_address).call()
     balance = execution_info.result.balance
 
-    assert_revert(lambda: signer.send_transaction(account, erc20.contract_address, 'transfer', [
-        recipient,
-        *uint(balance[0] + 1)
-    ]))
+    await assert_revert(signer.send_transaction(
+        account, erc20.contract_address, 'transfer', [
+            recipient,
+            *uint(balance[0] + 1)
+        ]
+    ))
 
 
 @pytest.mark.asyncio
@@ -217,10 +219,12 @@ async def test_decreaseAllowance_underflow(erc20_factory):
     assert execution_info.result.remaining == init_amount
 
     # increasing the decreased allowance amount by more than the user's allowance
-    assert_revert(lambda: signer.send_transaction(account, erc20.contract_address, 'decreaseAllowance', [
-        spender,
-        *uint(init_amount[0] + 1)
-    ]))
+    await assert_revert(signer.send_transaction(
+        account, erc20.contract_address, 'decreaseAllowance', [
+            spender,
+            *uint(init_amount[0] + 1)
+        ]
+    ))
 
 
 @pytest.mark.asyncio
@@ -237,11 +241,13 @@ async def test_transfer_funds_greater_than_allowance(erc20_factory):
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *allowance])
 
     # increasing the transfer amount above allowance
-    assert_revert(lambda: signer.send_transaction(spender, erc20.contract_address, 'transferFrom', [
-        account.contract_address,
-        recipient,
-        *uint(allowance[0] + 1)
-    ]))
+    await assert_revert(signer.send_transaction(
+        spender, erc20.contract_address, 'transferFrom', [
+            account.contract_address,
+            recipient,
+            *uint(allowance[0] + 1)
+        ]
+    ))
 
 
 @pytest.mark.asyncio
@@ -254,8 +260,11 @@ async def test_increaseAllowance_overflow(erc20_factory):
     overflow_amount = uint(1)
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
 
-    assert_revert(lambda: signer.send_transaction(
-        account, erc20.contract_address, 'increaseAllowance', [spender, *overflow_amount]))
+    await assert_revert(signer.send_transaction(
+        account, erc20.contract_address, 'increaseAllowance', [
+            spender, *overflow_amount
+        ]
+    ))
 
 
 @pytest.mark.asyncio
@@ -264,8 +273,11 @@ async def test_transfer_to_zero_address(erc20_factory):
     recipient = 0
     amount = uint(1)
 
-    assert_revert(lambda: signer.send_transaction(
-        account, erc20.contract_address, 'transfer', [recipient, *amount]))
+    await assert_revert(signer.send_transaction(
+        account, erc20.contract_address, 'transfer', [
+            recipient, *amount
+        ]
+    ))
 
 
 @pytest.mark.asyncio
@@ -276,7 +288,7 @@ async def test_transferFrom_zero_address(erc20_factory):
 
     # Without using an account abstraction, the caller address
     # (get_caller_address) is zero
-    assert_revert(lambda: erc20.transfer(recipient, amount).invoke())
+    await assert_revert(erc20.transfer(recipient, amount).invoke())
 
 
 @pytest.mark.asyncio
@@ -293,13 +305,13 @@ async def test_transferFrom_func_to_zero_address(erc20_factory):
 
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *amount])
 
-    assert_revert(lambda: signer.send_transaction(
-        spender, erc20.contract_address, 'transferFrom',
-        [
+    await assert_revert(signer.send_transaction(
+        spender, erc20.contract_address, 'transferFrom', [
             account.contract_address,
             zero_address,
             *amount
-        ]))
+        ]
+    ))
 
 
 @pytest.mark.asyncio
@@ -315,13 +327,13 @@ async def test_transferFrom_func_from_zero_address(erc20_factory):
     recipient = 123
     amount = uint(1)
 
-    assert_revert(lambda: signer.send_transaction(
-        spender, erc20.contract_address, 'transferFrom',
-        [
+    await assert_revert(signer.send_transaction(
+        spender, erc20.contract_address, 'transferFrom', [
             zero_address,
             recipient,
             *amount
-        ]))
+        ]
+    ))
 
 
 @pytest.mark.asyncio
@@ -329,8 +341,12 @@ async def test_approve_zero_address_spender(erc20_factory):
     _, erc20, account = erc20_factory
     spender = 0
     amount = uint(1)
-    assert_revert(lambda: signer.send_transaction(
-        account, erc20.contract_address, 'approve', [spender, *amount]))
+    await assert_revert(signer.send_transaction(
+        account, erc20.contract_address, 'approve', [
+            spender,
+            *amount
+        ]
+    ))
 
 
 @pytest.mark.asyncio
@@ -341,4 +357,4 @@ async def test_approve_zero_address_caller(erc20_factory):
 
     # Without using an account abstraction, the caller address
     # (get_caller_address) is zero
-    assert_revert(lambda: erc20.approve(spender, amount).invoke())
+    await assert_revert(erc20.approve(spender, amount).invoke())

--- a/tests/test_ERC20_Mintable.py
+++ b/tests/test_ERC20_Mintable.py
@@ -67,7 +67,7 @@ async def test_mint_to_zero_address(token_factory):
     zero_address = 0
     amount = uint(1)
 
-    assert_revert(lambda: signer.send_transaction(
+    await assert_revert(signer.send_transaction(
         account,
         erc20.contract_address,
         'mint',
@@ -101,7 +101,7 @@ async def test_mint_overflow(token_factory):
         pass_amount[1]       # 2**128 - 1
     )
 
-    assert_revert(lambda: signer.send_transaction(
+    await assert_revert(signer.send_transaction(
         account,
         erc20.contract_address,
         'mint',

--- a/tests/test_ERC20_Pausable.py
+++ b/tests/test_ERC20_Pausable.py
@@ -66,35 +66,35 @@ async def test_pause(token_factory):
     execution_info = await token.paused().call()
     assert execution_info.result.paused == 1
 
-    assert_revert(lambda: signer.send_transaction(
+    await assert_revert(signer.send_transaction(
         owner,
         token.contract_address,
         'transfer',
         [other.contract_address, *amount]
     ))
 
-    assert_revert(lambda: signer.send_transaction(
+    await assert_revert(signer.send_transaction(
         owner,
         token.contract_address,
         'transferFrom',
         [other.contract_address, other.contract_address, *amount]
     ))
 
-    assert_revert(lambda: signer.send_transaction(
+    await assert_revert(signer.send_transaction(
         owner,
         token.contract_address,
         'approve',
         [other.contract_address, *amount]
     ))
 
-    assert_revert(lambda: signer.send_transaction(
+    await assert_revert(signer.send_transaction(
         owner,
         token.contract_address,
         'increaseAllowance',
         [other.contract_address, *amount]
     ))
 
-    assert_revert(lambda: signer.send_transaction(
+    await assert_revert(signer.send_transaction(
         owner,
         token.contract_address,
         'decreaseAllowance',
@@ -156,8 +156,8 @@ async def test_unpause(token_factory):
 async def test_only_owner(token_factory):
     _, token, _, other = token_factory
 
-    assert_revert(lambda: signer.send_transaction(
+    await assert_revert(signer.send_transaction(
         other, token.contract_address, 'pause', []))
 
-    assert_revert(lambda: signer.send_transaction(
+    assert assert_revert(signer.send_transaction(
         other, token.contract_address, 'unpause', []))


### PR DESCRIPTION
# `assert_revert` Fix

## Summary

This PR includes a fix for the utils function `assert_revert`. The structure of the function creates a perpetually failing transaction. This is difficult to find because each test case that uses this function expects the transaction in question to fail. This PR refactors all `assert_revert` instances. To further test this claim, simply wrap a transaction that should pass with the original `assert_revert` implementation. 

## Implementation
Here's the fix:

```
# ORIGINAL
assert_revert(lambda: contract.foo().bar())

# FIXED
await assert_revert(contract.foo().bar())
```