### PR TITLE
Add `ERC721_only_token_owner` for burn

### DIFF
--- a/contracts/token/ERC721.cairo
+++ b/contracts/token/ERC721.cairo
@@ -15,7 +15,8 @@ from contracts.token.ERC721_base import (
     ERC721_approve, 
     ERC721_setApprovalForAll, 
     ERC721_transferFrom,
-    ERC721_safeTransferFrom
+    ERC721_safeTransferFrom,
+    ERC721_only_token_owner
 )
 
 from contracts.token.ERC721_Metadata_base import (
@@ -184,5 +185,16 @@ func setTokenURI{
         range_check_ptr
     }(token_id: Uint256, token_uri: felt):
     ERC721_Metadata_setTokenURI(token_id, token_uri)
+    return ()
+end
+
+@external
+func burn{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(tokenId: Uint256):
+    ERC721_only_token_owner(token_id)
+    ERC721_burn(tokenId)
     return ()
 end

--- a/contracts/token/ERC721_Mintable.cairo
+++ b/contracts/token/ERC721_Mintable.cairo
@@ -17,7 +17,8 @@ from contracts.token.ERC721_base import (
     ERC721_transferFrom,
     ERC721_safeTransferFrom,
     ERC721_mint,
-    ERC721_burn
+    ERC721_burn,
+    ERC721_only_token_owner
 )
 
 from contracts.token.ERC721_Metadata_base import (
@@ -222,7 +223,7 @@ func burn{
         syscall_ptr: felt*, 
         range_check_ptr
     }(tokenId: Uint256):
-    Ownable_only_owner()
+    ERC721_only_token_owner(tokenId)
     ERC721_burn(tokenId)
     return ()
 end

--- a/contracts/token/ERC721_base.cairo
+++ b/contracts/token/ERC721_base.cairo
@@ -288,6 +288,18 @@ func ERC721_safeMint{
     return ()
 end
 
+func ERC721_only_token_owner{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(token_id: Uint256):
+    let (caller) = get_caller_address()
+    let (owner) = ERC721_ownerOf(token_id)
+    # Note `ERC721_ownerOf` checks that the owner is not the zero address
+    assert caller = owner
+    return ()
+end
+
 #
 # Internals
 #

--- a/tests/test_ERC721_Mintable.py
+++ b/tests/test_ERC721_Mintable.py
@@ -291,6 +291,16 @@ async def test_burn_unowned_token(erc721_factory):
         other, erc721.contract_address, 'burn', [*token_to_burn]
     )
 
+
+@pytest.mark.asyncio
+async def test_burn_from_zero_address(erc721_factory):
+    _, erc721, _, _ = erc721_factory
+
+    await assert_revert(
+        erc721.burn(first_token_id).invoke()
+    )
+
+
 #
 # Approve
 #

--- a/tests/test_ERC721_Mintable.py
+++ b/tests/test_ERC721_Mintable.py
@@ -264,19 +264,32 @@ async def test_burn_nonexistent_token(erc721_factory):
 
 
 @pytest.mark.asyncio
-async def test_burn_contract_owner_token_by_different_account(erc721_factory):
-    starknet, erc721, _, _ = erc721_factory
-    not_owner = await starknet.deploy(
+async def test_burn_unowned_token(erc721_factory):
+    starknet, erc721, account, _ = erc721_factory
+    other = await starknet.deploy(
         "contracts/Account.cairo",
         constructor_calldata=[signer.public_key]
     )
 
-    # not_owner should not be able to burn tokens
-    await assert_revert(signer.send_transaction(
-        not_owner, erc721.contract_address, 'burn', [
-            *first_token_id
+    # mint 'token_to_burn' to other account
+    await signer.send_transaction(
+        account, erc721.contract_address, 'mint', [
+            other.contract_address,
+            *token_to_burn
         ]
-    ))
+    )
+
+    # contract owner (account) should not be able to burn other's token
+    await assert_revert(
+        signer.send_transaction(
+            account, erc721.contract_address, 'burn', [*token_to_burn]
+        )
+    )
+
+    # other can burn their own token
+    await signer.send_transaction(
+        other, erc721.contract_address, 'burn', [*token_to_burn]
+    )
 
 #
 # Approve


### PR DESCRIPTION
This PR proposes the inclusion of `ERC721_only_token_owner` in  `ERC721_base`. This method checks that the `caller` is the `tokenId` owner. Further, this method is meant to be imported into the contract (formerly 'frontend contract') and used within the exposed `burn` method. Finally, this resolves #157.