### PR TITLE
Fix `safeTransferFrom` logic, add `is_account`

### DIFF
--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -35,6 +35,10 @@ end
 func public_key() -> (res: felt):
 end
 
+@storage_var
+func _is_account() -> (res: felt):
+end
+
 #
 # Guards
 #
@@ -75,6 +79,16 @@ func get_nonce{
     return (res=res)
 end
 
+@view
+func is_account{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (res: felt):
+    let (res) = _is_account.read()
+    return (res)
+end
+
 #
 # Setters
 #
@@ -101,6 +115,7 @@ func constructor{
         range_check_ptr
     }(_public_key: felt):
     public_key.write(_public_key)
+    _is_account.write(1)
     return()
 end
 

--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -35,10 +35,6 @@ end
 func public_key() -> (res: felt):
 end
 
-@storage_var
-func _is_account() -> (res: felt):
-end
-
 #
 # Guards
 #
@@ -85,8 +81,7 @@ func is_account{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }() -> (res: felt):
-    let (res) = _is_account.read()
-    return (res)
+    return (1)
 end
 
 #
@@ -115,7 +110,6 @@ func constructor{
         range_check_ptr
     }(_public_key: felt):
     public_key.write(_public_key)
-    _is_account.write(1)
     return()
 end
 

--- a/contracts/IAccount.cairo
+++ b/contracts/IAccount.cairo
@@ -9,6 +9,9 @@ namespace IAccount:
     func get_nonce() -> (res : felt):
     end
 
+    func is_account() -> (res: felt):
+    end
+
     #
     # Business logic
     #

--- a/contracts/token/ERC721_base.cairo
+++ b/contracts/token/ERC721_base.cairo
@@ -14,6 +14,8 @@ from contracts.ERC165_base import (
 
 from contracts.token.IERC721_Receiver import IERC721_Receiver
 
+from contracts.IAccount import IAccount
+
 #
 # Storage
 #
@@ -382,9 +384,12 @@ func _check_onERC721Received{
         data_len: felt, 
         data: felt*
     ) -> (success: felt):
-    # We need to consider how to differentiate between EOA and contracts
-    # and insert a conditional to know when to use the proceeding check
     let (caller) = get_caller_address()
+    let (is_account) = IAccount.is_account(to)
+    if is_account == 1:
+        return (1)
+    end
+
     # The first parameter in an imported interface is the contract
     # address of the interface being called
     let (selector) = IERC721_Receiver.onERC721Received(

--- a/contracts/token/IERC721_Receiver.cairo
+++ b/contracts/token/IERC721_Receiver.cairo
@@ -12,4 +12,8 @@ namespace IERC721_Receiver:
         data: felt*
     ) -> (selector: felt): 
     end
+
+    # tmp method
+    func is_account() -> (res: felt):
+    end
 end

--- a/contracts/token/IERC721_Receiver.cairo
+++ b/contracts/token/IERC721_Receiver.cairo
@@ -18,7 +18,7 @@ namespace IERC721_Receiver:
     # non-account contracts. Currently, StarkNet does not support error handling from the
     # contract level; therefore, this ERC721 implementation requires that all contracts that
     # support safe ERC721 transfers (both accounts and non-accounts) include the `is_account` 
-    # method. This method should return `0` here since it's NOT an account.
+    # method. This method should return `0` since it's NOT an account.
     func is_account() -> (res: felt):
     end
 end

--- a/contracts/token/IERC721_Receiver.cairo
+++ b/contracts/token/IERC721_Receiver.cairo
@@ -13,7 +13,12 @@ namespace IERC721_Receiver:
     ) -> (selector: felt): 
     end
 
-    # tmp method
+
+    # ERC721's `safeTransferFrom` requires a means of differentiating between account and
+    # non-account contracts. Currently, StarkNet does not support error handling from the
+    # contract level; therefore, this ERC721 implementation requires that all contracts that
+    # support safe ERC721 transfers (both accounts and non-accounts) include the `is_account` 
+    # method. This method should return `0` here since it's NOT an account.
     func is_account() -> (res: felt):
     end
 end

--- a/contracts/token/utils/ERC721_Holder.cairo
+++ b/contracts/token/utils/ERC721_Holder.cairo
@@ -19,3 +19,13 @@ func onERC721Received{
     # ERC721_RECEIVER_ID
     return ('0x150b7a02')
 end
+
+#tmp method
+@view
+func is_account{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*, 
+        range_check_ptr
+    }() -> (res: felt):
+    return (0)
+end

--- a/contracts/token/utils/ERC721_Holder.cairo
+++ b/contracts/token/utils/ERC721_Holder.cairo
@@ -20,7 +20,11 @@ func onERC721Received{
     return ('0x150b7a02')
 end
 
-#tmp method
+# ERC721's `safeTransferFrom` requires a means of differentiating between account and
+# non-account contracts. Currently, StarkNet does not support error handling from the
+# contract level; therefore, this ERC721 implementation requires that all contracts that
+# support safe ERC721 transfers (both accounts and non-accounts) include the `is_account` 
+# method. This method should return `0` since this contract is NOT an account.
 @view
 func is_account{
         syscall_ptr : felt*, 

--- a/tests/test_Account.py
+++ b/tests/test_Account.py
@@ -106,7 +106,16 @@ async def test_public_key_setter(account_factory):
 
 @pytest.mark.asyncio
 async def test_is_account(account_factory):
-    _, account = account_factory
+    starknet, account = account_factory
 
+    # account contract
     execution_info = await account.is_account().call()
     assert execution_info.result == (1,)
+
+    other = await starknet.deploy(
+        "contracts/token/utils/ERC721_Holder.cairo"
+    )
+
+    # non-account contract
+    execution_info = await other.is_account().call()
+    assert execution_info.result == (0,)

--- a/tests/test_Account.py
+++ b/tests/test_Account.py
@@ -102,3 +102,11 @@ async def test_public_key_setter(account_factory):
 
     execution_info = await account.get_public_key().call()
     assert execution_info.result == (other.public_key,)
+
+
+@pytest.mark.asyncio
+async def test_is_account(account_factory):
+    _, account = account_factory
+
+    execution_info = await account.is_account().call()
+    assert execution_info.result == (1,)

--- a/tests/test_Account.py
+++ b/tests/test_Account.py
@@ -106,16 +106,8 @@ async def test_public_key_setter(account_factory):
 
 @pytest.mark.asyncio
 async def test_is_account(account_factory):
-    starknet, account = account_factory
+    _, account = account_factory
 
     # account contract
     execution_info = await account.is_account().call()
     assert execution_info.result == (1,)
-
-    other = await starknet.deploy(
-        "contracts/token/utils/ERC721_Holder.cairo"
-    )
-
-    # non-account contract
-    execution_info = await other.is_account().call()
-    assert execution_info.result == (0,)

--- a/tests/test_ERC721_Mintable.py
+++ b/tests/test_ERC721_Mintable.py
@@ -763,6 +763,33 @@ async def test_safeTransferFrom_to_unsupported_contract(erc721_factory):
         assert error['code'] == StarknetErrorCode.ENTRY_POINT_NOT_FOUND_IN_CONTRACT
 
 
+@pytest.mark.asyncio
+async def test_safeTransferFrom_to_eoa(erc721_factory):
+    starknet, erc721, account, _ = erc721_factory
+
+    account2 = await starknet.deploy(
+        "contracts/Account.cairo",
+        constructor_calldata=[signer.public_key]
+    )
+
+    await signer.send_transaction(
+        account, erc721.contract_address, 'safeTransferFrom', [
+            account.contract_address,
+            account2.contract_address,
+            *eighth_token_id,
+            len(data),
+            *data
+        ]
+    )
+
+    # check balance
+    execution_info = await erc721.balanceOf(account2.contract_address).call()
+    assert execution_info.result == (uint(1),)
+
+    # check owner
+    execution_info = await erc721.ownerOf(eighth_token_id).call()
+    assert execution_info.result == (account2.contract_address,)
+
 #
 # tokenURI
 #

--- a/tests/test_ERC721_Mintable.py
+++ b/tests/test_ERC721_Mintable.py
@@ -764,7 +764,7 @@ async def test_safeTransferFrom_to_unsupported_contract(erc721_factory):
 
 
 @pytest.mark.asyncio
-async def test_safeTransferFrom_to_eoa(erc721_factory):
+async def test_safeTransferFrom_to_account(erc721_factory):
     starknet, erc721, account, _ = erc721_factory
 
     account2 = await starknet.deploy(


### PR DESCRIPTION
# Fix `safeTransferFrom` logic, add `is_account`

## Summary

This PR adds the `is_account` method to the _Account_ contract. Further, this PR fixes the `safeTransferFrom` logic so that it checks if the `to` contract is an EOA by calling the `is_account` method. In order for this scheme to work, the contracts that will accept `safeTransferFrom` must also include an `is_account` view method (no storage is necessary). The _ERC721_Holder_ contract now includes this method. 

## Implementation
- Add `is_account` to _Account_ and _IAccount_ contracts
- _Account_ contracts set `is_account` to `1`(true in Cairo) in the constructor upon deployment
- Add `is_account` to _ERC721_Holder_ and _IERC_Receiver_ (which returns `0` since they're non-Account contracts)
- Add `safeTransferFrom` test for EOA

## Future
- Adding `is_account` to non-EOA contracts that want to accept NFT transfers is meant to be a temporary fix until we figure out a better solution
