### PR TITLE
dev: support for cairo-lang 0.8.1 in tests

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,9 +7,11 @@ from starkware.starknet.public.abi import get_selector_from_name
 from starkware.starknet.compiler.compile import compile_starknet_files
 from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.testing.starknet import StarknetContract
-from starkware.starknet.business_logic.transaction_execution_objects import Event
-from starkware.starknet.core.os.transaction_hash import calculate_transaction_hash_common, TransactionHashPrefix
 from starkware.starknet.definitions.general_config import StarknetChainId
+from starkware.starknet.business_logic.execution.objects import Event
+from starkware.starknet.core.os.transaction_hash.transaction_hash import calculate_transaction_hash_common, TransactionHashPrefix
+
+
 
 MAX_UINT256 = (2**128 - 1, 2**128 - 1)
 INVALID_UINT256 = (MAX_UINT256[0] + 1, MAX_UINT256[1])


### PR DESCRIPTION
Cairo 0.8.1 changes some locations of internal python objects. This, of course, breaks imports. This PR makes the imports work for 0.8.1 as well as for the previous versions. However, since the testenv is set up to always install the latest version of cairo-lang, maybe supporting the older ones is not necessary?