### PR TITLE
Remove unnecessary locals and alloc_locals

### DIFF
--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -204,8 +204,6 @@ end
 
 func hash_message{pedersen_ptr : HashBuiltin*}(message: Message*) -> (res: felt):
     alloc_locals
-    # we need to make `res_calldata` local
-    # to prevent the reference from being revoked
     let (res_calldata) = hash_calldata(message.calldata, message.calldata_size)
     let hash_ptr = pedersen_ptr
     with hash_ptr:

--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -206,7 +206,7 @@ func hash_message{pedersen_ptr : HashBuiltin*}(message: Message*) -> (res: felt)
     alloc_locals
     # we need to make `res_calldata` local
     # to prevent the reference from being revoked
-    let (local res_calldata) = hash_calldata(message.calldata, message.calldata_size)
+    let (res_calldata) = hash_calldata(message.calldata, message.calldata_size)
     let hash_ptr = pedersen_ptr
     with hash_ptr:
         let (hash_state_ptr) = hash_init()
@@ -243,3 +243,4 @@ func hash_calldata{pedersen_ptr: HashBuiltin*}(
         return (res=res)
     end
 end
+

--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -44,11 +44,7 @@ end
 #
 
 @view
-func assert_only_self{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }():
+func assert_only_self{syscall_ptr : felt*}():
     let (self) = get_contract_address()
     let (caller) = get_caller_address()
     assert self = caller

--- a/contracts/token/ERC20_base.cairo
+++ b/contracts/token/ERC20_base.cairo
@@ -130,8 +130,8 @@ func ERC20_transferFrom{
         amount: Uint256
     ) -> ():
     alloc_locals
-    let (local caller) = get_caller_address()
-    let (local caller_allowance: Uint256) = ERC20_allowances.read(owner=sender, spender=caller)
+    let (caller) = get_caller_address()
+    let (caller_allowance: Uint256) = ERC20_allowances.read(owner=sender, spender=caller)
 
     # validates amount <= caller_allowance and returns 1 if true   
     let (enough_allowance) = uint256_le(amount, caller_allowance)
@@ -163,13 +163,12 @@ func ERC20_increaseAllowance{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(spender: felt, added_value: Uint256) -> ():
-    alloc_locals
     uint256_check(added_value)
-    let (local caller) = get_caller_address()
-    let (local current_allowance: Uint256) = ERC20_allowances.read(caller, spender)
+    let (caller) = get_caller_address()
+    let (current_allowance: Uint256) = ERC20_allowances.read(caller, spender)
 
     # add allowance
-    let (local new_allowance: Uint256, is_overflow) = uint256_add(current_allowance, added_value)
+    let (new_allowance: Uint256, is_overflow) = uint256_add(current_allowance, added_value)
     assert (is_overflow) = 0
 
     ERC20_approve(spender, new_allowance)
@@ -183,9 +182,9 @@ func ERC20_decreaseAllowance{
     }(spender: felt, subtracted_value: Uint256) -> ():
     alloc_locals
     uint256_check(subtracted_value)
-    let (local caller) = get_caller_address()
-    let (local current_allowance: Uint256) = ERC20_allowances.read(owner=caller, spender=spender)
-    let (local new_allowance: Uint256) = uint256_sub(current_allowance, subtracted_value)
+    let (caller) = get_caller_address()
+    let (current_allowance: Uint256) = ERC20_allowances.read(owner=caller, spender=spender)
+    let (new_allowance: Uint256) = uint256_sub(current_allowance, subtracted_value)
 
     # validates new_allowance < current_allowance and returns 1 if true   
     let (enough_allowance) = uint256_lt(new_allowance, current_allowance)
@@ -200,7 +199,6 @@ func ERC20_mint{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(recipient: felt, amount: Uint256):
-    alloc_locals
     assert_not_zero(recipient)
     uint256_check(amount)
 
@@ -210,8 +208,8 @@ func ERC20_mint{
     let (new_balance, _: Uint256) = uint256_add(balance, amount)
     ERC20_balances.write(recipient, new_balance)
 
-    let (local supply: Uint256) = ERC20_total_supply.read()
-    let (local new_supply: Uint256, is_overflow) = uint256_add(supply, amount)
+    let (supply: Uint256) = ERC20_total_supply.read()
+    let (new_supply: Uint256, is_overflow) = uint256_add(supply, amount)
     assert (is_overflow) = 0
 
     ERC20_total_supply.write(new_supply)
@@ -255,7 +253,7 @@ func _transfer{
     assert_not_zero(recipient)
     uint256_check(amount) # almost surely not needed, might remove after confirmation
 
-    let (local sender_balance: Uint256) = ERC20_balances.read(account=sender)
+    let (sender_balance: Uint256) = ERC20_balances.read(account=sender)
 
     # validates amount <= sender_balance and returns 1 if true
     let (enough_balance) = uint256_le(amount, sender_balance)
@@ -272,3 +270,4 @@ func _transfer{
     ERC20_balances.write(recipient, new_recipient_balance)
     return ()
 end
+

--- a/contracts/token/ERC721_Enumerable_base.cairo
+++ b/contracts/token/ERC721_Enumerable_base.cairo
@@ -171,12 +171,11 @@ func _add_token_to_all_tokens_enumeration{
         syscall_ptr: felt*, 
         range_check_ptr
     }(token_id: Uint256):
-    alloc_locals
     let (supply: Uint256) = ERC721_Enumerable_all_tokens_len.read()
     ERC721_Enumerable_all_tokens.write(supply, token_id)
     ERC721_Enumerable_all_tokens_index.write(token_id, supply)
     
-    let (local new_supply: Uint256, _) = uint256_add(supply, Uint256(1, 0))
+    let (new_supply: Uint256, _) = uint256_add(supply, Uint256(1, 0))
     ERC721_Enumerable_all_tokens_len.write(new_supply)
     return ()
 end
@@ -187,15 +186,14 @@ func _remove_token_from_all_tokens_enumeration{
         syscall_ptr: felt*, 
         range_check_ptr
     }(token_id: Uint256):
-    alloc_locals
-    let (local supply: Uint256) = ERC721_Enumerable_all_tokens_len.read()
-    let (local last_token_index: Uint256) = uint256_sub(supply, Uint256(1, 0))
-    let (local token_index: Uint256) = ERC721_Enumerable_all_tokens_index.read(token_id)
+    let (supply: Uint256) = ERC721_Enumerable_all_tokens_len.read()
+    let (last_token_index: Uint256) = uint256_sub(supply, Uint256(1, 0))
+    let (token_index: Uint256) = ERC721_Enumerable_all_tokens_index.read(token_id)
 
     # When the token to delete is the last token, the swap operation is unnecessary. However,
     # since this occurs so rarely (when the last minted token is burnt), we still do the swap
     # here to avoid the gas cost of adding an 'if' statement (like in _remove_token_from_owner_enumeration)
-    let (local last_token_id: Uint256) = ERC721_Enumerable_all_tokens.read(last_token_index)
+    let (last_token_id: Uint256) = ERC721_Enumerable_all_tokens.read(last_token_index)
 
     ERC721_Enumerable_all_tokens.write(last_token_index, Uint256(0, 0))
     ERC721_Enumerable_all_tokens.write(token_index, last_token_id)
@@ -203,7 +201,7 @@ func _remove_token_from_all_tokens_enumeration{
     ERC721_Enumerable_all_tokens_index.write(last_token_id, token_index)
     ERC721_Enumerable_all_tokens_index.write(token_id, Uint256(0, 0))
 
-    let (local new_supply: Uint256) = uint256_sub(supply, Uint256(1, 0))
+    let (new_supply: Uint256) = uint256_sub(supply, Uint256(1, 0))
     ERC721_Enumerable_all_tokens_len.write(new_supply)
     return ()
 end
@@ -213,8 +211,7 @@ func _add_token_to_owner_enumeration{
         syscall_ptr: felt*, 
         range_check_ptr
     }(to: felt, token_id: Uint256):
-    alloc_locals
-    let (local length: Uint256) = ERC721_balanceOf(to) 
+    let (length: Uint256) = ERC721_balanceOf(to) 
     ERC721_Enumerable_owned_tokens.write(to, length, token_id)
     ERC721_Enumerable_owned_tokens_index.write(token_id, length)
     return ()
@@ -226,10 +223,10 @@ func _remove_token_from_owner_enumeration{
         range_check_ptr
     }(_from: felt, token_id: Uint256):
     alloc_locals
-    let (local last_token_index: Uint256) = ERC721_balanceOf(_from)
+    let (last_token_index: Uint256) = ERC721_balanceOf(_from)
     # the index starts at zero therefore the user's last token index is their balance minus one
     let (last_token_index) = uint256_sub(last_token_index, Uint256(1, 0))
-    let (local token_index: Uint256) = ERC721_Enumerable_owned_tokens_index.read(token_id)
+    let (token_index: Uint256) = ERC721_Enumerable_owned_tokens_index.read(token_id)
 
     # If index is last, we can just set the return values to zero
     let (is_equal) = uint256_eq(token_index, last_token_index)

--- a/contracts/token/ERC721_base.cairo
+++ b/contracts/token/ERC721_base.cairo
@@ -277,7 +277,7 @@ func ERC721_burn{
     }(token_id: Uint256):
     alloc_locals
     uint256_check(token_id)
-    let (local owner) = ERC721_ownerOf(token_id)
+    let (owner) = ERC721_ownerOf(token_id)
 
     # Clear approvals
     _approve(0, token_id)

--- a/contracts/token/utils/ERC721_Holder.cairo
+++ b/contracts/token/utils/ERC721_Holder.cairo
@@ -9,11 +9,7 @@ from contracts.ERC165_base import (
 )
 
 @view
-func onERC721Received{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*, 
-        range_check_ptr
-    }(
+func onERC721Received(
         operator: felt,
         _from: felt,
         tokenId: Uint256,


### PR DESCRIPTION
This PR proposes the removal of specific `local` variables and `alloc_locals` statements. The proposed changes shrink the amount of computational steps needed thus making the contracts more efficient. For example, a simple ERC20 `mint` transaction takes the compiler 731 steps for Account's `execute` and 343 steps for ERC20's `mint` in the current iteration. With the changes proposed in this PR, Account's `execute` instead takes 719 steps and ERC20's `mint` takes 331 steps.

This PR also removes unnecessary implicit arguments found in `assert_only_self` and `onERC721Received`. 