### PR TITLE
Integrate safemath to all token libraries

### DIFF
--- a/contracts/token/ERC20_base.cairo
+++ b/contracts/token/ERC20_base.cairo
@@ -7,8 +7,7 @@ from starkware.cairo.common.uint256 import Uint256, uint256_check
 
 from contracts.utils.safemath import (
     uint256_checked_add,
-    uint256_checked_sub_le,
-    uint256_checked_sub_lt
+    uint256_checked_sub_le
 )
 
 #
@@ -187,7 +186,7 @@ func ERC20_decreaseAllowance{
     let (local caller) = get_caller_address()
     let (local current_allowance: Uint256) = ERC20_allowances.read(owner=caller, spender=spender)
     # safemath validates new_allowance < current_allowance   
-    let (local new_allowance: Uint256) = uint256_checked_sub_lt(current_allowance, subtracted_value)
+    let (local new_allowance: Uint256) = uint256_checked_sub_le(current_allowance, subtracted_value)
 
     ERC20_approve(spender, new_allowance)
     return ()

--- a/contracts/token/ERC721_base.cairo
+++ b/contracts/token/ERC721_base.cairo
@@ -2,7 +2,6 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.cairo.common.math import assert_not_zero, assert_not_equal
-from starkware.cairo.common.alloc import alloc
 from starkware.starknet.common.syscalls import get_caller_address
 from starkware.cairo.common.uint256 import Uint256, uint256_check
 
@@ -176,7 +175,7 @@ func ERC721_approve{
         return ()
     else:
         let (is_approved) = ERC721_operator_approvals.read(owner, caller)
-        assert_not_zero(is_approved)
+        assert is_approved = TRUE
         _approve(to, token_id)
         return ()
     end
@@ -440,7 +439,7 @@ func _safe_transfer{
     _transfer(_from, to, token_id)
 
     let (success) = _check_onERC721Received(_from, to, token_id, data_len, data)
-    assert_not_zero(success)
+    assert success = TRUE
     return ()
 end
 


### PR DESCRIPTION
## Summary

This PR integrates `safemath` into the `ERC721_Enumerable_base` and `ERC20_base` libraries. Aside from ensuring proper arithmetic checks, utilizing `safemath` methods provides more readable code. 

This PR also adds boolean constants to `ERC721_Enumerable_base`, again, for readability.