### PR TITLE
Fix pytest warnings, move `event_loop` to conftest.py

### DIFF
--- a/tests/access/test_Ownable.py
+++ b/tests/access/test_Ownable.py
@@ -1,14 +1,9 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import Signer, contract_path
 
+
 signer = Signer(123456789987654321)
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -1,20 +1,15 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
 from utils import Signer, assert_revert, contract_path
+
 
 signer = Signer(123456789987654321)
 other = Signer(987654321123456789)
 
 IACCOUNT_ID = 0xf10dbd44
 TRUE = 1
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/account/test_AddressRegistry.py
+++ b/tests/account/test_AddressRegistry.py
@@ -1,16 +1,11 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import Signer, contract_path
+
 
 signer = Signer(123456789987654321)
 L1_ADDRESS = 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
 ANOTHER_ADDRESS = 0xd9e1ce17f2641f24ae83637ab66a2cca9c378b9f
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+import asyncio
+
+@pytest.fixture(scope='module')
+def event_loop():
+    return asyncio.new_event_loop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,3 +4,4 @@ import asyncio
 @pytest.fixture(scope='module')
 def event_loop():
     return asyncio.new_event_loop()
+    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,4 +4,3 @@ import asyncio
 @pytest.fixture(scope='module')
 def event_loop():
     return asyncio.new_event_loop()
-    

--- a/tests/introspection/test_ERC165.py
+++ b/tests/introspection/test_ERC165.py
@@ -1,16 +1,12 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import assert_revert, contract_path
 
+
+# interface ids
 ERC165_ID = 0x01ffc9a7
 INVALID_ID = 0xffffffff
 OTHER_ID = 0x12345678
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/security/test_safemath.py
+++ b/tests/security/test_safemath.py
@@ -1,15 +1,9 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
     MAX_UINT256, assert_revert, add_uint, sub_uint,
     mul_uint, div_rem_uint, to_uint, contract_path
 )
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/token/erc20/test_ERC20.py
+++ b/tests/token/erc20/test_ERC20.py
@@ -1,17 +1,12 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
     Signer, uint, str_to_felt, MAX_UINT256, INVALID_UINT256, ZERO_ADDRESS,
     assert_event_emitted, assert_revert, sub_uint, add_uint, contract_path
 )
 
+
 signer = Signer(123456789987654321)
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/token/erc20/test_ERC20_Burnable_mock.py
+++ b/tests/token/erc20/test_ERC20_Burnable_mock.py
@@ -8,12 +8,8 @@ from utils import (
     contract_path
 )
 
+
 signer = Signer(123456789987654321)
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/token/erc20/test_ERC20_Mintable.py
+++ b/tests/token/erc20/test_ERC20_Mintable.py
@@ -1,5 +1,4 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
     Signer, uint, str_to_felt, MAX_UINT256, ZERO_ADDRESS, INVALID_UINT256,
@@ -10,11 +9,6 @@ signer = Signer(123456789987654321)
 
 # random address
 RECIPIENT = 789
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/token/erc20/test_ERC20_Pausable.py
+++ b/tests/token/erc20/test_ERC20_Pausable.py
@@ -1,14 +1,9 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import Signer, uint, str_to_felt, assert_revert, contract_path
 
+
 signer = Signer(123456789987654321)
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/token/erc20/test_ERC20_Upgradeable.py
+++ b/tests/token/erc20/test_ERC20_Upgradeable.py
@@ -1,10 +1,10 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
     Signer, to_uint, sub_uint, str_to_felt, assert_revert,
-    get_contract_def, cached_contract, assert_event_emitted
+    get_contract_def, cached_contract
 )
+
 
 signer = Signer(123456789987654321)
 
