### PR TITLE
use `tx_info.transaction_hash` instead of `hash_multicall` in Account

### DIFF
--- a/src/openzeppelin/account/library.cairo
+++ b/src/openzeppelin/account/library.cairo
@@ -16,20 +16,9 @@ from openzeppelin.introspection.ERC165 import (
     ERC165_register_interface
 )
 
-from openzeppelin.utils.constants import PREFIX_TRANSACTION 
-
 #
 # Structs
 #
-
-struct MultiCall:
-    member account: felt
-    member calls_len: felt
-    member calls: Call*
-    member nonce: felt
-    member max_fee: felt
-    member version: felt
-end
 
 struct Call:
     member to: felt
@@ -182,25 +171,15 @@ func Account_execute{
     from_call_array_to_call(call_array_len, call_array, calldata, calls)
     let calls_len = call_array_len
 
-    local multicall: MultiCall = MultiCall(
-        tx_info.account_contract_address,
-        calls_len,
-        calls,
-        _current_nonce,
-        tx_info.max_fee,
-        tx_info.version
-    )
-
     # validate transaction
-    let (hash) = hash_multicall(&multicall)
-    Account_is_valid_signature(hash, tx_info.signature_len, tx_info.signature)
+    Account_is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature)
 
     # bump nonce
     Account_current_nonce.write(_current_nonce + 1)
 
     # execute call
     let (response : felt*) = alloc()
-    let (response_len) = execute_list(multicall.calls_len, multicall.calls, response)
+    let (response_len) = execute_list(calls_len, calls, response)
 
     return (response_len=response_len, response=response)
 end
