### PR TITLE
added ownership transfer, renounce, getter, and event

### DIFF
--- a/src/openzeppelin/access/ownable.cairo
+++ b/src/openzeppelin/access/ownable.cairo
@@ -6,6 +6,10 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
 
+@event
+func OwnershipTransferred(previous_owner : felt, new_owner : felt):
+end
+
 @storage_var
 func Ownable_owner() -> (owner: felt):
 end
@@ -47,6 +51,18 @@ func Ownable_transfer_ownership{
         range_check_ptr
     }(new_owner: felt) -> (new_owner: felt):
     Ownable_only_owner()
+    let (old_owner) = Ownable_owner.read()
     Ownable_owner.write(new_owner)
+    OwnershipTransferred.emit(previous_owner=old_owner, new_owner=new_owner)
     return (new_owner=new_owner)
+end
+
+func Ownable_renounce_ownership{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (new_owner : felt):
+    Ownable_only_owner()
+    Ownable_transfer_ownership(0)
+    return (new_owner=0)
 end

--- a/src/openzeppelin/token/erc20/ERC20_Mintable.cairo
+++ b/src/openzeppelin/token/erc20/ERC20_Mintable.cairo
@@ -25,7 +25,10 @@ from openzeppelin.token.erc20.library import (
 
 from openzeppelin.access.ownable import (
     Ownable_initializer,
-    Ownable_only_owner
+    Ownable_only_owner,
+    Ownable_get_owner,
+    Ownable_transfer_ownership,
+    Ownable_renounce_ownership
 )
 
 from openzeppelin.utils.constants import TRUE
@@ -180,4 +183,34 @@ func mint{
     Ownable_only_owner()
     ERC20_mint(to, amount)
     return ()
+end
+
+@view
+func owner{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (owner : felt):
+    let (owner) = Ownable_get_owner()
+    return (owner=owner)
+end
+
+@external
+func transferOwnership{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(new_owner: felt) -> (new_owner: felt):
+    let (new_owner) = Ownable_transfer_ownership(new_owner=new_owner)
+    return (new_owner=new_owner)
+end
+
+@external
+func renounceOwnership{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (new_owner : felt):
+    let (new_owner) = Ownable_renounce_ownership()
+    return (new_owner=new_owner)
 end

--- a/src/openzeppelin/token/erc20/ERC20_Pausable.cairo
+++ b/src/openzeppelin/token/erc20/ERC20_Pausable.cairo
@@ -25,7 +25,10 @@ from openzeppelin.token.erc20.library import (
 
 from openzeppelin.access.ownable import (
     Ownable_initializer,
-    Ownable_only_owner
+    Ownable_only_owner,
+    Ownable_get_owner,
+    Ownable_transfer_ownership,
+    Ownable_renounce_ownership
 )
 
 from openzeppelin.security.pausable import (
@@ -213,4 +216,34 @@ func unpause{
     Ownable_only_owner()
     Pausable_unpause()
     return ()
+end
+
+@view
+func owner{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (owner : felt):
+    let (owner) = Ownable_get_owner()
+    return (owner=owner)
+end
+
+@external
+func transferOwnership{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(new_owner: felt) -> (new_owner: felt):
+    let (new_owner) = Ownable_transfer_ownership(new_owner=new_owner)
+    return (new_owner=new_owner)
+end
+
+@external
+func renounceOwnership{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (new_owner : felt):
+    let (new_owner) = Ownable_renounce_ownership()
+    return (new_owner=new_owner)
 end

--- a/src/openzeppelin/token/erc721/ERC721_Mintable_Burnable.cairo
+++ b/src/openzeppelin/token/erc721/ERC721_Mintable_Burnable.cairo
@@ -30,7 +30,10 @@ from openzeppelin.introspection.ERC165 import ERC165_supports_interface
 
 from openzeppelin.access.ownable import (
     Ownable_initializer,
-    Ownable_only_owner
+    Ownable_only_owner,
+    Ownable_get_owner,
+    Ownable_transfer_ownership,
+    Ownable_renounce_ownership
 )
 
 #
@@ -222,4 +225,34 @@ func burn{
     ERC721_only_token_owner(tokenId)
     ERC721_burn(tokenId)
     return ()
+end
+
+@view
+func owner{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (owner : felt):
+    let (owner) = Ownable_get_owner()
+    return (owner=owner)
+end
+
+@external
+func transferOwnership{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(new_owner: felt) -> (new_owner: felt):
+    let (new_owner) = Ownable_transfer_ownership(new_owner=new_owner)
+    return (new_owner=new_owner)
+end
+
+@external
+func renounceOwnership{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (new_owner : felt):
+    let (new_owner) = Ownable_renounce_ownership()
+    return (new_owner=new_owner)
 end

--- a/src/openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo
+++ b/src/openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo
@@ -35,7 +35,10 @@ from openzeppelin.security.pausable import (
 
 from openzeppelin.access.ownable import (
     Ownable_initializer,
-    Ownable_only_owner
+    Ownable_only_owner,
+    Ownable_get_owner,
+    Ownable_transfer_ownership,
+    Ownable_renounce_ownership
 )
 
 #
@@ -253,4 +256,34 @@ func unpause{
     Ownable_only_owner()
     Pausable_unpause()
     return ()
+end
+
+@view
+func owner{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (owner : felt):
+    let (owner) = Ownable_get_owner()
+    return (owner=owner)
+end
+
+@external
+func transferOwnership{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(new_owner: felt) -> (new_owner: felt):
+    let (new_owner) = Ownable_transfer_ownership(new_owner=new_owner)
+    return (new_owner=new_owner)
+end
+
+@external
+func renounceOwnership{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (new_owner : felt):
+    let (new_owner) = Ownable_renounce_ownership()
+    return (new_owner=new_owner)
 end

--- a/src/openzeppelin/token/erc721_enumerable/ERC721_Enumerable_Mintable_Burnable.cairo
+++ b/src/openzeppelin/token/erc721_enumerable/ERC721_Enumerable_Mintable_Burnable.cairo
@@ -37,7 +37,10 @@ from openzeppelin.introspection.ERC165 import ERC165_supports_interface
 
 from openzeppelin.access.ownable import (
     Ownable_initializer,
-    Ownable_only_owner
+    Ownable_only_owner,
+    Ownable_get_owner,
+    Ownable_transfer_ownership,
+    Ownable_renounce_ownership
 )
 
 #
@@ -259,4 +262,34 @@ func setTokenURI{
     Ownable_only_owner()
     ERC721_setTokenURI(tokenId, tokenURI)
     return ()
+end
+
+@view
+func owner{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (owner : felt):
+    let (owner) = Ownable_get_owner()
+    return (owner=owner)
+end
+
+@external
+func transferOwnership{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(new_owner: felt) -> (new_owner: felt):
+    let (new_owner) = Ownable_transfer_ownership(new_owner=new_owner)
+    return (new_owner=new_owner)
+end
+
+@external
+func renounceOwnership{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (new_owner : felt):
+    let (new_owner) = Ownable_renounce_ownership()
+    return (new_owner=new_owner)
 end

--- a/tests/mocks/Ownable.cairo
+++ b/tests/mocks/Ownable.cairo
@@ -7,7 +7,8 @@ from starkware.starknet.common.syscalls import get_caller_address
 from openzeppelin.access.ownable import (
     Ownable_initializer,
     Ownable_get_owner,
-    Ownable_transfer_ownership
+    Ownable_transfer_ownership,
+    Ownable_renounce_ownership
 )
 
 @constructor
@@ -38,4 +39,14 @@ func transfer_ownership{
     }(new_owner: felt) -> (new_owner: felt):
     Ownable_transfer_ownership(new_owner)
     return (new_owner=new_owner)
+end
+
+@external
+func renounce_ownership{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (new_owner: felt):
+    Ownable_renounce_ownership()
+    return (new_owner=0)
 end


### PR DESCRIPTION
Fixes #241. Added the ownership transfer event and renounce ownership to the ownable contract and then added transfer, renounce, and get owner to the ready to go erc20 and erc721 contracts