### PR TITLE
More cairo syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 ## Usage
 
 > ## ⚠️ WARNING! ⚠️
-
-> This is repo contains highly experimental code.
+> This repo contains highly experimental code.
 > Expect rapid iteration.
 > **Use at your own risk.**
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # OpenZeppelin Contracts for Cairo
-
 [![Tests and linter](https://github.com/OpenZeppelin/cairo-contracts/actions/workflows/python-app.yml/badge.svg)](https://github.com/OpenZeppelin/cairo-contracts/actions/workflows/python-app.yml)
 
 **A library for secure smart contract development** written in Cairo for [StarkNet](https://starkware.co/product/starknet/), a decentralized ZK Rollup.
@@ -14,12 +13,10 @@
 ### First time?
 
 Before installing Cairo on your machine, you need to install `gmp`:
-
 ```bash
 sudo apt install -y libgmp3-dev # linux
 brew install gmp # mac
 ```
-
 > If you have any troubles installing gmp on your Apple M1 computer, [here’s a list of potential solutions](https://github.com/OpenZeppelin/nile/issues/22).
 
 ### Set up the project
@@ -59,7 +56,6 @@ from openzeppelin.token.erc20.ERC20 import constructor
 ```
 
 Compile and deploy it right away:
-
 ```bash
 nile compile
 
@@ -69,7 +65,6 @@ nile deploy MyToken <name> <symbol> <decimals> <initial_supply> <recipient> --al
 > Note that `<initial_supply>` is expected to be two integers i.e. `1` `0`. See [Uint256](docs/Utilities.md#Uint256) for more information.
 
 ### Write a custom contract using library modules
-
 [Read more about libraries](docs/Extensibility.md#libraries).
 
 ```cairo
@@ -112,30 +107,24 @@ end
 ## Learn
 
 ### Contract documentation
-
 * [Account](docs/Account.md)
 * [ERC20](docs/ERC20.md)
 * [ERC721](docs/ERC721.md)
 * [Contract extensibility pattern](docs/Extensibility.md)
 * [Proxies and upgrades](docs/Proxies.md)
 * [Utilities](docs/Utilities.md)
-
 ### Cairo
-
 * [StarkNet official documentation](https://www.cairo-lang.org/docs/hello_starknet/index.html#hello-starknet)
 * [Cairo language documentation](https://www.cairo-lang.org/docs/hello_cairo/index.html#hello-cairo)
 * Perama's [Cairo by example](https://perama-v.github.io/cairo/by-example/)
 * [Cairo 101 workshops](https://www.youtube.com/playlist?list=PLcIyXLwiPilV5RBZj43AX1FY4FJMWHFTY)
-
 ### Nile
-
 * [Getting started with StarkNet using Nile](https://medium.com/coinmonks/starknet-tutorial-for-beginners-using-nile-6af9c2270c15)
 * [How to manage smart contract deployments with Nile](https://medium.com/@martriay/manage-your-starknet-deployments-with-nile-%EF%B8%8F-e849d40546dd)
 
 ## Development
 
 ### Set up the project
-
 Clone the repository
 
 ```bash
@@ -151,14 +140,12 @@ source env/bin/activate
 ```
 
 Install Nile:
-
 ```bash
 pip install cairo-nile
 nile install
 ```
 
 ### Compile the contracts
-
 ```bash
 nile compile --directory src
 
@@ -218,7 +205,6 @@ This project is still in a very early and experimental phase. It has never been 
 Please report any security issues you find to security@openzeppelin.org.
 
 ## Contribute
-
 OpenZeppelin Contracts for Cairo exists thanks to its contributors. There are many ways you can participate and help build high quality software. Check out the [contribution](CONTRIBUTING.md) guide!
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # OpenZeppelin Contracts for Cairo
+
 [![Tests and linter](https://github.com/OpenZeppelin/cairo-contracts/actions/workflows/python-app.yml/badge.svg)](https://github.com/OpenZeppelin/cairo-contracts/actions/workflows/python-app.yml)
 
 **A library for secure smart contract development** written in Cairo for [StarkNet](https://starkware.co/product/starknet/), a decentralized ZK Rollup.
@@ -6,6 +7,7 @@
 ## Usage
 
 > ## ⚠️ WARNING! ⚠️
+
 > This is repo contains highly experimental code.
 > Expect rapid iteration.
 > **Use at your own risk.**
@@ -13,10 +15,12 @@
 ### First time?
 
 Before installing Cairo on your machine, you need to install `gmp`:
+
 ```bash
 sudo apt install -y libgmp3-dev # linux
 brew install gmp # mac
 ```
+
 > If you have any troubles installing gmp on your Apple M1 computer, [here’s a list of potential solutions](https://github.com/OpenZeppelin/nile/issues/22).
 
 ### Set up the project
@@ -47,7 +51,7 @@ pip install openzeppelin-cairo-contracts
 
 Presets are ready-to-use contracts that you can deploy right away. They also serve as examples of how to use library modules. [Read more about presets](docs/Extensibility.md#presets).
 
-```python
+```cairo
 # contracts/MyToken.cairo
 
 %lang starknet
@@ -56,6 +60,7 @@ from openzeppelin.token.erc20.ERC20 import constructor
 ```
 
 Compile and deploy it right away:
+
 ```bash
 nile compile
 
@@ -65,9 +70,10 @@ nile deploy MyToken <name> <symbol> <decimals> <initial_supply> <recipient> --al
 > Note that `<initial_supply>` is expected to be two integers i.e. `1` `0`. See [Uint256](docs/Utilities.md#Uint256) for more information.
 
 ### Write a custom contract using library modules
+
 [Read more about libraries](docs/Extensibility.md#libraries).
 
-```python
+```cairo
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
@@ -107,24 +113,30 @@ end
 ## Learn
 
 ### Contract documentation
+
 * [Account](docs/Account.md)
 * [ERC20](docs/ERC20.md)
 * [ERC721](docs/ERC721.md)
 * [Contract extensibility pattern](docs/Extensibility.md)
 * [Proxies and upgrades](docs/Proxies.md)
 * [Utilities](docs/Utilities.md)
+
 ### Cairo
+
 * [StarkNet official documentation](https://www.cairo-lang.org/docs/hello_starknet/index.html#hello-starknet)
 * [Cairo language documentation](https://www.cairo-lang.org/docs/hello_cairo/index.html#hello-cairo)
 * Perama's [Cairo by example](https://perama-v.github.io/cairo/by-example/)
 * [Cairo 101 workshops](https://www.youtube.com/playlist?list=PLcIyXLwiPilV5RBZj43AX1FY4FJMWHFTY)
+
 ### Nile
+
 * [Getting started with StarkNet using Nile](https://medium.com/coinmonks/starknet-tutorial-for-beginners-using-nile-6af9c2270c15)
 * [How to manage smart contract deployments with Nile](https://medium.com/@martriay/manage-your-starknet-deployments-with-nile-%EF%B8%8F-e849d40546dd)
 
 ## Development
 
 ### Set up the project
+
 Clone the repository
 
 ```bash
@@ -140,12 +152,14 @@ source env/bin/activate
 ```
 
 Install Nile:
+
 ```bash
 pip install cairo-nile
 nile install
 ```
 
 ### Compile the contracts
+
 ```bash
 nile compile --directory src
 
@@ -189,7 +203,7 @@ tox
 platform linux -- Python 3.7.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
 rootdir: /home/readme/cairo-contracts
 plugins: asyncio-0.16.0, web3-5.24.0, typeguard-2.13.0
-collected 19 items                                                                                               
+collected 19 items
 
 tests/test_Account.py ....                                 [ 21%]
 tests/test_AddressRegistry.py ..                           [ 31%]
@@ -205,6 +219,7 @@ This project is still in a very early and experimental phase. It has never been 
 Please report any security issues you find to security@openzeppelin.org.
 
 ## Contribute
+
 OpenZeppelin Contracts for Cairo exists thanks to its contributors. There are many ways you can participate and help build high quality software. Check out the [contribution](CONTRIBUTING.md) guide!
 
 ## License

--- a/docs/Account.md
+++ b/docs/Account.md
@@ -1,5 +1,4 @@
 # Accounts
-
 Unlike Ethereum where accounts are directly derived from a private key, there's no native account concept on StarkNet.
 
 Instead, signature validation has to be done at the contract level. To relieve smart contract applications such as ERC20 tokens or exchanges from this responsibility, we make use of Account contracts to deal with transaction authentication.
@@ -27,7 +26,6 @@ A more detailed writeup on the topic can be found on [Perama's blogpost](https:/
 ## Quickstart
 
 The general workflow is:
-
 1. Account contract is deployed to StarkNet
 2. Signed transactions can now be sent to the Account contract which validates and executes them
 
@@ -172,7 +170,6 @@ Where:
 * `version` is a fixed number which is used to invalidate old transactions
 
 This `MultiCall` message is built within the `__execute__` method which has the following interface:
-
 ```cairo
 func __execute__(
         call_array_len: felt,
@@ -209,7 +206,6 @@ await signer.send_transaction(account, registry.contract_address, 'set_L1_addres
 You can read more about how messages are structured and hashed in the [Account message scheme  discussion](https://github.com/OpenZeppelin/cairo-contracts/discussions/24). For more information on the design choices and implementation of multicall, you can read the [How should Account multicall work discussion](https://github.com/OpenZeppelin/cairo-contracts/discussions/27).
 
 > Note that the scheme of building multicall transactions within the `__execute__` method will change once StarkNet allows for pointers in struct arrays. In which case, multiple transactions can be passed to (as opposed to built within) `__execute__`.
-
 ## API Specification
 
 This in a nutshell is the Account contract public API:
@@ -273,7 +269,6 @@ nonce: felt
 Sets the public key that will control this Account. It can be used to rotate keys for security, change them in case of compromised keys or even transferring ownership of the account.
 
 ##### Parameters:
-
 ```cairo
 public_key: felt
 ```
@@ -287,7 +282,6 @@ None.
 This function is inspired by [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) and checks whether a given signature is valid, otherwise it reverts.
 
 ##### Parameters:
-
 ```cairo
 hash: felt
 signature_len: felt
@@ -309,7 +303,6 @@ This is the only external entrypoint to interact with the Account contract. It:
 5. Forwards the contract call response data as return value
 
 ##### Parameters:
-
 ```cairo
 call_array_len: felt
 call_array: AccountCallArray*
@@ -321,7 +314,6 @@ nonce: felt
 > Note that the current signature scheme expects a 2-element array like `[sig_r, sig_s]`.
 
 ##### Returns:
-
 ```cairo
 response_len: felt
 response: felt*
@@ -346,7 +338,6 @@ Currently, there's only a single library/preset Account scheme, but we're lookin
 ## L1 escape hatch mechanism
 
 *[unknown, to be defined]*
-
 ## Paying for gas
 
 *[unknown, to be defined]*

--- a/docs/Account.md
+++ b/docs/Account.md
@@ -1,4 +1,5 @@
 # Accounts
+
 Unlike Ethereum where accounts are directly derived from a private key, there's no native account concept on StarkNet.
 
 Instead, signature validation has to be done at the contract level. To relieve smart contract applications such as ERC20 tokens or exchanges from this responsibility, we make use of Account contracts to deal with transaction authentication.
@@ -10,14 +11,14 @@ A more detailed writeup on the topic can be found on [Perama's blogpost](https:/
 * [Quickstart](#quickstart)
 * [Standard Interface](#standard-interface)
 * [Keys, signatures and signers](#keys-signatures-and-signers)
-    + [Signer utility](#signer-utility)
+  * [Signer utility](#signer-utility)
 * [Call and MultiCall format](#call-and-multicall-format)
 * [API Specification](#api-specification)
-    - [`get_public_key`](#get_public_key)
-    - [`get_nonce`](#get_nonce)
-    - [`set_public_key`](#set_public_key)
-    - [`is_valid_signature`](#is_valid_signature)
-    - [`__execute__`](#__execute__)
+  * [`get_public_key`](#get_public_key)
+  * [`get_nonce`](#get_nonce)
+  * [`set_public_key`](#set_public_key)
+  * [`is_valid_signature`](#is_valid_signature)
+  * [`__execute__`](#__execute__)
 * [Account differentiation with ERC165](#account-differentiation-with-erc165)
 * [Extending the Account contract](#extending-the-account-contract)
 * [L1 escape hatch mechanism](#l1-escape-hatch-mechanism)
@@ -25,13 +26,14 @@ A more detailed writeup on the topic can be found on [Perama's blogpost](https:/
 
 ## Quickstart
 
-The general workflow is: 
+The general workflow is:
+
 1. Account contract is deployed to StarkNet
 2. Signed transactions can now be sent to the Account contract which validates and executes them
 
 In Python, this would look as follows:
 
-```python
+```cairo
 from starkware.starknet.testing.starknet import Starknet
 signer = Signer(123456789987654321)
 starknet = await Starknet.empty()
@@ -50,7 +52,7 @@ await signer.send_transaction(account, some_contract_address, 'some_function', [
 
 The [`IAccount.cairo`](../src/openzeppelin/account/IAccount.cairo) contract interface contains the standard account interface proposed in [#41](https://github.com/OpenZeppelin/cairo-contracts/discussions/41) and adopted by OpenZeppelin and Argent. It implements [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) and it is agnostic of signature validation and nonce management strategies.
 
-```c#
+```cairo
 @contract_interface
 namespace IAccount:
     #
@@ -94,9 +96,9 @@ The `Signer()` class in [utils.py](../tests/utils.py) is used to perform transac
 
 It exposes three functions:
 
-- `def sign(message_hash)` receives a hash and returns a signed message of it
-- `def send_transaction(account, to, selector_name, calldata, nonce=None, max_fee=0)` returns a future of a signed transaction, ready to be sent.
-- `def send_transactions(account, calls, nonce=None, max_fee=0)` returns a future of batched signed transactions, ready to be sent.
+* `def sign(message_hash)` receives a hash and returns a signed message of it
+* `def send_transaction(account, to, selector_name, calldata, nonce=None, max_fee=0)` returns a future of a signed transaction, ready to be sent.
+* `def send_transactions(account, calls, nonce=None, max_fee=0)` returns a future of batched signed transactions, ready to be sent.
 
 To use Signer, pass a private key when instantiating the class:
 
@@ -125,14 +127,13 @@ If utilizing multicall, send multiple transactions with the `send_transactions` 
     )
 ```
 
-
 ## Call and MultiCall format
 
 The idea is for all user intent to be encoded into a `Call` representing a smart contract call. If the user wants to send multiple messages in a single transaction, these `Call`s are bundled into a `MultiCall`. It should be noted that every transaction utilizes multicall. A single `Call`, however, is treated as a bundle of one.
 
 A single `Call` is structured as follows:
 
-```c#
+```cairo
 struct Call:
     member to: felt
     member selector: felt
@@ -143,14 +144,14 @@ end
 
 Where:
 
-- `to` is the address of the target contract of the message
-- `selector` is the selector of the function to be called on the target contract
-- `calldata_len` is the number of calldata parameters
-- `calldata` is an array representing the function parameters
+* `to` is the address of the target contract of the message
+* `selector` is the selector of the function to be called on the target contract
+* `calldata_len` is the number of calldata parameters
+* `calldata` is an array representing the function parameters
 
 `MultiCall` is structured as:
 
-```c#
+```cairo
 struct MultiCall:
     member account: felt
     member calls_len: felt
@@ -163,14 +164,15 @@ end
 
 Where:
 
-- `account` is the Account contract address. It is included to prevent transaction replays in case there's another Account contract controlled by the same public keys
-- `calls_len` is the number of calls bundled into the transaction
-- `calls` is an array representing each `Call`
-- `nonce` is an unique identifier of this message to prevent transaction replays. Current implementation requires nonces to be incremental
-- `max_fee` is the maximum fee a user will pay
-- `version` is a fixed number which is used to invalidate old transactions
+* `account` is the Account contract address. It is included to prevent transaction replays in case there's another Account contract controlled by the same public keys
+* `calls_len` is the number of calls bundled into the transaction
+* `calls` is an array representing each `Call`
+* `nonce` is an unique identifier of this message to prevent transaction replays. Current implementation requires nonces to be incremental
+* `max_fee` is the maximum fee a user will pay
+* `version` is a fixed number which is used to invalidate old transactions
 
 This `MultiCall` message is built within the `__execute__` method which has the following interface:
+
 ```cairo
 func __execute__(
         call_array_len: felt,
@@ -184,11 +186,11 @@ end
 
 Where:
 
-- `call_array_len` is the number of calls
-- `call_array` is an array representing each `Call`
-- `calldata_len` is the number of calldata parameters
-- `calldata` is an array representing the function parameters 
-- `nonce` is an unique identifier of this message to prevent transaction replays. Current implementation requires nonces to be incremental
+* `call_array_len` is the number of calls
+* `call_array` is an array representing each `Call`
+* `calldata_len` is the number of calldata parameters
+* `calldata` is an array representing the function parameters
+* `nonce` is an unique identifier of this message to prevent transaction replays. Current implementation requires nonces to be incremental
 
 `__execute__` acts as a single entrypoint for all user interaction with any contract, including managing the account contract itself. That's why if you want to change the public key controlling the Account, you would send a transaction targeting the very Account contract:
 
@@ -198,7 +200,7 @@ await signer.send_transaction(account, account.contract_address, 'set_public_key
 
 Note that Signer's `send_transaction` and `send_transactions` call `__execute__` under the hood.
 
-Or if you want to update the Account's L1 address on the `AccountRegistry` contract, you would 
+Or if you want to update the Account's L1 address on the `AccountRegistry` contract, you would
 
 ```python
 await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [NEW_ADDRESS])
@@ -207,7 +209,6 @@ await signer.send_transaction(account, registry.contract_address, 'set_L1_addres
 You can read more about how messages are structured and hashed in the [Account message scheme  discussion](https://github.com/OpenZeppelin/cairo-contracts/discussions/24). For more information on the design choices and implementation of multicall, you can read the [How should Account multicall work discussion](https://github.com/OpenZeppelin/cairo-contracts/discussions/27).
 
 > Note that the scheme of building multicall transactions within the `__execute__` method will change once StarkNet allows for pointers in struct arrays. In which case, multiple transactions can be passed to (as opposed to built within) `__execute__`.
-
 
 ## API Specification
 
@@ -243,12 +244,13 @@ end
 
 Returns the public key associated with the Account contract.
 
-##### Parameters:
+##### Parameters
 
 None.
 
-##### Returns:
-```
+##### Returns
+
+```cairo
 public_key: felt
 ```
 
@@ -256,13 +258,13 @@ public_key: felt
 
 Returns the current transaction nonce for the Account.
 
-##### Parameters:
+##### Parameters
 
 None.
 
-##### Returns:
+##### Returns
 
-```
+```cairo
 nonce: felt
 ```
 
@@ -270,12 +272,13 @@ nonce: felt
 
 Sets the public key that will control this Account. It can be used to rotate keys for security, change them in case of compromised keys or even transferring ownership of the account.
 
-##### Parameters:
-```
+##### Parameters
+
+```cairo
 public_key: felt
 ```
 
-##### Returns:
+##### Returns
 
 None.
 
@@ -283,14 +286,15 @@ None.
 
 This function is inspired by [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) and checks whether a given signature is valid, otherwise it reverts.
 
-##### Parameters:
-```
+##### Parameters
+
+```cairo
 hash: felt
 signature_len: felt
 signature: felt*
 ```
 
-##### Returns:
+##### Returns
 
 None.
 
@@ -304,8 +308,9 @@ This is the only external entrypoint to interact with the Account contract. It:
 4. Calls the target contract with the intended function selector and calldata parameters
 5. Forwards the contract call response data as return value
 
-##### Parameters:
-```
+##### Parameters
+
+```cairo
 call_array_len: felt
 call_array: AccountCallArray*
 calldata_len: felt
@@ -315,9 +320,9 @@ nonce: felt
 
 > Note that the current signature scheme expects a 2-element array like `[sig_r, sig_s]`.
 
+##### Returns
 
-##### Returns:
-```
+```cairo
 response_len: felt
 response: felt*
 ```
@@ -333,15 +338,14 @@ Our ERC165 integration on StarkNet is inspired by OpenZeppelin's Solidity implem
 Account contracts can be extended by following the [extensibility pattern](../docs/Extensibility.md#the-pattern). The basic idea behind integrating the pattern is to import the requisite methods from the Account library and incorporate the extended logic thereafter.
 
 Currently, there's only a single library/preset Account scheme, but we're looking for feedback and new presets to emerge. Some new validation schemes to look out for in the future:
-- multisig
-- guardian logic like in [Argent's account](https://github.com/argentlabs/argent-contracts-starknet/blob/de5654555309fa76160ba3d7393d32d2b12e7349/contracts/ArgentAccount.cairo)
-- [Ethereum signatures](https://github.com/OpenZeppelin/cairo-contracts/issues/161)
 
+* multisig
+* guardian logic like in [Argent's account](https://github.com/argentlabs/argent-contracts-starknet/blob/de5654555309fa76160ba3d7393d32d2b12e7349/contracts/ArgentAccount.cairo)
+* [Ethereum signatures](https://github.com/OpenZeppelin/cairo-contracts/issues/161)
 
 ## L1 escape hatch mechanism
 
 *[unknown, to be defined]*
-
 
 ## Paying for gas
 

--- a/docs/Account.md
+++ b/docs/Account.md
@@ -244,11 +244,11 @@ end
 
 Returns the public key associated with the Account contract.
 
-##### Parameters
+##### Parameters:
 
 None.
 
-##### Returns
+##### Returns:
 
 ```cairo
 public_key: felt
@@ -258,11 +258,11 @@ public_key: felt
 
 Returns the current transaction nonce for the Account.
 
-##### Parameters
+##### Parameters:
 
 None.
 
-##### Returns
+##### Returns:
 
 ```cairo
 nonce: felt
@@ -272,13 +272,13 @@ nonce: felt
 
 Sets the public key that will control this Account. It can be used to rotate keys for security, change them in case of compromised keys or even transferring ownership of the account.
 
-##### Parameters
+##### Parameters:
 
 ```cairo
 public_key: felt
 ```
 
-##### Returns
+##### Returns:
 
 None.
 
@@ -286,7 +286,7 @@ None.
 
 This function is inspired by [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) and checks whether a given signature is valid, otherwise it reverts.
 
-##### Parameters
+##### Parameters:
 
 ```cairo
 hash: felt
@@ -294,7 +294,7 @@ signature_len: felt
 signature: felt*
 ```
 
-##### Returns
+##### Returns:
 
 None.
 
@@ -308,7 +308,7 @@ This is the only external entrypoint to interact with the Account contract. It:
 4. Calls the target contract with the intended function selector and calldata parameters
 5. Forwards the contract call response data as return value
 
-##### Parameters
+##### Parameters:
 
 ```cairo
 call_array_len: felt
@@ -320,7 +320,7 @@ nonce: felt
 
 > Note that the current signature scheme expects a 2-element array like `[sig_r, sig_s]`.
 
-##### Returns
+##### Returns:
 
 ```cairo
 response_len: felt

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -1,27 +1,27 @@
 # Security
 
- The following documentation provides context, reasoning, and examples of methods and constants found in `openzeppelin/security/`. 
- 
- > Expect this module to evolve. 
+ The following documentation provides context, reasoning, and examples of methods and constants found in `openzeppelin/security/`.
 
- ## Table of Contents 
+ > Expect this module to evolve.
 
- * [Reentrancy Guard](#Reentrancy-Guard) 
- 
- ## Reentrancy Guard 
- 
+## Table of Contents
+
+* [Reentrancy Guard](#Reentrancy-Guard)
+
+## Reentrancy Guard
+
 A [reentrancy attack](https://gus-tavo-guim.medium.com/reentrancy-attack-on-smart-contracts-how-to-identify-the-exploitable-and-an-example-of-an-attack-4470a2d8dfe4) occurs when the caller is able to obtain more resources than allowed by recursively calling a target’s function.
 
 Since Cairo does not support modifiers like Solidity, the [`reentrancy_guard`](../src/openzeppelin/security/reentrancy_guard.cairo) library exposes two methods `ReentrancyGuard_start` and `ReentrancyGuard_end` to protect functions against reentrancy attacks. The protected function must call `ReentrancyGuard_start` before the first function statement, and `ReentrancyGuard_end` before the return statement, as shown below:
 
-```
+```cairo
 from openzeppelin.security.reentrancy_guard import (
     ReentrancyGuard_start,
     ReentrancyGuard_end
 )
 
 func test_function{
-        syscall_ptr : felt*, 
+        syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }():
@@ -31,4 +31,3 @@ func test_function{
    return ()
 end
 ```
-


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/cairo-contracts/issues/279

Previously, code blocks used `c#` or `python` for syntax highlighting because `cairo` was not available. This change updates code blocks to use `cairo` now that it is available.

The other changes were auto applied via markdownlint format on save. If reviewers request, they can be reverted.