### PR TITLE
Removed Underscore from Importable `name` and `symbol`

### DIFF
--- a/contracts/token/ERC721.cairo
+++ b/contracts/token/ERC721.cairo
@@ -5,8 +5,8 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.cairo.common.uint256 import Uint256 
 
 from contracts.token.ERC721_base import (
-    ERC721_name_,
-    ERC721_symbol_,
+    ERC721_name,
+    ERC721_symbol,
     ERC721_balanceOf,
     ERC721_ownerOf,
     ERC721_getApproved,
@@ -57,7 +57,7 @@ func name{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }() -> (name: felt):
-    let (name) = ERC721_name_()
+    let (name) = ERC721_name()
     return (name)
 end
 
@@ -67,7 +67,7 @@ func symbol{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }() -> (symbol: felt):
-    let (symbol) = ERC721_symbol_()
+    let (symbol) = ERC721_symbol()
     return (symbol)
 end
 

--- a/contracts/token/ERC721_Mintable.cairo
+++ b/contracts/token/ERC721_Mintable.cairo
@@ -5,8 +5,8 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.cairo.common.uint256 import Uint256
 
 from contracts.token.ERC721_base import (
-    ERC721_name_,
-    ERC721_symbol_,
+    ERC721_name,
+    ERC721_symbol,
     ERC721_balanceOf,
     ERC721_ownerOf,
     ERC721_getApproved,
@@ -69,7 +69,7 @@ func name{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }() -> (name: felt):
-    let (name) = ERC721_name_()
+    let (name) = ERC721_name()
     return (name)
 end
 
@@ -79,7 +79,7 @@ func symbol{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }() -> (symbol: felt):
-    let (symbol) = ERC721_symbol_()
+    let (symbol) = ERC721_symbol()
     return (symbol)
 end
 

--- a/contracts/token/ERC721_Pausable.cairo
+++ b/contracts/token/ERC721_Pausable.cairo
@@ -5,8 +5,8 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.cairo.common.uint256 import Uint256
 
 from contracts.token.ERC721_base import (
-    ERC721_name_,
-    ERC721_symbol_,
+    ERC721_name,
+    ERC721_symbol,
     ERC721_balanceOf,
     ERC721_ownerOf,
     ERC721_getApproved,
@@ -75,7 +75,7 @@ func name{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }() -> (name: felt):
-    let (name) = ERC721_name_()
+    let (name) = ERC721_name()
     return (name)
 end
 
@@ -85,7 +85,7 @@ func symbol{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }() -> (symbol: felt):
-    let (symbol) = ERC721_symbol_()
+    let (symbol) = ERC721_symbol()
     return (symbol)
 end
 

--- a/contracts/token/ERC721_base.cairo
+++ b/contracts/token/ERC721_base.cairo
@@ -18,11 +18,11 @@ from contracts.token.IERC721_Receiver import IERC721_Receiver
 #
 
 @storage_var
-func ERC721_name() -> (name: felt):
+func ERC721_name_() -> (name: felt):
 end
 
 @storage_var
-func ERC721_symbol() -> (symbol: felt):
+func ERC721_symbol_() -> (symbol: felt):
 end
 
 @storage_var
@@ -53,8 +53,8 @@ func ERC721_initializer{
         name: felt,
         symbol: felt,
     ):
-    ERC721_name.write(name)
-    ERC721_symbol.write(symbol)
+    ERC721_name_.write(name)
+    ERC721_symbol_.write(symbol)
     # register IERC721
     ERC165_register_interface('0x80ac58cd')
     return ()
@@ -64,21 +64,21 @@ end
 # Getters
 #
 
-func ERC721_name_{
+func ERC721_name{
         syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }() -> (name: felt):
-    let (name) = ERC721_name.read()
+    let (name) = ERC721_name_.read()
     return (name)
 end
 
-func ERC721_symbol_{
+func ERC721_symbol{
         syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }() -> (symbol: felt):
-    let (symbol) = ERC721_symbol.read()
+    let (symbol) = ERC721_symbol_.read()
     return (symbol)
 end
 


### PR DESCRIPTION
Removed the last underscore in `ERC721_name_` and `ERC721_symbol_`