### PR TITLE
Update documentation

### DIFF
--- a/docs/Account.md
+++ b/docs/Account.md
@@ -120,8 +120,8 @@ If utilizing multicall, send multiple transactions with the `send_transactions` 
     await signer.send_transactions(
         account,
         [
-            (contract_address, 'method_name', []),
-            (contract_address, 'method_name', [])
+            (contract_address, 'method_name', [param1, param2]),
+            (contract_address, 'another_method', [])
         ]
     )
 ```

--- a/docs/Account.md
+++ b/docs/Account.md
@@ -108,13 +108,13 @@ PRIVATE_KEY = 123456789987654321
 signer = Signer(PRIVATE_KEY)
 ```
 
-Then send single transactions with `send_transaction` method.
+Then send single transactions with the `send_transaction` method.
 
 ```python
 await signer.send_transaction(account, contract_address, 'method_name', [])
 ```
 
-If utilizing multicall, send multiple transactions with `send_transactions` method.
+If utilizing multicall, send multiple transactions with the `send_transactions` method.
 
 ```python
     await signer.send_transactions(
@@ -146,6 +146,7 @@ Where:
 
 - `to` is the address of the target contract of the message
 - `selector` is the selector of the function to be called on the target contract
+- `calldata_len` is the number of calldata parameters
 - `calldata` is an array representing the function parameters
 
 `MultiCall` is structured as:
@@ -270,7 +271,7 @@ None.
 
 This is the only external entrypoint to interact with the Account contract. It:
 
-1. Takes the input and builds a [Message](#message-format) with it
+1. Takes the input and builds a [Multicall](#message-format) message with it
 2. Validates the transaction signature matches the message (including the nonce)
 3. Increments the nonce
 4. Calls the target contract with the intended function selector and calldata parameters
@@ -299,11 +300,13 @@ response: felt*
 
 Certain contracts like ERC721 require a means to differentiate between account contracts and non-account contracts. For a contract to declare itself as an account, it should implement [ERC165](https://eips.ethereum.org/EIPS/eip-165) as proposed in [#100](https://github.com/OpenZeppelin/cairo-contracts/discussions/100). To be in compliance with ERC165 specifications, the idea is to calculate the XOR of `IAccount`'s EVM selectors (not StarkNet selectors). The resulting magic value of `IAccount` is 0x50b70dcb.
 
-Our ERC165 integration on StarkNet is inspired by OpenZeppelin's Solidity implementation of [ERC165Storage](https://docs.openzeppelin.com/contracts/4.x/api/utils#ERC165Storage) which stores the interfaces that the implementing contract supports. In the case of account contracts, querying `supportsInterface` of an account's address with the `IAccount` magic value should return true (meaning `1` in Cairo).
+Our ERC165 integration on StarkNet is inspired by OpenZeppelin's Solidity implementation of [ERC165Storage](https://docs.openzeppelin.com/contracts/4.x/api/utils#ERC165Storage) which stores the interfaces that the implementing contract supports. In the case of account contracts, querying `supportsInterface` of an account's address with the `IAccount` magic value should return `TRUE`.
 
 ## Extending the Account contract
 
-There's no clear contract extensibility pattern for Cairo smart contracts yet. In the meantime the best way to extend our contracts is copypasting and modifying them at your own risk. Since `__execute__` relies on it, we suggest changing how `is_valid_signature` works to explore different signature validation schemes such as multisig, or some guardian logic like in [Argent's account](https://github.com/argentlabs/argent-contracts-starknet/blob/de5654555309fa76160ba3d7393d32d2b12e7349/contracts/ArgentAccount.cairo).
+Account contracts can be extended by following the [extensibility pattern](../docs/Extensibility.md#the-pattern). The basic idea behind integrating the pattern is to import the requisite methods from the Account library and incorporate the extended logic thereafter. The Account library is constructed to accomodate the current validation scheme; however, new schemes may require amending or adding methods in the library. 
+
+Since `__execute__` relies on it, we suggest changing how `is_valid_signature` works to explore different signature validation schemes such as multisig, some guardian logic like in [Argent's account](https://github.com/argentlabs/argent-contracts-starknet/blob/de5654555309fa76160ba3d7393d32d2b12e7349/contracts/ArgentAccount.cairo), or even [Ethereum signatures](https://github.com/OpenZeppelin/cairo-contracts/issues/161).
 
 
 ## L1 escape hatch mechanism

--- a/docs/ERC20.md
+++ b/docs/ERC20.md
@@ -142,7 +142,7 @@ func transfer{
 end
 ```
 
