### PR TITLE
Prefer cairo syntax highlighting in Markdown files

### DIFF
--- a/docs/ERC20.md
+++ b/docs/ERC20.md
@@ -5,32 +5,32 @@ The ERC20 token standard is a specification for [fungible tokens](https://docs.o
 ## Table of Contents
 
 - [Interface](#interface)
-  * [ERC20 compatibility](#erc20-compatibility)
+  - [ERC20 compatibility](#erc20-compatibility)
 - [Usage](#usage)
 - [Extensibility](#extensibility)
 - [Presets](#presets)
-  * [ERC20 (basic)](#erc20-basic)
-  * [ERC20_Mintable](#erc20_mintable)
-  * [ERC20_Pausable](#erc20_pausable)
-  * [ERC20_Upgradeable](#erc20_upgradeable)
+  - [ERC20 (basic)](#erc20-basic)
+  - [ERC20_Mintable](#erc20_mintable)
+  - [ERC20_Pausable](#erc20_pausable)
+  - [ERC20_Upgradeable](#erc20_upgradeable)
 - [API Specification](#api-specification)
-  * [Methods](#methods)
-    * [`name`](#name)
-    * [`symbol`](#symbol)
-    * [`decimals`](#decimals)
-    * [`totalSupply`](#totalsupply)
-    * [`balanceOf`](#balanceof)
-    * [`allowance`](#allowance)
-    * [`transfer`](#transfer)
-    * [`transferFrom`](#transferfrom)
-    * [`approve`](#approve)
-  * [Events](#events)
-    * [`Transfer (event)`](#transfer-event)
-    * [`Approval (event)`](#approval-event)
+  - [Methods](#methods)
+    - [`name`](#name)
+    - [`symbol`](#symbol)
+    - [`decimals`](#decimals)
+    - [`totalSupply`](#totalsupply)
+    - [`balanceOf`](#balanceof)
+    - [`allowance`](#allowance)
+    - [`transfer`](#transfer)
+    - [`transferFrom`](#transferfrom)
+    - [`approve`](#approve)
+  - [Events](#events)
+    - [`Transfer (event)`](#transfer-event)
+    - [`Approval (event)`](#approval-event)
 
 ## Interface
 
-```jsx
+```cairo
 @contract_interface
 namespace IERC20:
     func name() -> (name: felt):
@@ -55,8 +55,8 @@ namespace IERC20:
     end
 
     func transferFrom(
-            sender: felt, 
-            recipient: felt, 
+            sender: felt,
+            recipient: felt,
             amount: Uint256
         ) -> (success: felt):
     end
@@ -132,7 +132,7 @@ ERC20 contracts can be extended by following the [extensibility pattern](../docs
 ```python
 @external
 func transfer{
-        syscall_ptr : felt*, 
+        syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(recipient: felt, amount: Uint256) -> (success: felt):
@@ -145,6 +145,7 @@ end
 Note that extensibility does not have to be only library-based like in the above example. For instance, an ERC20 contract with a pausing mechanism can define the pausing methods directly in the contract or even import the `pausable` methods from the library and tailor them further.
 
 Some other ways to extend ERC20 contracts may include:
+
 - Implementing a minting mechanism
 - Creating a timelock
 - Adding roles such as owner or minter
@@ -161,7 +162,7 @@ The [`ERC20`](../src/openzeppelin/token/erc20/ERC20.cairo) preset offers a quick
 
 ### ERC20_Mintable
 
-The [`ERC20_Mintable`](../src/openzeppelin/token/erc20/ERC20_Mintable.cairo) preset allows the contract owner to mint new tokens. 
+The [`ERC20_Mintable`](../src/openzeppelin/token/erc20/ERC20_Mintable.cairo) preset allows the contract owner to mint new tokens.
 
 ### ERC20_Pausable
 
@@ -175,7 +176,7 @@ The [`ERC20_Upgradeable`](../src/openzeppelin/token/erc20/ERC20_Upgradeable.cair
 
 ### Methods
 
-```jsx
+```cairo
 func name() -> (name: felt):
 end
 
@@ -198,8 +199,8 @@ func transfer(recipient: felt, amount: Uint256) -> (success: felt):
 end
 
 func transferFrom(
-        sender: felt, 
-        recipient: felt, 
+        sender: felt,
+        recipient: felt,
         amount: Uint256
     ) -> (success: felt):
 end
@@ -216,7 +217,7 @@ Parameters: None.
 
 Returns:
 
-```jsx
+```cairo
 name: felt
 ```
 
@@ -228,7 +229,7 @@ Parameters: None.
 
 Returns:
 
-```jsx
+```cairo
 symbol: felt
 ```
 
@@ -240,7 +241,7 @@ Parameters: None.
 
 Returns:
 
-```jsx
+```cairo
 decimals: felt
 ```
 
@@ -252,7 +253,7 @@ Parameters: None.
 
 Returns:
 
-```jsx
+```cairo
 totalSupply: Uint256
 ```
 
@@ -262,13 +263,13 @@ Returns the amount of tokens owned by `account`.
 
 Parameters:
 
-```jsx
+```cairo
 account: felt
 ```
 
 Returns:
 
-```jsx
+```cairo
 balance: Uint256
 ```
 
@@ -280,14 +281,14 @@ This value changes when `approve` or `transferFrom` are called.
 
 Parameters:
 
-```jsx
+```cairo
 owner: felt
 spender: felt
 ```
 
 Returns:
 
-```jsx
+```cairo
 remaining: Uint256
 ```
 
@@ -299,14 +300,14 @@ Emits a [Transfer](#transfer-event) event.
 
 Parameters:
 
-```jsx
+```cairo
 recipient: felt
 amount: Uint256
 ```
 
 Returns:
 
-```jsx
+```cairo
 success: felt
 ```
 
@@ -318,7 +319,7 @@ Emits a [Transfer](#transfer-event) event.
 
 Parameters:
 
-```jsx
+```cairo
 sender: felt
 recipient: felt
 amount: Uint256
@@ -326,7 +327,7 @@ amount: Uint256
 
 Returns:
 
-```jsx
+```cairo
 success: felt
 ```
 
@@ -338,20 +339,20 @@ Emits an [Approval](#approval-event) event.
 
 Parameters:
 
-```jsx
+```cairo
 spender: felt
 amount: Uint256
 ```
 
 Returns:
 
-```jsx
+```cairo
 success: felt
 ```
 
 ### Events
 
-```jsx
+```cairo
 func Transfer(from_: felt, to: felt, value: Uint256):
 end
 
@@ -361,13 +362,13 @@ end
 
 #### `Transfer (event)`
 
-Emitted when `value` tokens are moved from one account (`from_`) to another (`to`). 
+Emitted when `value` tokens are moved from one account (`from_`) to another (`to`).
 
 Note that `value` may be zero.
 
 Parameters:
 
-```jsx
+```cairo
 from_: felt
 to: felt
 value: Uint256
@@ -379,7 +380,7 @@ Emitted when the allowance of a `spender` for an `owner` is set by a call to [ap
 
 Parameters:
 
-```jsx
+```cairo
 owner: felt
 spender: felt
 value: Uint256

--- a/docs/ERC721.md
+++ b/docs/ERC721.md
@@ -57,7 +57,7 @@ The ERC721 token standard is a specification for [non-fungible tokens](https://d
 
 ## IERC721
 
-```jsx
+```cairo
 @contract_interface
 namespace IERC721:
     func balanceOf(owner: felt) -> (balance: Uint256):
@@ -67,9 +67,9 @@ namespace IERC721:
     end
 
     func safeTransferFrom(
-        from_: felt, 
-        to: felt, 
-        tokenId: Uint256, 
+        from_: felt,
+        to: felt,
+        tokenId: Uint256,
         data_len: felt,
         data: felt*
     ):
@@ -106,7 +106,7 @@ Although StarkNet is not EVM compatible, this implementation aims to be as close
 
 But some differences can still be found, such as:
 
-- `tokenURI` returns a felt representation of the queried token's URI. The EIP721 standard, however, states that the return value should be of type string. If a token's URI is not set, the returned value is `0`. Note that URIs cannot exceed 31 characters. See [Interpreting ERC721 URIs](#interpreting-erc721-uris) 
+- `tokenURI` returns a felt representation of the queried token's URI. The EIP721 standard, however, states that the return value should be of type string. If a token's URI is not set, the returned value is `0`. Note that URIs cannot exceed 31 characters. See [Interpreting ERC721 URIs](#interpreting-erc721-uris)
 - `interface_id`s are hardcoded and initialized by the constructor. The hardcoded values derive from Solidity's selector calculations. See [Supporting Interfaces](#supporting-interfaces)
 - `safeTransferFrom` can only be expressed as a single function in Cairo as opposed to the two functions declared in EIP721. The difference between both functions consists of accepting `data` as an argument. Because function overloading is currently not possible in Cairo, `safeTransferFrom` by default accepts the `data` argument. If `data` is not used, simply insert `0`.
 - `safeTransferFrom` is specified such that the optional `data` argument should be of type bytes. In Solidity, this means a dynamically-sized array. To be as close as possible to the standard, it accepts a dynamic array of felts. In Cairo, arrays are expressed with the array length preceding the actual array; hence, the method accepts `data_len` and `data` respectively as types `felt` and `felt*`
@@ -159,7 +159,7 @@ tokenId = uint(1)
 
 await signer.send_transaction(
     account, erc721.contract_address, 'mint', [
-        recipient_address, 
+        recipient_address,
         *tokenId
     ]
 )
@@ -173,7 +173,7 @@ EIP721 discourages the use of `transferFrom` and favors `safeTransferFrom` in re
 
 The current implementation of `safeTansferFrom` checks for `onERC721Received` and requires that the recipient contract supports ERC165 and exposes the `supportsInterface` method. See [ERC721Received](#erc721received)
 
-Please be aware that transferring tokens with `transferFrom` to a contract that does not support ERC721 can result in lost tokens forever. 
+Please be aware that transferring tokens with `transferFrom` to a contract that does not support ERC721 can result in lost tokens forever.
 
 ### Interpreting ERC721 URIs
 Token URIs in Cairo are stored as single field elements. Each field element equates to 252-bits (or  31.5 bytes) which means that a token's URI can be no longer than 31 characters.
@@ -205,7 +205,7 @@ string_uri = felt_to_str(felt_uri)
 
 ### ERC721Received
 
-In order to be sure a contract can safely accept ERC721 tokens, said contract must implement the `ERC721_Receiver` interface (as expressed in the EIP721 specification). Methods such as `safeTransferFrom` and `safeMint` call the recipient contract's `onERC721Received` method. If the contract fails to return the correct magic value, the transaction fails. 
+In order to be sure a contract can safely accept ERC721 tokens, said contract must implement the `ERC721_Receiver` interface (as expressed in the EIP721 specification). Methods such as `safeTransferFrom` and `safeMint` call the recipient contract's `onERC721Received` method. If the contract fails to return the correct magic value, the transaction fails.
 
 StarkNet contracts that support safe transfers, however, must also support ERC165 and include `supportsInterface` as proposed in [#100](https://github.com/OpenZeppelin/cairo-contracts/discussions/100). `safeTransferFrom` requires a means of differentiating between account and non-account contracts. Currently, StarkNet does not support error handling from the contract level;
 therefore, the current ERC721 implementation requires that all contracts that support safe ERC721 transfers (both accounts and non-accounts) include the `supportsInterface` method. Further, `supportsInterface` should return `TRUE` if the recipient contract supports the `IERC721_Receiver` magic value `0x150b7a02` (which invokes `onERC721Received`). If the recipient contract supports the `IAccount` magic value `0x50b70dcb`, `supportsInterface` should return `TRUE`. Otherwise, `safeTransferFrom` should fail.
@@ -214,7 +214,7 @@ therefore, the current ERC721 implementation requires that all contracts that su
 
 Interface for any contract that wants to support safeTransfers from ERC721 asset contracts.
 
-```jsx
+```cairo
 @contract_interface
 namespace IERC721_Receiver:
     func onERC721Received(
@@ -228,13 +228,13 @@ namespace IERC721_Receiver:
 end
 ```
 
-### Supporting Interfaces 
+### Supporting Interfaces
 
 In order to ensure EVM/StarkNet compatibility, this ERC721 implementation does not calculate interface identifiers. Instead, the interface IDs are hardcoded from their EVM calculations. On the EVM, the interface ID is calculated from the selector's first four bytes of the hash of the function's signature while Cairo selectors are 252 bytes long. Due to this difference, hardcoding EVM's already-calculated interface IDs is the most consistent approach to both follow the EIP165 standard and EVM compatibility.
 
 Further, this implementation stores supported interfaces in a mapping (similar to OpenZeppelin's [ERC165Storage](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/introspection/ERC165Storage.sol)).
 
-### Ready-to-Use Presets 
+### Ready-to-Use Presets
 
 ERC721 presets have been created to allow for quick deployments as-is. To be as explicit as possible, each preset includes the additional features they offer in the contract name. For example:
 -  `ERC721_Mintable_Burnable` includes `mint` and `burn`
@@ -257,8 +257,8 @@ from contracts.token.ERC721_base import ERC721_approve
 
 @external
 func approve{
-        pedersen_ptr: HashBuiltin*, 
-        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        syscall_ptr: felt*,
         range_check_ptr
     }(to: felt, tokenId: Uint256):
     ERC721_approve(to, tokenId)
@@ -273,15 +273,15 @@ The following contract presets are ready to deploy and can be used as-is for qui
 
 ### ERC721_Mintable_Burnable
 
-The `ERC721_Mintable_Burnable` preset offers a quick and easy setup for creating NFTs. The contract owner can create tokens with `mint`, whereas token owners can destroy their tokens with `burn`. 
+The `ERC721_Mintable_Burnable` preset offers a quick and easy setup for creating NFTs. The contract owner can create tokens with `mint`, whereas token owners can destroy their tokens with `burn`.
 
-### ERC721_Mintable_Pausable  
+### ERC721_Mintable_Pausable
 
 The `ERC721_Mintable_Pausable` preset creates a contract with pausable token transfers and minting capabilities. This preset proves useful for scenarios such as preventing trades until the end of an evaluation period and having an emergency switch for freezing all token transfers in the event of a large bug. In this preset, only the contract owner can `mint`, `pause`, and `unpause`.
 
 ### ERC721_Enumerable_Mintable_Burnable
 
-The `ERC721_Enumerable_Mintable_Burnable` preset adds enumerability of all the token ids in the contract as well as all token ids owned by each account. This allows contracts to publish its full list of NFTs and make them discoverable. 
+The `ERC721_Enumerable_Mintable_Burnable` preset adds enumerability of all the token ids in the contract as well as all token ids owned by each account. This allows contracts to publish its full list of NFTs and make them discoverable.
 
 In regard to implementation, contracts should import the following view methods:
 -  `ERC721_Enumerable_totalSupply`
@@ -296,7 +296,7 @@ In order for the tokens to be correctly indexed, the contract should also import
 
 #### IERC721_Enumerable
 
-```jsx
+```cairo
 @contract_interface
 namespace IERC721_Enumerable:
     func totalSupply() -> (totalSupply: Uint256):
@@ -314,11 +314,11 @@ end
 
 The `ERC721_Metadata` extension allows your smart contract to be interrogated for its name and for details about the assets which your NFTs represent.
 
-We follow OpenZeppelin's Solidity approach of integrating the Metadata methods `name`, `symbol`, and `tokenURI` into all ERC721 implementations. If preferred, a contract can be created that does not import the Metadata methods from the `ERC721_base` library. Note that the `IERC721_Metadata` interface id should be removed from the constructor as well. 
+We follow OpenZeppelin's Solidity approach of integrating the Metadata methods `name`, `symbol`, and `tokenURI` into all ERC721 implementations. If preferred, a contract can be created that does not import the Metadata methods from the `ERC721_base` library. Note that the `IERC721_Metadata` interface id should be removed from the constructor as well.
 
 #### IERC721_Metadata
 
-```jsx
+```cairo
 @contract_interface
 namespace IERC721_Metadata:
     func name() -> (name: felt):
@@ -346,7 +346,7 @@ Also utilizes the ERC165 method `supportsInterface` to determine if the contract
 
 ### IERC721 API
 
-```jsx
+```cairo
 func balanceOf(owner: felt) -> (balance: Uint256):
 end
 
@@ -354,9 +354,9 @@ func ownerOf(tokenId: Uint256) -> (owner: felt):
 end
 
 func safeTransferFrom(
-        from_: felt, 
-        to: felt, 
-        tokenId: Uint256, 
+        from_: felt,
+        to: felt,
+        tokenId: Uint256,
         data_len: felt,
         data: felt*
     ):
@@ -385,13 +385,13 @@ Returns the number of tokens in `owner`'s account.
 
 Parameters:
 
-```jsx
+```cairo
 owner: felt
 ```
 
 Returns:
 
-```jsx
+```cairo
 balance: Uint256
 ```
 
@@ -401,13 +401,13 @@ Returns the owner of the `tokenId` token.
 
 Parameters:
 
-```jsx
+```cairo
 tokenId: Uint256
 ```
 
 Returns:
 
-```jsx
+```cairo
 owner: felt
 ```
 
@@ -419,7 +419,7 @@ Emits a [Transfer](#transfer-event) event.
 
 Parameters:
 
-```jsx
+```cairo
 from_: felt
 to: felt
 tokenId: Uint256
@@ -441,7 +441,7 @@ Emits a [Transfer](#transfer-event) event.
 
 Parameters:
 
-```jsx
+```cairo
 from_: felt
 to: felt
 tokenId: Uint256
@@ -459,7 +459,7 @@ Emits an [Approval](#approval-event) event.
 
 Parameters:
 
-```jsx
+```cairo
 to: felt
 tokenId: Uint256
 ```
@@ -474,13 +474,13 @@ Returns the account approved for `tokenId` token.
 
 Parameters:
 
-```jsx
+```cairo
 tokenId: Uint256
 ```
 
 Returns:
 
-```jsx
+```cairo
 operator: felt
 ```
 
@@ -492,7 +492,7 @@ Emits an [ApprovalForAll](#approvalforall-event) event.
 
 Parameters:
 
-```jsx
+```cairo
 operator: felt
 ```
 
@@ -506,14 +506,14 @@ Returns if the `operator` is allowed to manage all of the assets of `owner`.
 
 Parameters:
 
-```jsx
+```cairo
 owner: felt
 operator: felt
 ```
 
 Returns:
 
-```jsx
+```cairo
 isApproved: felt
 ```
 
@@ -525,7 +525,7 @@ Emitted when `owner` enables `approved` to manage the `tokenId` token.
 
 Parameters:
 
-```jsx
+```cairo
 owner: felt
 approved: felt
 tokenId: Uint256
@@ -537,7 +537,7 @@ Emitted when `owner` enables or disables (`approved`) `operator` to manage all o
 
 Parameters:
 
-```jsx
+```cairo
 owner: felt
 operator: felt
 approved: felt
@@ -549,7 +549,7 @@ Emitted when `tokenId` token is transferred from `from_` to `to`.
 
 Parameters:
 
-```jsx
+```cairo
 from_: felt
 to: felt
 tokenId: Uint256
@@ -558,7 +558,7 @@ tokenId: Uint256
 ---
 
 ### IERC721_Metadata API
-```jsx
+```cairo
 func name() -> (name: felt):
 end
 
@@ -579,7 +579,7 @@ None.
 
 Returns:
 
-```jsx
+```cairo
 name: felt
 ```
 
@@ -587,13 +587,13 @@ name: felt
 
 Returns the token collection symbol.
 
-Parameters: 
+Parameters:
 
 None.
 
 Returns:
 
-```jsx
+```cairo
 symbol: felt
 ```
 
@@ -603,20 +603,20 @@ Returns the Uniform Resource Identifier (URI) for `tokenID` token. If the URI is
 
 Parameters:
 
-```jsx
+```cairo
 tokenId: Uint256
 ```
 
 Returns:
 
-```jsx
+```cairo
 tokenURI: felt
 ```
 
 ---
 
 ### IERC721_Enumerable API
-```jsx
+```cairo
 
 func totalSupply() -> (totalSupply: Uint256):
 end
@@ -636,7 +636,7 @@ Parameters: None
 
 Returns:
 
-```jsx
+```cairo
 totalSupply: Uint256
 ```
 
@@ -646,13 +646,13 @@ Returns a token ID owned by `owner` at a given `index` of its token list. Use al
 
 Parameters:
 
-```jsx
+```cairo
 index: Uint256
 ```
 
 Returns:
 
-```jsx
+```cairo
 tokenId: Uint256
 ```
 
@@ -662,25 +662,25 @@ Returns a token ID at a given `index` of all the tokens stored by the contract. 
 
 Parameters:
 
-```jsx
+```cairo
 owner: felt
 index: Uint256
 ```
 
 Returns:
 
-```jsx
+```cairo
 tokenId: Uint256
 ```
 
 ---
 
 ### IERC721_Receiver API
-```jsx
+```cairo
 func onERC721Received(
-        operator: felt, 
-        from_: felt, 
-        tokenId: Uint256, 
+        operator: felt,
+        from_: felt,
+        tokenId: Uint256,
         data_len: felt
         data: felt*
     ) -> (selector: felt):
@@ -694,7 +694,7 @@ Whenever an IERC721 `tokenId` token is transferred to this non-account contract 
 
 Parameters:
 
-```jsx
+```cairo
 operator: felt
 from_: felt
 tokenId: Uint256
@@ -704,7 +704,7 @@ data: felt*
 
 Returns:
 
-```jsx
+```cairo
 selector: felt
 ```
 
@@ -718,7 +718,7 @@ It should be noted that the [constants library](../src/openzeppelin/utils/consta
 
 
 ### IERC165
-```jsx
+```cairo
 @contract_interface
 namespace IERC165:
     func supportsInterface(interfaceId: felt) -> (success: felt):
@@ -727,7 +727,7 @@ end
 ```
 
 ### ERC165 API Specification
-```jsx
+```cairo
 func supportsInterface(interfaceId: felt) -> (success: felt):
 end
 ```
@@ -738,12 +738,12 @@ Returns true if this contract implements the interface defined by `interfaceId`.
 
 Parameters:
 
-```jsx
+```cairo
 interfaceId: felt
 ```
 
 Returns:
 
-```jsx
+```cairo
 success: felt
 ```

--- a/docs/Proxies.md
+++ b/docs/Proxies.md
@@ -1,11 +1,11 @@
 # Proxies
 
-> Expect rapid iteration as this pattern matures and more patterns potentially emerge. 
+> Expect rapid iteration as this pattern matures and more patterns potentially emerge.
 
 ## Table of Contents
 * [Quickstart](#quickstart)
 * [Proxies](#proxies)
-  * [Proxy contract](#proxy-contract) 
+  * [Proxy contract](#proxy-contract)
   * [Implementation contract](#implementation-contract)
 * [Upgrades library API](#upgrades-library-api)
   * [Methods](#methods)
@@ -52,13 +52,13 @@ In Python, this would look as follows:
 
 A proxy contract is a contract that delegates function calls to another contract. This type of pattern decouples state and logic. Proxy contracts store the state and redirect function calls to an implementation contract that handles the logic. This allows for different patterns such as upgrades, where implementation contracts can change but the proxy contract (and thus the state) does not; as well as deploying multiple proxy instances pointing to the same implementation. This can be useful to deploy many contracts with identical logic but unique initialization data.
 
-In the case of contract upgrades, it is achieved by simply changing the proxy's reference to the implementation contract. This allows developers to add features, update logic, and fix bugs without touching the state or the contract address to interact with the application. 
+In the case of contract upgrades, it is achieved by simply changing the proxy's reference to the implementation contract. This allows developers to add features, update logic, and fix bugs without touching the state or the contract address to interact with the application.
 
 ### Proxy contract
 
-The [Proxy contract](../src/openzeppelin/upgrades/Proxy.cairo) includes two core methods:  
+The [Proxy contract](../src/openzeppelin/upgrades/Proxy.cairo) includes two core methods:
 
-1. The `__default__` method is a fallback method that redirects a function call and associated calldata to the implementation contract. 
+1. The `__default__` method is a fallback method that redirects a function call and associated calldata to the implementation contract.
 
 2. The `__l1_default__` method is also a fallback method; however, it redirects the function call and associated calldata to a layer one contract. In order to invoke `__l1_default__`, the original function call must include the library function `send_message_to_l1`. See Cairo's [Interacting with L1 contracts](https://www.cairo-lang.org/docs/hello_starknet/l1l2.html) for more information.
 
@@ -70,7 +70,7 @@ When interacting with the contract, function calls should be sent by the user to
 ### Implementation contract
 
 The implementation contract, also known as the logic contract, receives the redirected function calls from the proxy contract. The implementation contract should follow the [Extensibility pattern](../docs/Extensibility.md#the-pattern) and import directly from the [Proxy library](../src/openzeppelin/upgrades/library.cairo).
- 
+
 
 The implementation contract should:
 - import `Proxy_initializer` and `Proxy_set_implementation`
@@ -83,7 +83,7 @@ If the implementation is upgradeable, it should:
 The implementation contract should NOT:
 - deploy with a traditional constructor. Instead, use an initializer method that invokes `Proxy_initializer`.
 
-> Note that the imported `Proxy_initializer` includes a check the ensures the initializer can only be called once; however, `Proxy_set_implementation` does not include this check. It's up to the developers to protect their implementation contract's upgradeability with access controls such as [`Proxy_only_admin`](#proxy_only_admin). 
+> Note that the imported `Proxy_initializer` includes a check the ensures the initializer can only be called once; however, `Proxy_set_implementation` does not include this check. It's up to the developers to protect their implementation contract's upgradeability with access controls such as [`Proxy_only_admin`](#proxy_only_admin).
 
 For a full implementation contract example, please see:
 - [Proxiable implementation](../tests/mocks/proxiable_implementation.cairo)
@@ -91,7 +91,7 @@ For a full implementation contract example, please see:
 ## Upgrades library API
 
 ### Methods
-```jsx
+```cairo
 func Proxy_initializer(proxy_admin: felt):
 end
 
@@ -117,7 +117,7 @@ Initializes the proxy contract with an initial implementation.
 
 Parameters:
 
-```jsx
+```cairo
 proxy_admin: felt
 ```
 
@@ -131,7 +131,7 @@ Sets the implementation contract. This method is included in the proxy contract'
 
 Parameters:
 
-```jsx
+```cairo
 new_implementation: felt
 ```
 
@@ -161,7 +161,7 @@ None.
 
 Returns:
 
-```jsx
+```cairo
 admin: felt
 ```
 
@@ -175,7 +175,7 @@ None.
 
 Returns:
 
-```jsx
+```cairo
 implementation: felt
 ```
 
@@ -185,7 +185,7 @@ Sets the admin of the proxy contract.
 
 Parameters:
 
-```jsx
+```cairo
 new_admin: felt
 ```
 
@@ -195,7 +195,7 @@ None.
 
 ### Events
 
-```jsx
+```cairo
 func Upgraded(implementation: felt):
 end
 ```
@@ -206,11 +206,11 @@ Emitted when a proxy contract sets a new implementation address.
 
 Parameters:
 
-```jsx
+```cairo
 implementation: felt
 ```
 
-## Using proxies 
+## Using proxies
 
 ### Contract upgrades
 
@@ -266,7 +266,7 @@ result = await signer.send_transaction(
 
 ## Presets
 
-Presets are pre-written contracts that extend from our library of contracts. They can be deployed as-is or used as templates for customization. 
+Presets are pre-written contracts that extend from our library of contracts. They can be deployed as-is or used as templates for customization.
 
 Some presets include:
 - [ERC20_Upgradeable](../src/openzeppelin/token/erc20/ERC20_Upgradeable.cairo)


### PR DESCRIPTION
Prior to this change, Cairo code blocks used `jsx` syntax highlighting which was less readable than `cairo` syntax highlighting. I suspect that `jsx` was used because `cairo` may not have been available at the time of writing.

The other changes were autofixed via markdown lint (trailing whitespace removal, consistent `-` for bullets).

Before | After
--- | ---
<img width="1048" alt="before" src="https://user-images.githubusercontent.com/3699047/163824279-24d85fbe-6dbe-4e43-8db7-fc1aa60abe47.png"> | <img width="1054" alt="after" src="https://user-images.githubusercontent.com/3699047/163824294-9033c9b5-06d7-4abb-9c6f-7ed38cc9ae7d.png">