@@ -14,24 +14,6 @@ AMOUNT = to_uint(250)
 NAME = str_to_felt('Upgradeable Token')
 SYMBOL = str_to_felt('UTKN')
 DECIMALS = 18
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
-
-
-# random value
-VALUE = 123
-VALUE_2 = 987
-
-
-signer = Signer(123456789987654321)
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/token/erc721/test_ERC721_Mintable_Burnable.py
+++ b/tests/token/erc721/test_ERC721_Mintable_Burnable.py
@@ -1,10 +1,10 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
     Signer, str_to_felt, ZERO_ADDRESS, TRUE, FALSE, assert_revert, INVALID_UINT256,
     assert_event_emitted, get_contract_def, cached_contract, to_uint, sub_uint, add_uint
 )
+
 
 signer = Signer(123456789987654321)
 
@@ -27,11 +27,6 @@ IERC721_ID = 0x80ac58cd
 IERC721_METADATA_ID = 0x5b5e139f
 INVALID_ID = 0xffffffff
 UNSUPPORTED_ID = 0xabcd1234
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/token/erc721/test_ERC721_Mintable_Pausable.py
+++ b/tests/token/erc721/test_ERC721_Mintable_Pausable.py
@@ -1,23 +1,17 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
     Signer, str_to_felt, TRUE, FALSE, get_contract_def, cached_contract, assert_revert, to_uint
 )
 
-signer = Signer(123456789987654321)
 
+signer = Signer(123456789987654321)
 
 # random token IDs
 TOKENS = [to_uint(5042), to_uint(793)]
 TOKEN_TO_MINT = to_uint(33)
 # random data (mimicking bytes in Solidity)
 DATA = [0x42, 0x89, 0x55]
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/token/erc721/test_ERC721_SafeMintable_mock.py
+++ b/tests/token/erc721/test_ERC721_SafeMintable_mock.py
@@ -1,10 +1,10 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
     Signer, str_to_felt, ZERO_ADDRESS, INVALID_UINT256, assert_revert,
     assert_event_emitted, get_contract_def, cached_contract, to_uint
 )
+
 
 signer = Signer(123456789987654321)
 
@@ -12,11 +12,6 @@ signer = Signer(123456789987654321)
 TOKEN = to_uint(5042)
 # random data (mimicking bytes in Solidity)
 DATA = [0x42, 0x89, 0x55]
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/token/erc721_enumerable/test_ERC721_Enumerable_Mintable_Burnable.py
+++ b/tests/token/erc721_enumerable/test_ERC721_Enumerable_Mintable_Burnable.py
@@ -1,10 +1,10 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
     Signer, str_to_felt, MAX_UINT256, get_contract_def, cached_contract,
     TRUE, assert_revert, to_uint, sub_uint, add_uint
 )
+
 
 signer = Signer(123456789987654321)
 
@@ -20,11 +20,6 @@ RECIPIENT = 555
 DATA = [0x42, 0x89, 0x55]
 # selector id
 ENUMERABLE_INTERFACE_ID = 0x780e9d63
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/upgrades/test_Proxy.py
+++ b/tests/upgrades/test_Proxy.py
@@ -1,19 +1,14 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
     Signer, assert_revert, get_contract_def, cached_contract
 )
 
+
 # random value
 VALUE = 123
 
 signer = Signer(123456789987654321)
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/upgrades/test_upgrades.py
+++ b/tests/upgrades/test_upgrades.py
@@ -1,21 +1,15 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
     Signer, assert_revert, assert_event_emitted, get_contract_def, cached_contract
 )
 
+
 # random value
 VALUE_1 = 123
 VALUE_2 = 987
 
-
 signer = Signer(123456789987654321)
-
-
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope='module')

--- a/tox.ini
+++ b/tox.ini
@@ -27,3 +27,6 @@ deps =
 commands =
     python -m build . -o dist
     python -m twine check --strict dist/*
+
+[pytest]
+asyncio_mode=auto


### PR DESCRIPTION
This PR proposes to add `auto` mode to pytest-asyncio in `tox.ini`. This eliminates the myriad deprecation warnings from pytest when running tests (while also keeping the code up to date). Note that users can override `pytest-asyncio` with other async frameworks if they prefer.

This PR also proposes to add the `event_loop` to the `conftest.py` module. In doing so, all other `event_loop` instances can be discarded. 