### PR TITLE
change ERC165 interface ID for IAccount

### DIFF
--- a/openzeppelin/account/Account.cairo
+++ b/openzeppelin/account/Account.cairo
@@ -135,7 +135,7 @@ func constructor{
     }(_public_key: felt):
     public_key.write(_public_key)
     # Account magic value derived from ERC165 calculation of IAccount
-    ERC165_register_interface(0xbd73c577)
+    ERC165_register_interface(0xf10dbd44)
     return()
 end
 

--- a/openzeppelin/token/erc721/library.cairo
+++ b/openzeppelin/token/erc721/library.cairo
@@ -476,7 +476,7 @@ func _check_onERC721Received{
         return (TRUE)
     end
 
-    # IAccount_ID = 0x50b70dcb
-    let (is_account) = IERC165.supportsInterface(to, 0xbd73c577)
+    # IAccount_ID = 0xf10dbd44
+    let (is_account) = IERC165.supportsInterface(to, 0xf10dbd44)
     return (is_account)
 end

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -8,7 +8,7 @@ from utils import Signer
 signer = Signer(123456789987654321)
 other = Signer(987654321123456789)
 
-IACCOUNT_ID = 0xbd73c577
+IACCOUNT_ID = 0xf10dbd44
 TRUE = 1
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -110,7 +110,7 @@ class Signer():
             execution_info = await account.get_nonce().call()
             nonce, = execution_info.result
 
-        calls_with_selector = map(lambda call: (call[0], get_selector_from_name(call[1]), call[2]), calls)
+        calls_with_selector = [(call[0], get_selector_from_name(call[1]), call[2]) for call in calls]
         (call_array, calldata) = from_call_to_call_array(calls)
 
         message_hash = hash_multicall(
@@ -122,10 +122,8 @@ class Signer():
 def from_call_to_call_array(calls):
     call_array = []
     calldata = []
-    for i in range(len(calls)):
-        if len(calls[i]) != 3:
-            raise Exception("Invalid call parameters")
-        call = calls[i]
+    for i, call in enumerate(calls):
+        assert len(call) == 3, "Invalid call parameters"
         entry = (call[0], get_selector_from_name(call[1]), len(calldata), len(call[2]))
         call_array.append(entry)
         calldata.extend(call[2])


### PR DESCRIPTION
Following the latest discussions with Starkware we anticipate what the `IAccount` interface will be once account abstraction is fully implemented in StarkNet.

Based on that we compute `IAccount_interfaceID = 0xf10dbd44` according to:
```
interface IAccount {

    struct Call {
        address to;
        bytes4 selector;
        uint256 data;
    }

    function get_nonce() external;
    function is_valid_signature(bytes32, bytes32[] calldata) external;
    function __execute__(Call[] calldata) external;
    function __validate__(Call[] calldata) external;
}

contract Selector {

    // returns 0xf10dbd44
    function calculateSelector() public pure returns (bytes4) {
        IAccount i;
        return i.get_nonce.selector ^ 
        i.is_valid_signature.selector ^
        i.__execute__.selector ^
        i.__validate__.selector;
    }
}
```