### PR TITLE
Minor refactor for ERC721 balanceOf

### DIFF
--- a/openzeppelin/token/erc721/library.cairo
+++ b/openzeppelin/token/erc721/library.cairo
@@ -99,8 +99,8 @@ func ERC721_balanceOf{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(owner: felt) -> (balance: Uint256):
-    let (balance: Uint256) = ERC721_balances.read(owner)
     assert_not_zero(owner)
+    let (balance: Uint256) = ERC721_balances.read(owner)
     return (balance)
 end
 


### PR DESCRIPTION
https://github.com/OpenZeppelin/cairo-contracts/issues/197

In solidity implementation, we check owner first. 
```sol
    function balanceOf(address owner) public view virtual override returns (uint256) {
        require(owner != address(0), "ERC721: balance query for the zero address");
        return _balances[owner];
    }
```