### PR TITLE
Add events to erc20

### DIFF
--- a/contracts/token/ERC20_base.cairo
+++ b/contracts/token/ERC20_base.cairo
@@ -8,6 +8,18 @@ from starkware.cairo.common.uint256 import (
 )
 
 #
+# Events
+#
+
+@event
+func Transfer(_from: felt, to: felt, value: Uint256):
+end
+
+@event
+func Approval(owner: felt, spender: felt, value: Uint256):
+end
+
+#
 # Storage
 #
 
@@ -155,6 +167,7 @@ func ERC20_approve{
     assert_not_zero(spender)
     uint256_check(amount)
     ERC20_allowances.write(caller, spender, amount)
+    Approval.emit(caller, spender, amount)
     return ()
 end
 
@@ -215,6 +228,7 @@ func ERC20_mint{
     assert (is_overflow) = 0
 
     ERC20_total_supply.write(new_supply)
+    Transfer.emit(0, recipient, amount)
     return ()
 end
 
@@ -238,6 +252,7 @@ func ERC20_burn{
     let (supply: Uint256) = ERC20_total_supply.read()
     let (new_supply: Uint256) = uint256_sub(supply, amount)
     ERC20_total_supply.write(new_supply)
+    Transfer.emit(account, 0, amount)
     return ()
 end
 
@@ -270,5 +285,6 @@ func _transfer{
     # overflow is not possible because sum is guaranteed by mint to be less than total supply
     let (new_recipient_balance, _: Uint256) = uint256_add(recipient_balance, amount)
     ERC20_balances.write(recipient, new_recipient_balance)
+    Transfer.emit(sender, recipient, amount)
     return ()
 end

--- a/docs/ERC20.md
+++ b/docs/ERC20.md
@@ -68,7 +68,6 @@ Although StarkNet is not EVM compatible, this implementation aims to be as close
 - it uses Cairo's `uint256` instead of `felt`
 - it returns `1` as success to imitate a `bool`
 - it makes use of Cairo's short strings to simulate `name` and `symbol`
-- it emits events on StarkNet.
 
 But some differences can still be found, such as:
 

--- a/docs/ERC20.md
+++ b/docs/ERC20.md
@@ -9,15 +9,19 @@ The ERC20 token standard is a specification for [fungible tokens](https://docs.o
 - [Usage](#usage)
 - [Extensibility](#extensibility)
 - [API Specification](#api-specification)
-  * [`name`](#-name-)
-  * [`symbol`](#-symbol-)
-  * [`decimals`](#-decimals-)
-  * [`totalSupply`](#-total-supply-)
-  * [`balanceOf`](#-balance-of-)
-  * [`allowance`](#-allowance-)
-  * [`transfer`](#-transfer-)
-  * [`transferFrom`](#-transfer-from-)
-  * [`approve`](#-approve-)
+  * [Methods](#-methods-)
+    * [`name`](#-name-)
+    * [`symbol`](#-symbol-)
+    * [`decimals`](#-decimals-)
+    * [`totalSupply`](#-total-supply-)
+    * [`balanceOf`](#-balance-of-)
+    * [`allowance`](#-allowance-)
+    * [`transfer`](#-transfer-)
+    * [`transferFrom`](#-transferfrom-)
+    * [`approve`](#-approve-)
+  * [Events](#-events-)
+    * [`Transfer (event)`](#-transfer-(event)-)
+    * [`Approval (event)`](#-approval-(event)-)
 
 ## Interface
 
@@ -64,7 +68,7 @@ Although StarkNet is not EVM compatible, this implementation aims to be as close
 - it uses Cairo's `uint256` instead of `felt`
 - it returns `1` as success to imitate a `bool`
 - it makes use of Cairo's short strings to simulate `name` and `symbol`
-- it will emit events once they're implemented on StarkNet.
+- it emits events on StarkNet.
 
 But some differences can still be found, such as:
 
@@ -129,6 +133,8 @@ For example, you could:
 
 ## API Specification
 
+### Methods
+
 ```jsx
 func name() -> (name: felt):
 end
@@ -162,7 +168,7 @@ func approve(spender: felt, amount: Uint256) -> (success: felt):
 end
 ```
 
-### `name`
+#### `name`
 
 Returns the name of the token.
 
@@ -174,7 +180,7 @@ Returns:
 name: felt
 ```
 
-### `symbol`
+#### `symbol`
 
 Returns the ticker symbol of the token.
 
@@ -186,7 +192,7 @@ Returns:
 symbol: felt
 ```
 
-### `decimals`
+#### `decimals`
 
 Returns the number of decimals the token uses - e.g. 8 means to divide the token amount by 100000000 to get its user representation.
 
@@ -198,7 +204,7 @@ Returns:
 decimals: felt
 ```
 
-### `totalSupply`
+#### `totalSupply`
 
 Returns the amount of tokens in existence.
 
@@ -210,7 +216,7 @@ Returns:
 totalSupply: Uint256
 ```
 
-### `balanceOf`
+#### `balanceOf`
 
 Returns the amount of tokens owned by `account`.
 
@@ -226,7 +232,7 @@ Returns:
 balance: Uint256
 ```
 
-### `allowance`
+#### `allowance`
 
 Returns the remaining number of tokens that `spender` will be allowed to spend on behalf of `owner` through `transferFrom`. This is zero by default.
 
@@ -245,9 +251,11 @@ Returns:
 remaining: Uint256
 ```
 
-### `transfer`
+#### `transfer`
 
 Moves `amount` tokens from the caller’s account to `recipient`. It returns `1` representing a bool if it succeeds.
+
+Emits a [Transfer](#-transfer-(event)-) event.
 
 Parameters:
 
@@ -262,9 +270,11 @@ Returns:
 success: felt
 ```
 
-### `transferFrom`
+#### `transferFrom`
 
 Moves `amount` tokens from `sender` to `recipient` using the allowance mechanism. `amount` is then deducted from the caller’s allowance. It returns `1` representing a bool if it succeeds.
+
+Emits a [Transfer](#-transfer-(event)-) event.
 
 Parameters:
 
@@ -280,9 +290,11 @@ Returns:
 success: felt
 ```
 
-### `approve`
+#### `approve`
 
 Sets `amount` as the allowance of `spender` over the caller’s tokens. It returns `1` representing a bool if it succeeds.
+
+Emits an [Approval](#-approval-(event)-) event.
 
 Parameters:
 
@@ -295,4 +307,40 @@ Returns:
 
 ```jsx
 success: felt
+```
+
+### Events
+
+```jsx
+func Transfer(_from: felt, to: felt, value: Uint256):
+end
+
+func Approval(owner: felt, spender: felt, value: Uint256):
+end
+```
+
+#### `Transfer (event)`
+
+Emitted when `value` tokens are moved from one account (`_from`) to another (`to`). 
+
+Note that `value` may be zero.
+
+Parameters:
+
+```jsx
+_from: felt
+to: felt
+value: Uint256
+```
+
+#### `Approval (event)`
+
+Emitted when the allowance of a `spender` for an `owner` is set by a call to [approve](#-approve-). `value` is the new allowance.
+
+Parameters:
+
+```jsx
+owner: felt
+spender: felt
+value: Uint256
 ```

--- a/tests/mocks/ERC20_Burnable_mock.cairo
+++ b/tests/mocks/ERC20_Burnable_mock.cairo
@@ -1,0 +1,175 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.uint256 import Uint256
+
+from contracts.token.ERC20_base import (
+    ERC20_name,
+    ERC20_symbol,
+    ERC20_totalSupply,
+    ERC20_decimals,
+    ERC20_balanceOf,
+    ERC20_allowance,
+
+    ERC20_initializer,
+    ERC20_approve,
+    ERC20_increaseAllowance,
+    ERC20_decreaseAllowance,
+    ERC20_transfer,
+    ERC20_transferFrom,
+    ERC20_burn
+)
+
+@constructor
+func constructor{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(
+        name: felt,
+        symbol: felt,
+        initial_supply: Uint256,
+        recipient: felt
+    ):
+    ERC20_initializer(name, symbol, initial_supply, recipient)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func name{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (name: felt):
+    let (name) = ERC20_name()
+    return (name)
+end
+
+@view
+func symbol{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (symbol: felt):
+    let (symbol) = ERC20_symbol()
+    return (symbol)
+end
+
+@view
+func totalSupply{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (totalSupply: Uint256):
+    let (totalSupply: Uint256) = ERC20_totalSupply()
+    return (totalSupply)
+end
+
+@view
+func decimals{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (decimals: felt):
+    let (decimals) = ERC20_decimals()
+    return (decimals)
+end
+
+@view
+func balanceOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(account: felt) -> (balance: Uint256):
+    let (balance: Uint256) = ERC20_balanceOf(account)
+    return (balance)
+end
+
+@view
+func allowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt, spender: felt) -> (remaining: Uint256):
+    let (remaining: Uint256) = ERC20_allowance(owner, spender)
+    return (remaining)
+end
+
+#
+# Externals
+#
+
+@external
+func transfer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(recipient: felt, amount: Uint256) -> (success: felt):
+    ERC20_transfer(recipient, amount)
+    # Cairo equivalent to 'return (true)'
+    return (1)
+end
+
+@external
+func transferFrom{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        sender: felt, 
+        recipient: felt, 
+        amount: Uint256
+    ) -> (success: felt):
+    ERC20_transferFrom(sender, recipient, amount)
+    # Cairo equivalent to 'return (true)'
+    return (1)
+end
+
+@external
+func approve{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, amount: Uint256) -> (success: felt):
+    ERC20_approve(spender, amount)
+    # Cairo equivalent to 'return (true)'
+    return (1)
+end
+
+@external
+func increaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, added_value: Uint256) -> (success: felt):
+    ERC20_increaseAllowance(spender, added_value)
+    # Cairo equivalent to 'return (true)'
+    return (1)
+end
+
+@external
+func decreaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, subtracted_value: Uint256) -> (success: felt):
+    ERC20_decreaseAllowance(spender, subtracted_value)
+    # Cairo equivalent to 'return (true)'
+    return (1)
+end
+
+@external
+func burn{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(amount: Uint256):
+    let (owner) = get_caller_address()
+    ERC20_burn(owner, amount)
+    return ()
+end

--- a/tests/mocks/ERC20_Burnable_mock.cairo
+++ b/tests/mocks/ERC20_Burnable_mock.cairo
@@ -4,6 +4,8 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
 from starkware.cairo.common.uint256 import Uint256
 
+from contracts.utils.constants import TRUE
+
 from contracts.token.ERC20_base import (
     ERC20_name,
     ERC20_symbol,
@@ -111,8 +113,7 @@ func transfer{
         range_check_ptr
     }(recipient: felt, amount: Uint256) -> (success: felt):
     ERC20_transfer(recipient, amount)
-    # Cairo equivalent to 'return (true)'
-    return (1)
+    return (TRUE)
 end
 
 @external
@@ -126,8 +127,7 @@ func transferFrom{
         amount: Uint256
     ) -> (success: felt):
     ERC20_transferFrom(sender, recipient, amount)
-    # Cairo equivalent to 'return (true)'
-    return (1)
+    return (TRUE)
 end
 
 @external
@@ -137,8 +137,7 @@ func approve{
         range_check_ptr
     }(spender: felt, amount: Uint256) -> (success: felt):
     ERC20_approve(spender, amount)
-    # Cairo equivalent to 'return (true)'
-    return (1)
+    return (TRUE)
 end
 
 @external
@@ -148,8 +147,7 @@ func increaseAllowance{
         range_check_ptr
     }(spender: felt, added_value: Uint256) -> (success: felt):
     ERC20_increaseAllowance(spender, added_value)
-    # Cairo equivalent to 'return (true)'
-    return (1)
+    return (TRUE)
 end
 
 @external
@@ -159,8 +157,7 @@ func decreaseAllowance{
         range_check_ptr
     }(spender: felt, subtracted_value: Uint256) -> (success: felt):
     ERC20_decreaseAllowance(spender, subtracted_value)
-    # Cairo equivalent to 'return (true)'
-    return (1)
+    return (TRUE)
 end
 
 @external

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -3,7 +3,7 @@ import asyncio
 from starkware.starknet.public.abi import get_selector_from_name
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    Signer, uint, str_to_felt, MAX_UINT256, ZERO_ADDRESS,
+    Signer, uint, str_to_felt, MAX_UINT256, ZERO_ADDRESS, assert_event_emitted,
     assert_revert, sub_uint, add_uint
 )
 
@@ -94,20 +94,22 @@ async def test_transfer_emit_event(erc20_factory):
     recipient = 123
     amount = uint(100)
 
-    execution_info = await signer.send_transaction(
+    tx_exec_info = await signer.send_transaction(
         account, erc20.contract_address, 'transfer', [
             recipient,
             *amount
         ])
 
-    assert execution_info.raw_events[0].from_address == erc20.contract_address
-    assert execution_info.raw_events[0].keys[0] == get_selector_from_name(
-        'Transfer')
-    assert execution_info.raw_events[0].data == [
-        account.contract_address,
-        recipient,
-        *amount
-    ]
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc20.contract_address,
+        name='Transfer',
+        data=[
+            account.contract_address,
+            recipient,
+            *amount
+        ]
+    )
 
 
 @pytest.mark.asyncio
@@ -149,20 +151,22 @@ async def test_approve_emit_event(erc20_factory):
     spender = 123
     amount = uint(345)
 
-    execution_info = await signer.send_transaction(
+    tx_exec_info = await signer.send_transaction(
         account, erc20.contract_address, 'approve', [
             spender,
             *amount
         ])
 
-    assert execution_info.raw_events[0].from_address == erc20.contract_address
-    assert execution_info.raw_events[0].keys[0] == get_selector_from_name(
-        'Approval')
-    assert execution_info.raw_events[0].data == [
-        account.contract_address,
-        spender,
-        *amount
-    ]
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc20.contract_address,
+        name='Approval',
+        data=[
+            account.contract_address,
+            spender,
+            *amount
+        ]
+    )
 
 
 @pytest.mark.asyncio
@@ -213,21 +217,23 @@ async def test_transferFrom_emit_event(erc20_factory):
     # approve
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *amount])
     # transferFrom
-    execution_info = await signer.send_transaction(
+    tx_exec_info = await signer.send_transaction(
         spender, erc20.contract_address, 'transferFrom', [
             account.contract_address,
             recipient,
             *amount
         ])
 
-    assert execution_info.raw_events[0].from_address == erc20.contract_address
-    assert execution_info.raw_events[0].keys[0] == get_selector_from_name(
-        'Transfer')
-    assert execution_info.raw_events[0].data == [
-        account.contract_address,
-        recipient,
-        *amount
-    ]
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc20.contract_address,
+        name='Transfer',
+        data=[
+            account.contract_address,
+            recipient,
+            *amount
+        ]
+    )
 
 
 @pytest.mark.asyncio
@@ -271,20 +277,22 @@ async def test_increaseAllowance_emit_event(erc20_factory):
         ])
 
     # increase allowance
-    execution_info = await signer.send_transaction(
+    tx_exec_info = await signer.send_transaction(
         account, erc20.contract_address, 'increaseAllowance', [
             spender,
             *amount
         ])
 
-    assert execution_info.raw_events[0].from_address == erc20.contract_address
-    assert execution_info.raw_events[0].keys[0] == get_selector_from_name(
-        'Approval')
-    assert execution_info.raw_events[0].data == [
-        account.contract_address,
-        spender,
-        *add_uint(amount, amount)
-    ]
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc20.contract_address,
+        name='Approval',
+        data=[
+            account.contract_address,
+            spender,
+            *add_uint(amount, amount)
+        ]
+    )
 
 
 @pytest.mark.asyncio
@@ -331,20 +339,22 @@ async def test_decreaseAllowance_emit_event(erc20_factory):
         ])
 
     # decrease allowance
-    execution_info = await signer.send_transaction(
+    tx_exec_info = await signer.send_transaction(
         account, erc20.contract_address, 'decreaseAllowance', [
             spender,
             *subtract_amount
         ])
 
-    assert execution_info.raw_events[0].from_address == erc20.contract_address
-    assert execution_info.raw_events[0].keys[0] == get_selector_from_name(
-        'Approval')
-    assert execution_info.raw_events[0].data == [
-        account.contract_address,
-        spender,
-        *sub_uint(init_amount, subtract_amount)
-    ]
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc20.contract_address,
+        name='Approval',
+        data=[
+            account.contract_address,
+            spender,
+            *sub_uint(init_amount, subtract_amount)
+        ]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -89,7 +89,7 @@ async def test_transfer(erc20_factory):
 
 
 @pytest.mark.asyncio
-async def test_transfer_emit_event(erc20_factory):
+async def test_transfer_emits_event(erc20_factory):
     _, erc20, account = erc20_factory
     recipient = 123
     amount = uint(100)

--- a/tests/test_ERC20.py
+++ b/tests/test_ERC20.py
@@ -146,7 +146,7 @@ async def test_approve(erc20_factory):
 
 
 @pytest.mark.asyncio
-async def test_approve_emit_event(erc20_factory):
+async def test_approve_emits_event(erc20_factory):
     _, erc20, account = erc20_factory
     spender = 123
     amount = uint(345)
@@ -205,7 +205,7 @@ async def test_transferFrom(erc20_factory):
 
 
 @pytest.mark.asyncio
-async def test_transferFrom_emit_event(erc20_factory):
+async def test_transferFrom_emits_event(erc20_factory):
     starknet, erc20, account = erc20_factory
     spender = await starknet.deploy(
         "contracts/Account.cairo",
@@ -264,7 +264,7 @@ async def test_increaseAllowance(erc20_factory):
 
 
 @pytest.mark.asyncio
-async def test_increaseAllowance_emit_event(erc20_factory):
+async def test_increaseAllowance_emits_event(erc20_factory):
     _, erc20, account = erc20_factory
     # new spender, starting from zero
     spender = 234
@@ -324,7 +324,7 @@ async def test_decreaseAllowance(erc20_factory):
 
 
 @pytest.mark.asyncio
-async def test_decreaseAllowance_emit_event(erc20_factory):
+async def test_decreaseAllowance_emits_event(erc20_factory):
     _, erc20, account = erc20_factory
     # new spender, starting from zero
     spender = 321

--- a/tests/test_ERC20_Burnable_mock.py
+++ b/tests/test_ERC20_Burnable_mock.py
@@ -55,7 +55,7 @@ async def test_burn(erc20_factory):
 
 
 @pytest.mark.asyncio
-async def test_burn_emit_event(erc20_factory):
+async def test_burn_emits_event(erc20_factory):
     _, erc20, account = erc20_factory
     amount = to_uint(100)
 

--- a/tests/test_ERC20_Burnable_mock.py
+++ b/tests/test_ERC20_Burnable_mock.py
@@ -1,0 +1,96 @@
+import pytest
+import asyncio
+from starkware.starknet.public.abi import get_selector_from_name
+from starkware.starknet.testing.starknet import Starknet
+from utils import (
+    Signer, to_uint, str_to_felt, ZERO_ADDRESS,
+    assert_revert, sub_uint, add_uint
+)
+
+signer = Signer(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def event_loop():
+    return asyncio.new_event_loop()
+
+
+@pytest.fixture(scope='module')
+async def erc20_factory():
+    starknet = await Starknet.empty()
+    account = await starknet.deploy(
+        "contracts/Account.cairo",
+        constructor_calldata=[signer.public_key]
+    )
+
+    erc20 = await starknet.deploy(
+        "tests/mocks/ERC20_Burnable_mock.cairo",
+        constructor_calldata=[
+            str_to_felt("Token"),      # name
+            str_to_felt("TKN"),        # symbol
+            *to_uint(1000),            # initial_supply
+            account.contract_address   # recipient
+        ]
+    )
+    return starknet, erc20, account
+
+
+@pytest.mark.asyncio
+async def test_burn(erc20_factory):
+    _, erc20, account = erc20_factory
+    amount = to_uint(100)
+
+    execution_info = await erc20.balanceOf(account.contract_address).invoke()
+    init_balance = execution_info.result.balance
+
+    await signer.send_transaction(
+        account, erc20.contract_address, 'burn', [
+            *amount
+        ])
+
+    execution_info = await erc20.balanceOf(account.contract_address).invoke()
+    new_balance = execution_info.result.balance
+
+    assert sub_uint(init_balance, amount) == new_balance
+
+
+@pytest.mark.asyncio
+async def test_burn_emit_event(erc20_factory):
+    _, erc20, account = erc20_factory
+    amount = to_uint(100)
+
+    execution_info = await signer.send_transaction(
+        account, erc20.contract_address, 'burn', [
+            *amount
+        ])
+
+    assert execution_info.raw_events[0].from_address == erc20.contract_address
+    assert execution_info.raw_events[0].keys[0] == get_selector_from_name(
+        'Transfer')
+    assert execution_info.raw_events[0].data == [
+        account.contract_address,
+        ZERO_ADDRESS,
+        *amount
+    ]
+
+
+@pytest.mark.asyncio
+async def test_burn_not_enough_balance(erc20_factory):
+    _, erc20, account = erc20_factory
+
+    execution_info = await erc20.balanceOf(account.contract_address).invoke()
+    amount = execution_info.result.balance
+
+    await assert_revert(signer.send_transaction(
+        account, erc20.contract_address, 'burn', [
+            *add_uint(amount, to_uint(1))
+        ])
+    )
+
+
+@pytest.mark.asyncio
+async def test_burn_from_zero_address(erc20_factory):
+    _, erc20, _ = erc20_factory
+    amount = to_uint(1)
+
+    await assert_revert(erc20.burn(amount).invoke())

--- a/tests/test_ERC20_Burnable_mock.py
+++ b/tests/test_ERC20_Burnable_mock.py
@@ -3,7 +3,7 @@ import asyncio
 from starkware.starknet.public.abi import get_selector_from_name
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    Signer, to_uint, str_to_felt, ZERO_ADDRESS,
+    Signer, to_uint, str_to_felt, ZERO_ADDRESS, assert_event_emitted,
     assert_revert, sub_uint, add_uint
 )
 
@@ -59,19 +59,21 @@ async def test_burn_emit_event(erc20_factory):
     _, erc20, account = erc20_factory
     amount = to_uint(100)
 
-    execution_info = await signer.send_transaction(
+    tx_exec_info = await signer.send_transaction(
         account, erc20.contract_address, 'burn', [
             *amount
         ])
 
-    assert execution_info.raw_events[0].from_address == erc20.contract_address
-    assert execution_info.raw_events[0].keys[0] == get_selector_from_name(
-        'Transfer')
-    assert execution_info.raw_events[0].data == [
-        account.contract_address,
-        ZERO_ADDRESS,
-        *amount
-    ]
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc20.contract_address,
+        name='Transfer',
+        data=[
+            account.contract_address,
+            ZERO_ADDRESS,
+            *amount
+        ]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_ERC20_Mintable.py
+++ b/tests/test_ERC20_Mintable.py
@@ -63,7 +63,7 @@ async def test_mint(token_factory):
 
 
 @pytest.mark.asyncio
-async def test_mint_emit_event(token_factory):
+async def test_mint_emits_event(token_factory):
     _, erc20, account = token_factory
     amount = uint(1)
 

--- a/tests/test_ERC20_Mintable.py
+++ b/tests/test_ERC20_Mintable.py
@@ -3,7 +3,7 @@ import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from starkware.starknet.public.abi import get_selector_from_name
 from utils import (
-    Signer, uint, str_to_felt, MAX_UINT256, ZERO_ADDRESS, assert_revert
+    Signer, uint, str_to_felt, MAX_UINT256, ZERO_ADDRESS, assert_revert, assert_event_emitted
 )
 
 signer = Signer(123456789987654321)
@@ -67,20 +67,22 @@ async def test_mint_emit_event(token_factory):
     _, erc20, account = token_factory
     amount = uint(1)
 
-    execution_info = await signer.send_transaction(
+    tx_exec_info = await signer.send_transaction(
         account, erc20.contract_address, 'mint', [
             account.contract_address,
             *amount
         ])
 
-    assert execution_info.raw_events[0].from_address == erc20.contract_address
-    assert execution_info.raw_events[0].keys[0] == get_selector_from_name(
-        'Transfer')
-    assert execution_info.raw_events[0].data == [
-        ZERO_ADDRESS,
-        account.contract_address,
-        *amount
-    ]
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc20.contract_address,
+        name='Transfer',
+        data=[
+            ZERO_ADDRESS,
+            account.contract_address,
+            *amount
+        ]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ from starkware.cairo.common.hash_state import compute_hash_on_elements
 from starkware.crypto.signature.signature import private_to_stark_key, sign
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
 from starkware.starkware_utils.error_handling import StarkException
+from starkware.starknet.business_logic.transaction_execution_objects import Event
 from starkware.starknet.public.abi import get_selector_from_name
 
 MAX_UINT256 = (2**128 - 1, 2**128 - 1)
@@ -18,6 +19,14 @@ def str_to_felt(text):
 def felt_to_str(felt):
     b_felt = felt.to_bytes(31, "big")
     return b_felt.decode()
+
+
+def assert_event_emitted(tx_exec_info, from_address, name, data):
+    assert Event(
+        from_address=from_address,
+        keys=[get_selector_from_name(name)],
+        data=data,
+    ) in tx_exec_info.raw_events
 
 
 def uint(a):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,7 @@ from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.public.abi import get_selector_from_name
 
 MAX_UINT256 = (2**128 - 1, 2**128 - 1)
+ZERO_ADDRESS = 0
 
 
 def str_to_felt(text):


### PR DESCRIPTION
## Summary

This PR resolves #137 and also proposes to remove all local `zero_address` variables (within the ERC20 test modules) in favor of importing `ZERO_ADDRESS` from `utils.py`. Further, this PR proposes the inclusion of `ERC20_Burnable_mock.cairo` with accompanying `test_ERC20_Burnable_mock.py` to test both the functionality of `ERC20_burn` and its emitted `Transfer` event.

## Future

Some possible improvements to consider:

- refactor `ERC20_transferFrom` so that both `Transfer` and `Approval` are emitted. This isn't required by [EIP20](https://eips.ethereum.org/EIPS/eip-20); however, it _does_ follow OpenZeppelin's Solidity implementation with their reasoning [here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol#L26-L29).
- create an ERC20 burnable preset