@@ -230,92 +209,6 @@ func execute_list{syscall_ptr: felt*}(
     # do the next calls recursively
     let (response_len) = execute_list(calls_len - 1, calls + Call.SIZE, response + res.retdata_size)
     return (response_len + res.retdata_size)
-end
-
-func hash_multicall{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*
-    } (
-        multicall: MultiCall*
-    ) -> (res: felt):
-    alloc_locals
-    let (calls_hash) = hash_call_array(multicall.calls_len, multicall.calls)
-    let hash_ptr = pedersen_ptr
-    with hash_ptr:
-        let (hash_state_ptr) = hash_init()
-        let (hash_state_ptr) = hash_update_single(hash_state_ptr, PREFIX_TRANSACTION)
-        let (hash_state_ptr) = hash_update_single(hash_state_ptr, multicall.account)
-        let (hash_state_ptr) = hash_update_single(hash_state_ptr, calls_hash)
-        let (hash_state_ptr) = hash_update_single(hash_state_ptr, multicall.nonce)
-        let (hash_state_ptr) = hash_update_single(hash_state_ptr, multicall.max_fee)
-        let (hash_state_ptr) = hash_update_single(hash_state_ptr, multicall.version)
-        let (res) = hash_finalize(hash_state_ptr)
-        let pedersen_ptr = hash_ptr
-        return (res=res)
-    end
-end
-
-func hash_call_array{pedersen_ptr: HashBuiltin*}(
-        calls_len: felt,
-        calls: Call*
-    ) -> (res: felt):
-    alloc_locals
-
-    # convert [call] to [Hash(call)]
-    let (hash_array : felt*) = alloc()
-    hash_call_loop(calls_len, calls, hash_array)
-
-    # hash [Hash(call)]
-    let hash_ptr = pedersen_ptr
-    with hash_ptr:
-        let (hash_state_ptr) = hash_init()
-        let (hash_state_ptr) = hash_update(hash_state_ptr, hash_array, calls_len)
-        let (res) = hash_finalize(hash_state_ptr)
-        let pedersen_ptr = hash_ptr
-        return (res=res)
-    end
-end
-
-func hash_call_loop{pedersen_ptr: HashBuiltin*}(
-        calls_len: felt,
-        calls: Call*,
-        hash_array: felt*
-    ):
-    if calls_len == 0:
-        return ()
-    end
-    let this_call = [calls]
-    let (calldata_hash) = hash_calldata(this_call.calldata_len, this_call.calldata)
-    let hash_ptr = pedersen_ptr
-    with hash_ptr:
-        let (hash_state_ptr) = hash_init()
-        let (hash_state_ptr) = hash_update_single(hash_state_ptr, this_call.to)
-        let (hash_state_ptr) = hash_update_single(hash_state_ptr, this_call.selector)
-        let (hash_state_ptr) = hash_update_single(hash_state_ptr, calldata_hash)
-        let (res) = hash_finalize(hash_state_ptr)
-        let pedersen_ptr = hash_ptr
-        assert [hash_array] = res
-    end
-    hash_call_loop(calls_len - 1, calls + Call.SIZE, hash_array + 1)
-    return()
-end
-
-func hash_calldata{pedersen_ptr: HashBuiltin*}(
-        calldata_len: felt,
-        calldata: felt*
-    ) -> (res: felt):
-    let hash_ptr = pedersen_ptr
-    with hash_ptr:
-        let (hash_state_ptr) = hash_init()
-        let (hash_state_ptr) = hash_update(
-            hash_state_ptr,
-            calldata,
-            calldata_len
-        )
-        let (res) = hash_finalize(hash_state_ptr)
-        let pedersen_ptr = hash_ptr
-        return (res=res)
-    end
 end
 
 func from_call_array_to_call{syscall_ptr: felt*}(

--- a/src/openzeppelin/utils/constants.cairo
+++ b/src/openzeppelin/utils/constants.cairo
@@ -11,12 +11,6 @@ const TRUE = 1
 const FALSE = 0
 
 #
-# Hashing Transactions
-#
-
-const PREFIX_TRANSACTION = 'StarkNet Transaction'
-
-#
 # Numbers
 #
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,7 +9,8 @@ from starkware.starknet.compiler.compile import compile_starknet_files
 from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.testing.starknet import StarknetContract
 from starkware.starknet.business_logic.transaction_execution_objects import Event
-
+from starkware.starknet.core.os.transaction_hash import calculate_transaction_hash_common, TransactionHashPrefix
+from starkware.starknet.definitions.general_config import StarknetChainId
 
 MAX_UINT256 = (2**128 - 1, 2**128 - 1)
 INVALID_UINT256 = (MAX_UINT256[0] + 1, MAX_UINT256[1])
@@ -178,8 +179,7 @@ class Signer():
             (call[0], get_selector_from_name(call[1]), call[2]) for call in calls]
         (call_array, calldata) = from_call_to_call_array(calls)
 
-        message_hash = hash_multicall(
-            account.contract_address, calls_with_selector, nonce, max_fee)
+        message_hash = get_transaction_hash(account, call_array, calldata, nonce, max_fee)
         sig_r, sig_s = self.sign(message_hash)
 
         return await account.__execute__(call_array, calldata, nonce).invoke(signature=[sig_r, sig_s])
@@ -196,19 +196,21 @@ def from_call_to_call_array(calls):
         calldata.extend(call[2])
     return (call_array, calldata)
 
+def get_transaction_hash(account, call_array, calldata, nonce, max_fee):
+    execute_calldata = [
+        len(call_array),
+        *[x for t in call_array for x in t],
+        len(calldata),
+        *calldata,
+        nonce]
 
-def hash_multicall(sender, calls, nonce, max_fee):
-    hash_array = []
-    for call in calls:
-        call_elements = [call[0], call[1], compute_hash_on_elements(call[2])]
-        hash_array.append(compute_hash_on_elements(call_elements))
-
-    message = [
-        str_to_felt('StarkNet Transaction'),
-        sender,
-        compute_hash_on_elements(hash_array),
-        nonce,
+    return calculate_transaction_hash_common(
+        TransactionHashPrefix.INVOKE,
+        TRANSACTION_VERSION,
+        account,
+        get_selector_from_name('__execute__'),
+        execute_calldata,
         max_fee,
-        TRANSACTION_VERSION
-    ]
-    return compute_hash_on_elements(message)
+        StarknetChainId.TESTNET.value,
+        []
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -179,7 +179,7 @@ class Signer():
             (call[0], get_selector_from_name(call[1]), call[2]) for call in calls]
         (call_array, calldata) = from_call_to_call_array(calls)
 
-        message_hash = get_transaction_hash(account, call_array, calldata, nonce, max_fee)
+        message_hash = get_transaction_hash(account.contract_address, call_array, calldata, nonce, max_fee)
         sig_r, sig_s = self.sign(message_hash)
 
         return await account.__execute__(call_array, calldata, nonce).invoke(signature=[sig_r, sig_s])


### PR DESCRIPTION
Since 0.8.0, the transaction hash is available to the account as part of the `tx_info` object.

The transaction hash is a hash chain of all the information of the transaction:

- A prefix that depends on the transaction type.
- The transaction's version.
- The Account address.
- The Entry point selector.
- A hash chain of the calldata (multicall + nonce).
- The transaction's maximum fee.
- The network's chain ID.

It can thus be used to authorise transactions on an account.

This PR replaces the custom `hash_multicall` method by the transaction hash.