### PR TITLE
Add proxy contract and upgrades lib

### DIFF
--- a/contracts/proxy/Proxy.cairo
+++ b/contracts/proxy/Proxy.cairo
@@ -11,7 +11,7 @@ from contracts.proxy.library import (
 # Constructor
 #
 
-@external
+@constructor
 func constructor{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,

--- a/contracts/proxy/Proxy.cairo
+++ b/contracts/proxy/Proxy.cairo
@@ -1,0 +1,76 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import delegate_l1_handler, delegate_call
+from contracts.proxy.library import (
+    Proxy_implementation_address,
+    Proxy_set_implementation
+)
+
+#
+# Constructor
+#
+
+@external
+func constructor{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(implementation_address: felt):
+    Proxy_set_implementation(implementation_address)
+    return ()
+end
+
+#
+# Fallback functions
+#
+
+@external
+@raw_input
+@raw_output
+func __default__{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(
+        selector: felt,
+        calldata_size: felt,
+        calldata: felt*
+    ) -> (
+        retdata_size: felt,
+        retdata: felt*
+    ):
+    let (address) = Proxy_implementation_address.read()
+
+    let (retdata_size: felt, retdata: felt*) = delegate_call(
+        contract_address=address,
+        function_selector=selector,
+        calldata_size=calldata_size,
+        calldata=calldata
+    )
+
+    return (retdata_size=retdata_size, retdata=retdata)
+end
+
+@l1_handler
+@raw_input
+func __l1_default__{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(
+        selector: felt,
+        calldata_size: felt,
+        calldata: felt*
+    ):
+    let (address) = Proxy_implementation_address.read()
+
+    delegate_l1_handler(
+        contract_address=address,
+        function_selector=selector,
+        calldata_size=calldata_size,
+        calldata=calldata
+    )
+
+    return ()
+end

--- a/contracts/proxy/library.cairo
+++ b/contracts/proxy/library.cairo
@@ -1,0 +1,64 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+
+#
+# Storage variables
+#
+
+@storage_var
+func Proxy_implementation_address() -> (implementation_address: felt):
+end
+
+@storage_var
+func Proxy_admin() -> (proxy_admin: felt):
+end
+
+@storage_var
+func Proxy_initialized() -> (initialized: felt):
+end
+
+#
+# Initialize
+#
+
+func Proxy_initializer{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(proxy_admin: felt):
+    let (initialized) = Proxy_initialized.read()
+    assert proxy_admin = 0
+    Proxy_initialized.write(1)
+    Proxy_admin.write(proxy_admin)
+    return ()
+end
+
+#
+# Upgrades
+#
+
+func Proxy_set_implementation{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(new_implementation: felt):
+    Proxy_implementation_address.write(new_implementation)
+    return ()
+end
+
+#
+# Guards
+#
+
+func Proxy_only_admin{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }():
+    let (caller) = get_caller_address()
+    let (admin) = Proxy_admin.read()
+    assert admin = caller
+    return ()
+end

--- a/contracts/proxy/library.cairo
+++ b/contracts/proxy/library.cairo
@@ -2,6 +2,15 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
+from contracts.utils.constants import TRUE, FALSE
+
+#
+# Events
+#
+
+@event
+func Upgraded(implementation: felt):
+end
 
 #
 # Storage variables
@@ -29,8 +38,8 @@ func Proxy_initializer{
         range_check_ptr
     }(proxy_admin: felt):
     let (initialized) = Proxy_initialized.read()
-    assert proxy_admin = 0
-    Proxy_initialized.write(1)
+    assert initialized = FALSE
+    Proxy_initialized.write(TRUE)
     Proxy_admin.write(proxy_admin)
     return ()
 end
@@ -45,6 +54,7 @@ func Proxy_set_implementation{
         range_check_ptr
     }(new_implementation: felt):
     Proxy_implementation_address.write(new_implementation)
+    Upgraded.emit(new_implementation)
     return ()
 end
 
@@ -62,3 +72,38 @@ func Proxy_only_admin{
     assert admin = caller
     return ()
 end
+
+#
+# Getters
+#
+
+func Proxy_get_admin{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }() -> (admin: felt):
+    let (admin) = Proxy_admin.read()
+    return (admin)
+end 
+
+func Proxy_get_implementation{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }() -> (implementation: felt):
+    let (implementation) = Proxy_implementation_address.read()
+    return (implementation)
+end 
+
+#
+# Setters
+#
+
+func Proxy_set_admin{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(new_admin: felt):
+    Proxy_admin.write(new_admin)
+    return ()
+end 

--- a/contracts/proxy/library.cairo
+++ b/contracts/proxy/library.cairo
@@ -29,7 +29,7 @@ func Proxy_initialized() -> (initialized: felt):
 end
 
 #
-# Initialize
+# Initializer
 #
 
 func Proxy_initializer{

--- a/contracts/token/ERC20_Upgradeable.cairo
+++ b/contracts/token/ERC20_Upgradeable.cairo
@@ -1,0 +1,186 @@
+%lang starknet
+%builtins pedersen range_check
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from contracts.token.ERC20_base import (
+    ERC20_name,
+    ERC20_symbol,
+    ERC20_totalSupply,
+    ERC20_decimals,
+    ERC20_balanceOf,
+    ERC20_allowance,
+
+    ERC20_initializer,
+    ERC20_approve,
+    ERC20_increaseAllowance,
+    ERC20_decreaseAllowance,
+    ERC20_transfer,
+    ERC20_transferFrom
+)
+
+from contracts.proxy.library import (
+    Proxy_initializer,
+    Proxy_only_admin,
+    Proxy_set_implementation
+)
+
+#
+# Initializer
+#
+
+@external
+func initializer{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(
+        name: felt,
+        symbol: felt,
+        initial_supply: Uint256,
+        recipient: felt,
+        proxy_admin: felt
+    ):
+    Proxy_initializer(proxy_admin)
+    ERC20_initializer(name, symbol, initial_supply, recipient)
+    return ()
+end
+
+@external
+func upgrade{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(new_implementation: felt):
+    Proxy_only_admin()
+    Proxy_set_implementation(new_implementation)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func name{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (name: felt):
+    let (name) = ERC20_name()
+    return (name)
+end
+
+@view
+func symbol{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (symbol: felt):
+    let (symbol) = ERC20_symbol()
+    return (symbol)
+end
+
+@view
+func totalSupply{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (totalSupply: Uint256):
+    let (totalSupply: Uint256) = ERC20_totalSupply()
+    return (totalSupply)
+end
+
+@view
+func decimals{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (decimals: felt):
+    let (decimals) = ERC20_decimals()
+    return (decimals)
+end
+
+@view
+func balanceOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(account: felt) -> (balance: Uint256):
+    let (balance: Uint256) = ERC20_balanceOf(account)
+    return (balance)
+end
+
+@view
+func allowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt, spender: felt) -> (remaining: Uint256):
+    let (remaining: Uint256) = ERC20_allowance(owner, spender)
+    return (remaining)
+end
+
+#
+# Externals
+#
+
+@external
+func transfer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(recipient: felt, amount: Uint256) -> (success: felt):
+    ERC20_transfer(recipient, amount)
+    # Cairo equivalent to 'return (true)'
+    return (1)
+end
+
+@external
+func transferFrom{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        sender: felt, 
+        recipient: felt, 
+        amount: Uint256
+    ) -> (success: felt):
+    ERC20_transferFrom(sender, recipient, amount)
+    # Cairo equivalent to 'return (true)'
+    return (1)
+end
+
+@external
+func approve{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, amount: Uint256) -> (success: felt):
+    ERC20_approve(spender, amount)
+    # Cairo equivalent to 'return (true)'
+    return (1)
+end
+
+@external
+func increaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, added_value: Uint256) -> (success: felt):
+    ERC20_increaseAllowance(spender, added_value)
+    # Cairo equivalent to 'return (true)'
+    return (1)
+end
+
+@external
+func decreaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, subtracted_value: Uint256) -> (success: felt):
+    ERC20_decreaseAllowance(spender, subtracted_value)
+    # Cairo equivalent to 'return (true)'
+    return (1)
+end

--- a/tests/mocks/dummy_implementation.cairo
+++ b/tests/mocks/dummy_implementation.cairo
@@ -1,0 +1,76 @@
+%lang starknet
+%builtins pedersen range_check
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from contracts.proxy.library import (
+    Proxy_initializer,
+    Proxy_only_admin,
+    Proxy_set_implementation
+)
+
+#
+# Storage
+#
+
+@storage_var
+func value_1() -> (res: felt):
+end
+
+#
+# Initializer
+#
+
+@external
+func initializer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(proxy_admin: felt):
+    Proxy_initializer(proxy_admin)
+    return ()
+end
+
+#
+# Upgrades
+#
+
+@external
+func upgrade{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(new_implementation: felt):
+    Proxy_only_admin()
+    Proxy_set_implementation(new_implementation)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func get_value_1{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (val: felt):
+    let (val) = value_1.read()
+    return (val)
+end
+
+#
+# Setters
+#
+
+@external
+func set_value_1{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(val: felt):
+    value_1.write(val)
+    return ()
+end

--- a/tests/mocks/dummy_implementation_v2.cairo
+++ b/tests/mocks/dummy_implementation_v2.cairo
@@ -1,0 +1,134 @@
+%lang starknet
+%builtins pedersen range_check
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from contracts.proxy.library import (
+    Proxy_initializer,
+    Proxy_only_admin,
+    Proxy_set_implementation,
+    Proxy_get_implementation,
+    Proxy_set_admin,
+    Proxy_get_admin
+)
+
+#
+# Storage
+#
+
+@storage_var
+func value_1() -> (res: felt):
+end
+
+@storage_var
+func value_2() -> (res: felt):
+end
+
+#
+# Initializer
+#
+
+@external
+func initializer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(proxy_admin: felt):
+    Proxy_initializer(proxy_admin)
+    return ()
+end
+
+#
+# Upgrades
+#
+
+@external
+func upgrade{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(new_implementation: felt):
+    Proxy_only_admin()
+    Proxy_set_implementation(new_implementation)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func get_value_1{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (val: felt):
+    let (val) = value_1.read()
+    return (val)
+end
+
+@view
+func get_value_2{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (val: felt):
+    let (val) = value_2.read()
+    return (val)
+end
+
+@view
+func get_implementation{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (address: felt):
+    let (address) = Proxy_get_implementation()
+    return (address)
+end
+
+@view
+func get_admin{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (admin: felt):
+    let (admin) = Proxy_get_admin()
+    return (admin)
+end
+
+#
+# Setters
+#
+
+@external
+func set_value_1{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(val: felt):
+    value_1.write(val)
+    return ()
+end
+
+@external
+func set_value_2{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(val: felt):
+    value_2.write(val)
+    return ()
+end
+
+@view
+func set_admin{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(new_admin: felt):
+    Proxy_only_admin()
+    Proxy_set_admin(new_admin)
+    return ()
+end

--- a/tests/test_ERC20_Upgradeable.py
+++ b/tests/test_ERC20_Upgradeable.py
@@ -1,0 +1,243 @@
+from utils import (
+    Signer, assert_revert, assert_event_emitted
+)
+from starkware.starknet.testing.starknet import Starknet, StarknetContract
+from starkware.starknet.compiler.compile import compile_starknet_files
+import pytest
+import asyncio
+from starkware.starknet.testing.starknet import Starknet
+from utils import Signer, to_uint, sub_uint, str_to_felt, assert_revert
+
+signer = Signer(123456789987654321)
+
+USER = 999
+INIT_SUPPLY = to_uint(1000)
+AMOUNT = to_uint(250)
+NAME = str_to_felt('Upgradeable Token')
+SYMBOL = str_to_felt('UTKN')
+
+
+@pytest.fixture(scope='module')
+def event_loop():
+    return asyncio.new_event_loop()
+
+
+# contract paths
+account_path = 'contracts/Account.cairo'
+proxy_path = 'contracts/proxy/Proxy.cairo'
+token_path = 'contracts/token/ERC20_Upgradeable.cairo'
+
+# random value
+VALUE = 123
+VALUE_2 = 987
+
+
+signer = Signer(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def event_loop():
+    return asyncio.new_event_loop()
+
+
+@pytest.fixture(scope='module')
+def contract_defs():
+    account_def = compile_starknet_files(
+        files=[account_path],
+        debug_info=True
+    )
+    token_def = compile_starknet_files(
+        files=[token_path],
+        debug_info=True
+    )
+    proxy_def = compile_starknet_files(
+        files=[proxy_path],
+        debug_info=True
+    )
+    return account_def, token_def, proxy_def
+
+
+@pytest.fixture(scope='module')
+async def token_init(contract_defs):
+    account_def, token_def, proxy_def = contract_defs
+    starknet = await Starknet.empty()
+    account1 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    account2 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    token_v1 = await starknet.deploy(
+        contract_def=token_def,
+        constructor_calldata=[]
+    )
+    token_v2 = await starknet.deploy(
+        contract_def=token_def,
+        constructor_calldata=[]
+    )
+    proxy = await starknet.deploy(
+        contract_def=proxy_def,
+        constructor_calldata=[token_v1.contract_address]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        token_v1,
+        token_v2,
+        proxy
+    )
+
+
+@pytest.fixture
+def token_factory(contract_defs, token_init):
+    account_def, token_def, proxy_def = contract_defs
+    state, account1, account2, token_v1, token_v2, proxy = token_init
+    _state = state.copy()
+    account1 = StarknetContract(
+        state=_state,
+        abi=account_def.abi,
+        contract_address=account1.contract_address,
+        deploy_execution_info=account1.deploy_execution_info
+    )
+    account2 = StarknetContract(
+        state=_state,
+        abi=account_def.abi,
+        contract_address=account2.contract_address,
+        deploy_execution_info=account2.deploy_execution_info
+    )
+    token_v1 = StarknetContract(
+        state=_state,
+        abi=token_def.abi,
+        contract_address=token_v1.contract_address,
+        deploy_execution_info=token_v1.deploy_execution_info
+    )
+    token_v2 = StarknetContract(
+        state=_state,
+        abi=token_def.abi,
+        contract_address=token_v2.contract_address,
+        deploy_execution_info=token_v2.deploy_execution_info
+    )
+    proxy = StarknetContract(
+        state=_state,
+        abi=proxy_def.abi,
+        contract_address=proxy.contract_address,
+        deploy_execution_info=proxy.deploy_execution_info
+    )
+    return account1, account2, token_v1, token_v2, proxy
+
+
+@pytest.fixture
+async def after_initializer(token_factory):
+    admin, other, token_v1, token_v2, proxy = token_factory
+
+    # initialize
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'initializer', [
+            NAME,
+            SYMBOL,
+            *INIT_SUPPLY,
+            admin.contract_address,
+            admin.contract_address
+        ]
+    )
+
+    return admin, other, token_v1, token_v2, proxy
+
+
+@pytest.mark.asyncio
+async def test_initializer(token_factory):
+    admin, _, _, _, proxy = token_factory
+
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'initializer', [
+            NAME,
+            SYMBOL,
+            *INIT_SUPPLY,
+            admin.contract_address,
+            admin.contract_address
+        ]
+    )
+
+    # check name
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'name', []
+    )
+    assert execution_info.result.response == [NAME]
+
+    # check symbol
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'symbol', []
+    )
+    assert execution_info.result.response == [SYMBOL]
+
+    # check total supply
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'totalSupply', []
+    )
+    assert execution_info.result.response == [*INIT_SUPPLY]
+
+
+@pytest.mark.asyncio
+async def test_upgrade(after_initializer):
+    admin, _, _, token_v2, proxy = after_initializer
+
+    # transfer
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'transfer', [
+            USER,
+            *AMOUNT
+        ]
+    )
+
+    # upgrade
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'upgrade', [
+            token_v2.contract_address
+        ]
+    )
+
+    # check admin balance
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'balanceOf', [
+            admin.contract_address
+        ]
+    )
+    assert execution_info.result.response == [*sub_uint(INIT_SUPPLY, AMOUNT)]
+
+    # check USER balance
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'balanceOf', [
+            USER
+        ]
+    )
+    assert execution_info.result.response == [*AMOUNT]
+
+    # check total supply
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'totalSupply', []
+    )
+    assert execution_info.result.response == [*INIT_SUPPLY]
+
+
+@pytest.mark.asyncio
+async def test_upgrade_from_nonadmin(after_initializer):
+    admin, non_admin, _, token_v2, proxy = after_initializer
+
+    # should revert
+    await assert_revert(
+        signer.send_transaction(
+            non_admin, proxy.contract_address, 'upgrade', [
+                token_v2.contract_address
+            ]
+        )
+    )
+
+    # should upgrade from admin
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'upgrade', [
+            token_v2.contract_address
+        ]
+    )

--- a/tests/test_Proxy.py
+++ b/tests/test_Proxy.py
@@ -1,0 +1,326 @@
+import pytest
+import asyncio
+from starkware.starknet.compiler.compile import compile_starknet_files
+from starkware.starknet.testing.starknet import Starknet, StarknetContract
+from utils import (
+    Signer, assert_revert, assert_event_emitted
+)
+
+# contract paths
+account_path = 'contracts/Account.cairo'
+proxy_path = 'contracts/proxy/Proxy.cairo'
+dummy_path = 'tests/mocks/dummy_implementation.cairo'
+dummy_path_v2 = 'tests/mocks/dummy_implementation_v2.cairo'
+
+# random value
+VALUE_1 = 123
+VALUE_2 = 987
+
+
+signer = Signer(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def event_loop():
+    return asyncio.new_event_loop()
+
+
+@pytest.fixture(scope='module')
+def contract_defs():
+    account_def = compile_starknet_files(
+        files=[account_path],
+        debug_info=True
+    )
+    dummy_v1_def = compile_starknet_files(
+        files=[dummy_path],
+        debug_info=True
+    )
+    dummy_v2_def = compile_starknet_files(
+        files=[dummy_path_v2],
+        debug_info=True
+    )
+    proxy_def = compile_starknet_files(
+        files=[proxy_path],
+        debug_info=True
+    )
+    return account_def, dummy_v1_def, dummy_v2_def, proxy_def
+
+
+@pytest.fixture(scope='module')
+async def proxy_init(contract_defs):
+    account_def, dummy_v1_def, dummy_v2_def, proxy_def = contract_defs
+    starknet = await Starknet.empty()
+    account1 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    account2 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    v1 = await starknet.deploy(
+        contract_def=dummy_v1_def,
+        constructor_calldata=[]
+    )
+    v2 = await starknet.deploy(
+        contract_def=dummy_v2_def,
+        constructor_calldata=[]
+    )
+    v3 = await starknet.deploy(
+        contract_def=dummy_v2_def,
+        constructor_calldata=[]
+    )
+    proxy = await starknet.deploy(
+        contract_def=proxy_def,
+        constructor_calldata=[v1.contract_address]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        v1,
+        v2,
+        v3,
+        proxy
+    )
+
+
+@pytest.fixture
+def proxy_factory(contract_defs, proxy_init):
+    account_def, dummy_v1_def, dummy_v2_def, proxy_def = contract_defs
+    state, account1, account2, v1, v2, v3, proxy = proxy_init
+    _state = state.copy()
+    account1 = StarknetContract(
+        state=_state,
+        abi=account_def.abi,
+        contract_address=account1.contract_address,
+        deploy_execution_info=account1.deploy_execution_info
+    )
+    account2 = StarknetContract(
+        state=_state,
+        abi=account_def.abi,
+        contract_address=account2.contract_address,
+        deploy_execution_info=account2.deploy_execution_info
+    )
+    v1 = StarknetContract(
+        state=_state,
+        abi=dummy_v1_def.abi,
+        contract_address=v1.contract_address,
+        deploy_execution_info=v1.deploy_execution_info
+    )
+    v2 = StarknetContract(
+        state=_state,
+        abi=dummy_v2_def.abi,
+        contract_address=v2.contract_address,
+        deploy_execution_info=v2.deploy_execution_info
+    )
+    v3 = StarknetContract(
+        state=_state,
+        abi=dummy_v2_def.abi,
+        contract_address=v3.contract_address,
+        deploy_execution_info=v3.deploy_execution_info
+    )
+    proxy = StarknetContract(
+        state=_state,
+        abi=proxy_def.abi,
+        contract_address=proxy.contract_address,
+        deploy_execution_info=proxy.deploy_execution_info
+    )
+    return account1, account2, v1, v2, v3, proxy
+
+
+@pytest.fixture
+async def after_upgrade(proxy_factory):
+    admin, other, v1, v2, v3, proxy = proxy_factory
+
+    # initialize
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'initializer', [
+            admin.contract_address
+        ]
+    )
+
+    # set value
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'set_value_1', [
+            VALUE_1
+        ]
+    )
+
+    # upgrade
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'upgrade', [
+            v2.contract_address
+        ]
+    )
+
+    return admin, other, v1, v2, v3, proxy
+
+
+@pytest.mark.asyncio
+async def test_initializer(proxy_factory):
+    admin, _, _, _, _, proxy = proxy_factory
+
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'initializer', [
+            admin.contract_address
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_upgrade(proxy_factory):
+    admin, _, _, v2, _, proxy = proxy_factory
+
+    # initialize implementation
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'initializer', [
+            admin.contract_address
+        ]
+    )
+
+    # set value
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'set_value_1', [
+            VALUE_1
+        ]
+    )
+
+    # check value
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'get_value_1', []
+    )
+    assert execution_info.result.response == [VALUE_1, ]
+
+    # upgrade
+    tx_exec_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'upgrade', [
+            v2.contract_address
+        ]
+    )
+
+    # check event
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=proxy.contract_address,
+        name='Upgraded',
+        data=[
+            v2.contract_address
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_upgrade_from_non_admin(proxy_factory):
+    admin, non_admin, _, v2, _, proxy = proxy_factory
+
+    # initialize implementation
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'initializer', [
+            admin.contract_address
+        ]
+    )
+
+    # upgrade should revert
+    await assert_revert(
+        signer.send_transaction(
+            non_admin, proxy.contract_address, 'upgrade', [
+                v2.contract_address
+            ]
+        )
+    )
+
+
+@pytest.mark.asyncio
+# Using `after_upgrade` fixture henceforth
+async def test_implementation_v2(after_upgrade):
+    admin, _, _, v2, _, proxy = after_upgrade
+
+    # check implementation address
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'get_implementation', []
+    )
+    assert execution_info.result.response == [v2.contract_address]
+
+    # check admin
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'get_admin', []
+    )
+    assert execution_info.result.response == [admin.contract_address]
+
+    # check value
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'get_value_1', []
+    )
+    assert execution_info.result.response == [VALUE_1, ]
+
+
+@pytest.mark.asyncio
+async def test_set_admin(after_upgrade):
+    admin, new_admin, _, _, _, proxy = after_upgrade
+
+    # change admin
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'set_admin', [
+            new_admin.contract_address
+        ]
+    )
+
+    # check admin
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'get_admin', []
+    )
+    assert execution_info.result.response == [new_admin.contract_address]
+
+
+@pytest.mark.asyncio
+async def test_set_admin_from_non_admin(after_upgrade):
+    _, non_admin, _, _, _, proxy = after_upgrade
+
+    # change admin should revert
+    await assert_revert(
+        signer.send_transaction(
+            non_admin, proxy.contract_address, 'set_admin', [
+                non_admin.contract_address
+            ]
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_implementation_v3(after_upgrade):
+    admin, _, _, _, v3, proxy = after_upgrade
+    # The dummy implementation sets a new variable in storage in v2
+    # and this tests that both v1 and v2's storage carries over to v3
+
+    # set value_2
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'set_value_2', [
+            VALUE_2
+        ]
+    )
+
+    # check value_2
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'get_value_2', []
+    )
+    assert execution_info.result.response == [VALUE_2, ]
+
+    # upgrade to v3
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'upgrade', [
+            v3.contract_address
+        ]
+    )
+
+    # check value in v3
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'get_value_1', []
+    )
+    assert execution_info.result.response == [VALUE_1, ]
+
+    # check value_2 in v3
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'get_value_2', []
+    )
+    assert execution_info.result.response == [VALUE_2, ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ from starkware.cairo.common.hash_state import compute_hash_on_elements
 from starkware.crypto.signature.signature import private_to_stark_key, sign
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
 from starkware.starkware_utils.error_handling import StarkException
+from starkware.starknet.business_logic.transaction_execution_objects import Event
 from starkware.starknet.public.abi import get_selector_from_name
 
 MAX_UINT256 = (2**128 - 1, 2**128 - 1)
@@ -47,6 +48,14 @@ def sub_uint(a, b):
     b = from_uint(b)
     c = a - b
     return to_uint(c)
+
+
+def assert_event_emitted(tx_exec_info, from_address, name, data):
+    assert Event(
+        from_address=from_address,
+        keys=[get_selector_from_name(name)],
+        data=data,
+    ) in tx_exec_info.raw_events
 
 
 async def assert_revert(fun):


### PR DESCRIPTION
This PR supercedes #129 and fixes #124. This PR proposes to include upgradeable dummy contract implementations for testing (which is inspired by OpenZeppelin's Solidity implementation). Further, this PR includes an ERC20_Upgradeable preset. 