-Note that extensibility does not have to be library-based like in the above example. For instance, an ERC20 contract with a pausing mechanism can define the pausing methods directly in the contract or even import the `pausable` methods from the library and tailor them further.
+Note that extensibility does not have to be only library-based like in the above example. For instance, an ERC20 contract with a pausing mechanism can define the pausing methods directly in the contract or even import the `pausable` methods from the library and tailor them further.
 
 Some other ways to extend ERC20 contracts may include:
 - Implementing a minting mechanism

--- a/docs/ERC20.md
+++ b/docs/ERC20.md
@@ -66,7 +66,8 @@ end
 Although StarkNet is not EVM compatible, this implementation aims to be as close as possible to the ERC20 standard, in the following ways:
 
 - it uses Cairo's `uint256` instead of `felt`
-- it returns `1` as success to imitate a `bool`
+- it returns `TRUE` (a constant representing `1`) as success to imitate a `bool`
+- it accepts a `felt` argument for `decimals` in the constructor calldata with a max value of 2^8 (imitating `uint8` type)
 - it makes use of Cairo's short strings to simulate `name` and `symbol`
 
 But some differences can still be found, such as:

--- a/docs/ERC20.md
+++ b/docs/ERC20.md
@@ -142,7 +142,7 @@ func transfer{
 end
 ```
 
-Some other ways to extend contracts may include:
+Some other ways to extend ERC20 contracts may include:
 - Implementing a minting mechanism
 - Creating a timelock
 - Adding roles such as owner or minter

--- a/docs/ERC20.md
+++ b/docs/ERC20.md
@@ -8,6 +8,11 @@ The ERC20 token standard is a specification for [fungible tokens](https://docs.o
   * [ERC20 compatibility](#erc20-compatibility)
 - [Usage](#usage)
 - [Extensibility](#extensibility)
+- [Presets](#presets)
+  * [ERC20 (basic)](#erc20-(basic))
+  * [ERC20_Mintable](#erc20_mintable)
+  * [ERC20_Pausable](#erc20_pausable)
+  * [ERC20_Upgradeable](#erc20_upgradeable)
 - [API Specification](#api-specification)
   * [Methods](#-methods-)
     * [`name`](#-name-)
@@ -66,14 +71,13 @@ end
 Although StarkNet is not EVM compatible, this implementation aims to be as close as possible to the ERC20 standard, in the following ways:
 
 - it uses Cairo's `uint256` instead of `felt`
-- it returns `TRUE` (a constant representing `1`) as success to imitate a `bool`
+- it returns `TRUE` (a constant representing `1`) as success
 - it accepts a `felt` argument for `decimals` in the constructor calldata with a max value of 2^8 (imitating `uint8` type)
 - it makes use of Cairo's short strings to simulate `name` and `symbol`
 
 But some differences can still be found, such as:
 
-- `decimals` returns a 252-bit `felt`, meaning it can be much larger than the standard's 8-bit `uint8`. However, compliant implementations should not return a value that is not representable in `uint8`.
-- `transfer`, `transferFrom` and `approve` will never return anything different from true (`1`) because they will revert on any error
+- `transfer`, `transferFrom` and `approve` will never return anything different from `TRUE` because they will revert on any error
 - function selectors are calculated differently between [Cairo](https://github.com/starkware-libs/cairo-lang/blob/7712b21fc3b1cb02321a58d0c0579f5370147a8b/src/starkware/starknet/public/abi.py#L25) and [Solidity](https://solidity-by-example.org/function-selector/)
 
 ## Usage
@@ -107,8 +111,6 @@ erc20 = await starknet.deploy(
 )
 ```
 
-> Note that decimals should not exceed `2^8` to be ERC20 compatible.
-
 As most StarkNet contracts, it expects to be called by another contract and it identifies it through `get_caller_address` (analogous to Solidity's `this.address`). This is why we need an Account contract to interact with it. For example:
 
 ```python
@@ -125,13 +127,47 @@ await signer.send_transaction(account, erc20.contract_address, 'transfer', [reci
 
 ## Extensibility
 
-There's no clear contract extensibility pattern for Cairo smart contracts yet. In the meantime the best way to extend our contracts is copypasting and modifying them at your own risk.
+ERC20 contracts can be extended by following the [extensibility pattern](../docs/Extensibility.md#the-pattern). The basic idea behind integrating the pattern is to import the requisite ERC20 methods from the ERC20 library and incorporate the extended logic thereafter. For example, let's say you wanted to implement a pausing mechanism. The contract should first import the ERC20 methods (and the extended logic if it's in a separate contract). Next, the contract should expose the methods with the extended logic therein like this:
 
-For example, you could:
+```python
+@external
+func transfer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(recipient: felt, amount: Uint256) -> (success: felt):
+    Pausable_when_not_paused()            # imported extended logic
+    ERC20_transfer(recipient, amount)     # imported library method
+    return (TRUE)
+end
+```
 
-- Implement a pausing mechanism
-- Add roles such as owner or minter
-- Modify the `_transfer` function to perform actions [before](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol#L229) or after [transfers](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol#L240)
+Some other ways to extend contracts may include:
+- Implementing a minting mechanism
+- Creating a timelock
+- Adding roles such as owner or minter
+
+For full examples of the extensibility pattern being used in ERC20 contracts, see [Presets](#presets).
+
+## Presets
+
+The following contract presets are ready to deploy and can be used as-is for quick prototyping and testing. Each preset mints an initial supply which is especially necessary for presets that do not expose a `mint` method.
+
+### ERC20 (basic)
+
+The `ERC20` preset offers a quick and easy setup for deploying a basic ERC20 token.
+
+### ERC20_Mintable
+
+The `ERC20_Mintable` preset allows the contract owner to mint new tokens. 
+
+### ERC20_Pausable
+
+The `ERC20_Pausable` preset allows the contract owner to pause/unpause all state-modifying methods i.e. `transfer`, `approve`, etc. This preset proves useful for scenarios such as preventing trades until the end of an evaluation period and having an emergency switch for freezing all token transfers in the event of a large bug.
+
+### ERC20_Upgradeable
+
+The `ERC20_Upgradeable` preset allows the contract owner to upgrade a contract by deploying a new ERC20 implementation contract while also maintaing the contract's state. This preset proves useful for scenarios such as eliminating bugs and adding new features. For more on upgradeability, see [Contract upgrades](../docs/Proxy.md#contract-upgrades).
 
 ## API Specification
 

--- a/docs/ERC20.md
+++ b/docs/ERC20.md
@@ -129,6 +129,8 @@ await signer.send_transaction(account, erc20.contract_address, 'transfer', [reci
 
 ERC20 contracts can be extended by following the [extensibility pattern](../docs/Extensibility.md#the-pattern). The basic idea behind integrating the pattern is to import the requisite ERC20 methods from the ERC20 library and incorporate the extended logic thereafter. For example, let's say you wanted to implement a pausing mechanism. The contract should first import the ERC20 methods (and the extended logic if it's in a separate contract). Next, the contract should expose the methods with the extended logic therein like this:
 
+ERC20 contracts can be extended by following the [extensibility pattern](../docs/Extensibility.md#the-pattern). The basic idea behind integrating the pattern is to import the requisite ERC20 methods from the ERC20 library and incorporate the extended logic thereafter. For example, let's say you wanted to implement a pausing mechanism. The contract should first import the ERC20 methods and the extended logic from the [pausable library](../openzeppelin/security/pausable.cairo) i.e. `Pausable_pause`, `Pausable_unpause`. Next, the contract should expose the methods with the extended logic therein like this:
+
 ```python
 @external
 func transfer{
@@ -141,6 +143,8 @@ func transfer{
     return (TRUE)
 end
 ```
+
+Note that extensibility does not have to be library-based like in the above example. For instance, an ERC20 contract with a pausing mechanism can define the pausing methods directly in the contract or even import the `pausable` methods from the library and tailor them further.
 
 Some other ways to extend ERC20 contracts may include:
 - Implementing a minting mechanism
@@ -155,19 +159,19 @@ The following contract presets are ready to deploy and can be used as-is for qui
 
 ### ERC20 (basic)
 
-The `ERC20` preset offers a quick and easy setup for deploying a basic ERC20 token.
+The [`ERC20`](../openzeppelin/token/erc20/ERC20.cairo) preset offers a quick and easy setup for deploying a basic ERC20 token.
 
 ### ERC20_Mintable
 
-The `ERC20_Mintable` preset allows the contract owner to mint new tokens. 
+The [`ERC20_Mintable`](../openzeppelin/token/erc20/ERC20_Mintable.cairo) preset allows the contract owner to mint new tokens. 
 
 ### ERC20_Pausable
 
-The `ERC20_Pausable` preset allows the contract owner to pause/unpause all state-modifying methods i.e. `transfer`, `approve`, etc. This preset proves useful for scenarios such as preventing trades until the end of an evaluation period and having an emergency switch for freezing all token transfers in the event of a large bug.
+The [`ERC20_Pausable`](../openzeppelin/token/erc20/ERC20_Pausable.cairo) preset allows the contract owner to pause/unpause all state-modifying methods i.e. `transfer`, `approve`, etc. This preset proves useful for scenarios such as preventing trades until the end of an evaluation period and having an emergency switch for freezing all token transfers in the event of a large bug.
 
 ### ERC20_Upgradeable
 
-The `ERC20_Upgradeable` preset allows the contract owner to upgrade a contract by deploying a new ERC20 implementation contract while also maintaing the contract's state. This preset proves useful for scenarios such as eliminating bugs and adding new features. For more on upgradeability, see [Contract upgrades](../docs/Proxy.md#contract-upgrades).
+The [`ERC20_Upgradeable`](../openzeppelin/token/erc20/ERC20_Upgradeable.cairo) preset allows the contract owner to upgrade a contract by deploying a new ERC20 implementation contract while also maintaing the contract's state. This preset proves useful for scenarios such as eliminating bugs and adding new features. For more on upgradeability, see [Contract upgrades](../docs/Proxy.md#contract-upgrades).
 
 ## API Specification
 

--- a/docs/ERC20.md
+++ b/docs/ERC20.md
@@ -127,8 +127,6 @@ await signer.send_transaction(account, erc20.contract_address, 'transfer', [reci
 
 ## Extensibility
 
-ERC20 contracts can be extended by following the [extensibility pattern](../docs/Extensibility.md#the-pattern). The basic idea behind integrating the pattern is to import the requisite ERC20 methods from the ERC20 library and incorporate the extended logic thereafter. For example, let's say you wanted to implement a pausing mechanism. The contract should first import the ERC20 methods (and the extended logic if it's in a separate contract). Next, the contract should expose the methods with the extended logic therein like this:
-
 ERC20 contracts can be extended by following the [extensibility pattern](../docs/Extensibility.md#the-pattern). The basic idea behind integrating the pattern is to import the requisite ERC20 methods from the ERC20 library and incorporate the extended logic thereafter. For example, let's say you wanted to implement a pausing mechanism. The contract should first import the ERC20 methods and the extended logic from the [pausable library](../openzeppelin/security/pausable.cairo) i.e. `Pausable_pause`, `Pausable_unpause`. Next, the contract should expose the methods with the extended logic therein like this:
 
 ```python

--- a/docs/Extensibility.md
+++ b/docs/Extensibility.md
@@ -87,7 +87,6 @@ func transfer{
     }(recipient: felt, amount: Uint256) -> (success: felt):
     Pausable_when_not_paused()
     ERC20_transfer(recipient, amount)
-    # Cairo equivalent to 'return (true)'
-    return (1)
+    return (TRUE)
 end
 ```

--- a/docs/Extensibility.md
+++ b/docs/Extensibility.md
@@ -50,15 +50,15 @@ Presets are pre-written contracts that extend from our library of contracts. The
 
 Some presets are:
 
-- [Ownable](https://github.com/OpenZeppelin/cairo-contracts/blob/main/contracts/Ownable.cairo)
-- [ERC20](https://github.com/OpenZeppelin/cairo-contracts/blob/main/contracts/token/ERC20.cairo)
-  - [ERC20_Mintable](https://github.com/OpenZeppelin/cairo-contracts/blob/main/contracts/token/ERC20_Mintable.cairo)
-  - [ERC20_Pausable](https://github.com/OpenZeppelin/cairo-contracts/blob/main/contracts/token/ERC20_Pausable.cairo)
-- [ERC165](https://github.com/OpenZeppelin/cairo-contracts/blob/main/contracts/ERC165.cairo)
-- [ERC721](https://github.com/OpenZeppelin/cairo-contracts/blob/main/contracts/token/ERC721.cairo)
-  - [ERC721_Enumerable](https://github.com/OpenZeppelin/cairo-contracts/blob/main/contracts/token/ERC721_Enumerable.cairo)
-  - [ERC721_Mintable](https://github.com/OpenZeppelin/cairo-contracts/blob/main/contracts/token/ERC721_Mintable.cairo)
-  - [ERC721_Pausable](https://github.com/OpenZeppelin/cairo-contracts/blob/main/contracts/token/ERC721_Pausable.cairo)
+- [Account](../openzeppelin/account/Account.cairo)
+- [ERC165](../tests/mocks/ERC165.cairo)
+- [ERC20_Mintable](../openzeppelin/token/erc20/ERC20_Mintable.cairo)
+- [ERC20_Pausable](../openzeppelin/token/erc20/ERC20_Pausable.cairo)
+- [ERC20_Upgradeable](../openzeppelin/token/erc20/ERC20_Upgradeable.cairo)
+- [ERC20](../openzeppelin/token/erc20/ERC20.cairo)
+- [ERC721_Mintable_Burnable](../openzeppelin/token/erc721/ERC721_Mintable_Burnable.cairo)
+- [ERC721_Mintable_Pausable](../openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo)
+- [ERC721_Enumerable_Mintable_Burnable](../openzeppelin/token/erc721_enum/ERC721_Enumerable_Mintable_Burnable.cairo)
 
 ## Emulating hooks
 


### PR DESCRIPTION
This PR updates ERC20, Extensibility, and Account docs. 

In the ERC20 docs, this PR:
- updates `Extensibility` section to include the extensibility pattern
- adds an example to construct an exposed method with extended logic
- proposes to add a `Presets` section
- fixes some of the documentation in regard to ERC20 compliance

In the Extensibility docs, this PR:
- updates `Presets`
- fixes code snippet

In the Account docs, this PR:
- updates all references to the interface (mainly `__execute__` and its params)
- adds documentation for multicall
- provides an example of multicall
- fixes `Extensibility` section

This resolves #206.