### PR TITLE
Use Nile's Signer

### DIFF
--- a/docs/Account.md
+++ b/docs/Account.md
@@ -112,11 +112,11 @@ Which returns:
 * `sig_r` the transaction signature
 * `sig_s` the transaction signature
 
-While the `Signer` class performs much of the work for a transaction to be sent, it neither manages nonces nor invokes the actual transaction on the Account contract. Those functions can be done manually; however, this implementation abstracts that all away with `ActivatedSigner`.
+While the `Signer` class performs much of the work for a transaction to be sent, it neither manages nonces nor invokes the actual transaction on the Account contract. To simplify Account management, most of this is abstracted away with `ActivatedSigner`.
 
 ### ActivatedSigner utility
 
-The `ActivatedSigner` class in [utils.py](../tests/utils.py) is used to perform transactions on a given Account, crafting the tx and managing nonces. In order for a transaction to be sent, this utility performs the following:
+The `ActivatedSigner` class in [utils.py](../tests/utils.py) is used to perform transactions on a given Account, crafting the transaction and managing nonces. In order for a transaction to be sent, this utility performs the following:
 
 * checks nonce
   * if none is given, it fetches the nonce from the Account contract via `get_nonce`
@@ -125,10 +125,9 @@ The `ActivatedSigner` class in [utils.py](../tests/utils.py) is used to perform 
   * a necessary process to convert the `to` contract address to hexadecimal format
 
 * passes transaction data to Nile's `Signer`
-  * this returns the signature for the transaction as well as the `calls` and `calldata`
+  * this returns the signature for the transaction as well as `calls` and `calldata`
 
 * invokes the Account contract's `__execute__` method
-  * where the transaction is finally sent
 
 Users only need to interact with the following exposed methods to perform a transaction:
 

--- a/docs/Account.md
+++ b/docs/Account.md
@@ -36,7 +36,7 @@ In Python, this would look as follows:
 
 ```python
 from starkware.starknet.testing.starknet import Starknet
-signer = Signer(123456789987654321)
+signer = ActivatedSigner(123456789987654321)
 starknet = await Starknet.empty()
 
 # 1. Deploy Account
@@ -93,7 +93,7 @@ Note that although the current implementation works only with StarkKeys, support
 
 ### Signer
 
-The Signer is responsible for creating a transaction signature with the user's private key for a given transaction. This implementation utilizes [Nile's Signer](https://github.com/OpenZeppelin/nile/blob/main/src/nile/signer.py) class to create transaction signatures through the Signer method `sign_transaction`.
+The signer is responsible for creating a transaction signature with the user's private key for a given transaction. This implementation utilizes [Nile's Signer](https://github.com/OpenZeppelin/nile/blob/main/src/nile/signer.py) class to create transaction signatures through the `Signer` method `sign_transaction`.
 
 `sign_transaction` expects the following parameters per transaction:
 
@@ -112,7 +112,7 @@ Which returns:
 * `sig_r` the transaction signature
 * `sig_s` the transaction signature
 
-While the Signer class performs much of the work for a transaction to be sent, it neither manages nonces nor invokes the actual transaction on the Account contract. Those functions can be done manually; however, this implementation abstracts that all away with `ActivatedSigner`.
+While the `Signer` class performs much of the work for a transaction to be sent, it neither manages nonces nor invokes the actual transaction on the Account contract. Those functions can be done manually; however, this implementation abstracts that all away with `ActivatedSigner`.
 
 ### ActivatedSigner utility
 
@@ -124,7 +124,7 @@ The `ActivatedSigner` class in [utils.py](../tests/utils.py) is used to perform 
 * reformats callarray
   * a necessary process to convert the `to` contract address to hexadecimal format
 
-* passes transaction data to Nile's Signer
+* passes transaction data to Nile's `Signer`
   * this returns the signature for the transaction as well as the `calls` and `calldata`
 
 * invokes the Account contract's `__execute__` method
@@ -234,7 +234,7 @@ Where:
 await signer.send_transaction(account, account.contract_address, 'set_public_key', [NEW_KEY])
 ```
 
-Note that Signer's `send_transaction` and `send_transactions` call `__execute__` under the hood.
+Note that `ActivatedSigner`'s `send_transaction` and `send_transactions` call `__execute__` under the hood.
 
 Or if you want to update the Account's L1 address on the `AccountRegistry` contract, you would
 

--- a/docs/ERC20.md
+++ b/docs/ERC20.md
@@ -114,7 +114,7 @@ erc20 = await starknet.deploy(
 As most StarkNet contracts, it expects to be called by another contract and it identifies it through `get_caller_address` (analogous to Solidity's `this.address`). This is why we need an Account contract to interact with it. For example:
 
 ```python
-signer = Signer(PRIVATE_KEY)
+signer = ActivatedSigner(PRIVATE_KEY)
 amount = uint(100)
 
 account = await starknet.deploy(

--- a/docs/ERC20.md
+++ b/docs/ERC20.md
@@ -114,7 +114,7 @@ erc20 = await starknet.deploy(
 As most StarkNet contracts, it expects to be called by another contract and it identifies it through `get_caller_address` (analogous to Solidity's `this.address`). This is why we need an Account contract to interact with it. For example:
 
 ```python
-signer = ActivatedSigner(PRIVATE_KEY)
+signer = TestSigner(PRIVATE_KEY)
 amount = uint(100)
 
 account = await starknet.deploy(

--- a/docs/ERC721.md
+++ b/docs/ERC721.md
@@ -153,7 +153,7 @@ erc721 = await starknet.deploy(
 To mint a non-fungible token, send a transaction like this:
 
 ```python
-signer = ActivatedSigner(PRIVATE_KEY)
+signer = TestSigner(PRIVATE_KEY)
 tokenId = uint(1)
 
 await signer.send_transaction(

--- a/docs/ERC721.md
+++ b/docs/ERC721.md
@@ -154,7 +154,7 @@ erc721 = await starknet.deploy(
 To mint a non-fungible token, send a transaction like this:
 
 ```python
-signer = Signer(PRIVATE_KEY)
+signer = ActivatedSigner(PRIVATE_KEY)
 tokenId = uint(1)
 
 await signer.send_transaction(

--- a/docs/Utilities.md
+++ b/docs/Utilities.md
@@ -30,12 +30,11 @@ To ease the readability of Cairo contracts, this project includes reusable [cons
 
 ## Strings
 
-Cairo currently only provides support for short string literals (less than 32 characters). Note that short strings aren't really strings, rather, they're representations of Cairo field elements. The following methods provide a simple conversion to/from field elements. 
+Cairo currently only provides support for short string literals (less than 32 characters). Note that short strings aren't really strings, rather, they're representations of Cairo field elements. The following methods provide a simple conversion to/from field elements.
 
 ### `str_to_felt`
 
 Takes an ASCII string and converts it to a field element via big endian representation.
-
 
 ### `felt_to_str`
 
@@ -45,7 +44,7 @@ Takes an integer and converts it to an ASCII string by trimming the null bytes a
 
 Cairo's native data type is a field element (felt). Felts equate to 252 bits which poses a problem regarding 256-bit integer integration. To resolve the bit discrepancy, Cairo represents 256-bit integers as a struct of two 128-bit integers. Further, the low bits precede the high bits e.g.
 
-```
+```python
 1 = (1, 0)
 1 << 128 = (0, 1)
 (1 << 128) - 1 = (340282366920938463463374607431768211455, 0)
@@ -56,7 +55,6 @@ Cairo's native data type is a field element (felt). Felts equate to 252 bits whi
 Converts a simple integer into a uint256-ish tuple.
 
 > Note `to_uint` should be used in favor of `uint`, as `uint` only returns the low bits of the tuple.
-
 
 ### `to_uint`
 
@@ -185,7 +183,7 @@ assert_event_emitted(
 
 ## Memoization
 
-Memoizing functions allow for quicker and computationally cheaper calculations which is immensely beneficial while testing smart contracts. 
+Memoizing functions allow for quicker and computationally cheaper calculations which is immensely beneficial while testing smart contracts.
 
 ### `get_contract_def`
 
@@ -227,6 +225,6 @@ def foo_factory(contract_defs, foo_init):
     return cached_foo  # return cached contracts
 ```
 
-## Signer
+## ActivatedSigner
 
-`Signer` is used to perform transactions on a given Account, crafting the tx and managing nonces. See the [Account documentation](../docs/Account.md#signer-utility) for in-depth information.
+`ActivatedSigner` is used to perform transactions with an instance of [Nile's Signer](https://github.com/OpenZeppelin/nile/blob/main/src/nile/signer.py) on a given Account, crafting the tx and managing nonces. The Signer instance creates the actual signature and `ActivatedSigner` invokes the Account contract's `__execute__` with said signature. See [ActivatedSigner utility](../docs/Account.md#activatedsigner-utility) for more information.

--- a/docs/Utilities.md
+++ b/docs/Utilities.md
@@ -227,4 +227,4 @@ def foo_factory(contract_defs, foo_init):
 
 ## ActivatedSigner
 
-`ActivatedSigner` is used to perform transactions with an instance of [Nile's Signer](https://github.com/OpenZeppelin/nile/blob/main/src/nile/signer.py) on a given Account, crafting the tx and managing nonces. The `Signer` instance creates the actual signature and `ActivatedSigner` invokes the Account contract's `__execute__` with said signature. See [ActivatedSigner utility](../docs/Account.md#activatedsigner-utility) for more information.
+`ActivatedSigner` is used to perform transactions with an instance of [Nile's Signer](https://github.com/OpenZeppelin/nile/blob/main/src/nile/signer.py) on a given Account, crafting the transaction and managing nonces. The `Signer` instance manages signatures and is leveraged by `ActivatedSigner` to operate with the Account contract's `__execute__` method. See [ActivatedSigner utility](../docs/Account.md#activatedsigner-utility) for more information.

--- a/docs/Utilities.md
+++ b/docs/Utilities.md
@@ -227,4 +227,4 @@ def foo_factory(contract_defs, foo_init):
 
 ## ActivatedSigner
 
-`ActivatedSigner` is used to perform transactions with an instance of [Nile's Signer](https://github.com/OpenZeppelin/nile/blob/main/src/nile/signer.py) on a given Account, crafting the tx and managing nonces. The Signer instance creates the actual signature and `ActivatedSigner` invokes the Account contract's `__execute__` with said signature. See [ActivatedSigner utility](../docs/Account.md#activatedsigner-utility) for more information.
+`ActivatedSigner` is used to perform transactions with an instance of [Nile's Signer](https://github.com/OpenZeppelin/nile/blob/main/src/nile/signer.py) on a given Account, crafting the tx and managing nonces. The `Signer` instance creates the actual signature and `ActivatedSigner` invokes the Account contract's `__execute__` with said signature. See [ActivatedSigner utility](../docs/Account.md#activatedsigner-utility) for more information.

--- a/docs/Utilities.md
+++ b/docs/Utilities.md
@@ -225,6 +225,6 @@ def foo_factory(contract_defs, foo_init):
     return cached_foo  # return cached contracts
 ```
 
-## ActivatedSigner
+## TestSigner
 
-`ActivatedSigner` is used to perform transactions with an instance of [Nile's Signer](https://github.com/OpenZeppelin/nile/blob/main/src/nile/signer.py) on a given Account, crafting the transaction and managing nonces. The `Signer` instance manages signatures and is leveraged by `ActivatedSigner` to operate with the Account contract's `__execute__` method. See [ActivatedSigner utility](../docs/Account.md#activatedsigner-utility) for more information.
+`TestSigner` is used to perform transactions with an instance of [Nile's Signer](https://github.com/OpenZeppelin/nile/blob/main/src/nile/signer.py) on a given Account, crafting the transaction and managing nonces. The `Signer` instance manages signatures and is leveraged by `TestSigner` to operate with the Account contract's `__execute__` method. See [TestSigner utility](../docs/Account.md#activatedsigner-utility) for more information.

--- a/tests/access/test_Ownable.py
+++ b/tests/access/test_Ownable.py
@@ -1,9 +1,9 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
-from utils import Signer, contract_path
+from utils import ActivatedSigner, contract_path
 
 
-signer = Signer(123456789987654321)
+signer = ActivatedSigner(123456789987654321)
 
 
 @pytest.fixture(scope='module')

--- a/tests/access/test_Ownable.py
+++ b/tests/access/test_Ownable.py
@@ -1,9 +1,9 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
-from utils import ActivatedSigner, contract_path
+from utils import TestSigner, contract_path
 
 
-signer = ActivatedSigner(123456789987654321)
+signer = TestSigner(123456789987654321)
 
 
 @pytest.fixture(scope='module')

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -2,11 +2,11 @@ import pytest
 from starkware.starknet.testing.starknet import Starknet
 from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
-from utils import Signer, assert_revert, contract_path
+from utils import ActivatedSigner, assert_revert, contract_path
 
 
-signer = Signer(123456789987654321)
-other = Signer(987654321123456789)
+signer = ActivatedSigner(123456789987654321)
+other = ActivatedSigner(987654321123456789)
 
 IACCOUNT_ID = 0xf10dbd44
 TRUE = 1

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -2,11 +2,11 @@ import pytest
 from starkware.starknet.testing.starknet import Starknet
 from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
-from utils import ActivatedSigner, assert_revert, contract_path
+from utils import TestSigner, assert_revert, contract_path
 
 
-signer = ActivatedSigner(123456789987654321)
-other = ActivatedSigner(987654321123456789)
+signer = TestSigner(123456789987654321)
+other = TestSigner(987654321123456789)
 
 IACCOUNT_ID = 0xf10dbd44
 TRUE = 1

--- a/tests/account/test_AddressRegistry.py
+++ b/tests/account/test_AddressRegistry.py
@@ -1,9 +1,9 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
-from utils import Signer, contract_path
+from utils import ActivatedSigner, contract_path
 
 
-signer = Signer(123456789987654321)
+signer = ActivatedSigner(123456789987654321)
 L1_ADDRESS = 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
 ANOTHER_ADDRESS = 0xd9e1ce17f2641f24ae83637ab66a2cca9c378b9f
 

--- a/tests/account/test_AddressRegistry.py
+++ b/tests/account/test_AddressRegistry.py
@@ -1,9 +1,9 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
-from utils import ActivatedSigner, contract_path
+from utils import TestSigner, contract_path
 
 
-signer = ActivatedSigner(123456789987654321)
+signer = TestSigner(123456789987654321)
 L1_ADDRESS = 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
 ANOTHER_ADDRESS = 0xd9e1ce17f2641f24ae83637ab66a2cca9c378b9f
 

--- a/tests/token/erc20/test_ERC20.py
+++ b/tests/token/erc20/test_ERC20.py
@@ -1,12 +1,12 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    ActivatedSigner, to_uint, add_uint, sub_uint, str_to_felt, MAX_UINT256, 
+    TestSigner, to_uint, add_uint, sub_uint, str_to_felt, MAX_UINT256, 
     ZERO_ADDRESS, INVALID_UINT256, TRUE, get_contract_def, cached_contract, 
     assert_revert, assert_event_emitted, contract_path
 )
 
-signer = ActivatedSigner(123456789987654321)
+signer = TestSigner(123456789987654321)
 
 # testing vars
 RECIPIENT = 123

--- a/tests/token/erc20/test_ERC20.py
+++ b/tests/token/erc20/test_ERC20.py
@@ -1,11 +1,12 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    Signer, to_uint, add_uint, sub_uint, str_to_felt, MAX_UINT256, ZERO_ADDRESS, INVALID_UINT256,
-    TRUE, get_contract_def, cached_contract, assert_revert, assert_event_emitted, contract_path
+    ActivatedSigner, to_uint, add_uint, sub_uint, str_to_felt, MAX_UINT256, 
+    ZERO_ADDRESS, INVALID_UINT256, TRUE, get_contract_def, cached_contract, 
+    assert_revert, assert_event_emitted, contract_path
 )
 
-signer = Signer(123456789987654321)
+signer = ActivatedSigner(123456789987654321)
 
 # testing vars
 RECIPIENT = 123

--- a/tests/token/erc20/test_ERC20_Burnable_mock.py
+++ b/tests/token/erc20/test_ERC20_Burnable_mock.py
@@ -1,11 +1,11 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    ActivatedSigner, to_uint, add_uint, sub_uint, str_to_felt, ZERO_ADDRESS, INVALID_UINT256,
+    TestSigner, to_uint, add_uint, sub_uint, str_to_felt, ZERO_ADDRESS, INVALID_UINT256,
     get_contract_def, cached_contract, assert_revert, assert_event_emitted, 
 )
 
-signer = ActivatedSigner(123456789987654321)
+signer = TestSigner(123456789987654321)
 
 # testing vars
 INIT_SUPPLY = to_uint(1000)

--- a/tests/token/erc20/test_ERC20_Burnable_mock.py
+++ b/tests/token/erc20/test_ERC20_Burnable_mock.py
@@ -1,5 +1,4 @@
 import pytest
-import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
     ActivatedSigner, to_uint, add_uint, sub_uint, str_to_felt, ZERO_ADDRESS, INVALID_UINT256,

--- a/tests/token/erc20/test_ERC20_Burnable_mock.py
+++ b/tests/token/erc20/test_ERC20_Burnable_mock.py
@@ -2,11 +2,11 @@ import pytest
 import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    Signer, to_uint, add_uint, sub_uint, str_to_felt, ZERO_ADDRESS, INVALID_UINT256,
-    get_contract_def, cached_contract, assert_revert, assert_event_emitted, contract_path
+    ActivatedSigner, to_uint, add_uint, sub_uint, str_to_felt, ZERO_ADDRESS, INVALID_UINT256,
+    get_contract_def, cached_contract, assert_revert, assert_event_emitted, 
 )
 
-signer = Signer(123456789987654321)
+signer = ActivatedSigner(123456789987654321)
 
 # testing vars
 INIT_SUPPLY = to_uint(1000)
@@ -15,9 +15,6 @@ UINT_ONE = to_uint(1)
 NAME = str_to_felt("Mintable Token")
 SYMBOL = str_to_felt("MTKN")
 DECIMALS = 18
-
-
-signer = Signer(123456789987654321)
 
 
 @pytest.fixture(scope='module')

--- a/tests/token/erc20/test_ERC20_Mintable.py
+++ b/tests/token/erc20/test_ERC20_Mintable.py
@@ -1,12 +1,12 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    ActivatedSigner, to_uint, add_uint, sub_uint, str_to_felt, 
+    TestSigner, to_uint, add_uint, sub_uint, str_to_felt, 
     MAX_UINT256, ZERO_ADDRESS, INVALID_UINT256, get_contract_def, 
     cached_contract, assert_revert, assert_event_emitted
 )
 
-signer = ActivatedSigner(123456789987654321)
+signer = TestSigner(123456789987654321)
 
 # testing vars
 RECIPIENT = 123

--- a/tests/token/erc20/test_ERC20_Mintable.py
+++ b/tests/token/erc20/test_ERC20_Mintable.py
@@ -1,11 +1,12 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    Signer, to_uint, add_uint, sub_uint, str_to_felt, MAX_UINT256, ZERO_ADDRESS, INVALID_UINT256,
-    get_contract_def, cached_contract, assert_revert, assert_event_emitted
+    ActivatedSigner, to_uint, add_uint, sub_uint, str_to_felt, 
+    MAX_UINT256, ZERO_ADDRESS, INVALID_UINT256, get_contract_def, 
+    cached_contract, assert_revert, assert_event_emitted
 )
 
-signer = Signer(123456789987654321)
+signer = ActivatedSigner(123456789987654321)
 
 # testing vars
 RECIPIENT = 123

--- a/tests/token/erc20/test_ERC20_Pausable.py
+++ b/tests/token/erc20/test_ERC20_Pausable.py
@@ -1,11 +1,11 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    Signer, TRUE, FALSE, to_uint, str_to_felt, assert_revert, get_contract_def,
-    cached_contract
+    ActivatedSigner, TRUE, FALSE, to_uint, str_to_felt, assert_revert, 
+    get_contract_def, cached_contract
 )
 
-signer = Signer(123456789987654321)
+signer = ActivatedSigner(123456789987654321)
 
 # testing vars
 INIT_SUPPLY = to_uint(1000)

--- a/tests/token/erc20/test_ERC20_Pausable.py
+++ b/tests/token/erc20/test_ERC20_Pausable.py
@@ -1,11 +1,11 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    ActivatedSigner, TRUE, FALSE, to_uint, str_to_felt, assert_revert, 
+    TestSigner, TRUE, FALSE, to_uint, str_to_felt, assert_revert, 
     get_contract_def, cached_contract
 )
 
-signer = ActivatedSigner(123456789987654321)
+signer = TestSigner(123456789987654321)
 
 # testing vars
 INIT_SUPPLY = to_uint(1000)

--- a/tests/token/erc20/test_ERC20_Upgradeable.py
+++ b/tests/token/erc20/test_ERC20_Upgradeable.py
@@ -1,12 +1,12 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    ActivatedSigner, to_uint, sub_uint, str_to_felt, assert_revert,
+    TestSigner, to_uint, sub_uint, str_to_felt, assert_revert,
     get_contract_def, cached_contract
 )
 
 
-signer = ActivatedSigner(123456789987654321)
+signer = TestSigner(123456789987654321)
 
 USER = 999
 INIT_SUPPLY = to_uint(1000)

--- a/tests/token/erc20/test_ERC20_Upgradeable.py
+++ b/tests/token/erc20/test_ERC20_Upgradeable.py
@@ -1,12 +1,12 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    Signer, to_uint, sub_uint, str_to_felt, assert_revert,
+    ActivatedSigner, to_uint, sub_uint, str_to_felt, assert_revert,
     get_contract_def, cached_contract
 )
 
 
-signer = Signer(123456789987654321)
+signer = ActivatedSigner(123456789987654321)
 
 USER = 999
 INIT_SUPPLY = to_uint(1000)

--- a/tests/token/erc721/test_ERC721_Mintable_Burnable.py
+++ b/tests/token/erc721/test_ERC721_Mintable_Burnable.py
@@ -1,12 +1,12 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    ActivatedSigner, str_to_felt, ZERO_ADDRESS, TRUE, FALSE, assert_revert, INVALID_UINT256,
+    TestSigner, str_to_felt, ZERO_ADDRESS, TRUE, FALSE, assert_revert, INVALID_UINT256,
     assert_event_emitted, get_contract_def, cached_contract, to_uint, sub_uint, add_uint
 )
 
 
-signer = ActivatedSigner(123456789987654321)
+signer = TestSigner(123456789987654321)
 
 NONEXISTENT_TOKEN = to_uint(999)
 # random token IDs

--- a/tests/token/erc721/test_ERC721_Mintable_Burnable.py
+++ b/tests/token/erc721/test_ERC721_Mintable_Burnable.py
@@ -1,12 +1,12 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    Signer, str_to_felt, ZERO_ADDRESS, TRUE, FALSE, assert_revert, INVALID_UINT256,
+    ActivatedSigner, str_to_felt, ZERO_ADDRESS, TRUE, FALSE, assert_revert, INVALID_UINT256,
     assert_event_emitted, get_contract_def, cached_contract, to_uint, sub_uint, add_uint
 )
 
 
-signer = Signer(123456789987654321)
+signer = ActivatedSigner(123456789987654321)
 
 NONEXISTENT_TOKEN = to_uint(999)
 # random token IDs

--- a/tests/token/erc721/test_ERC721_Mintable_Pausable.py
+++ b/tests/token/erc721/test_ERC721_Mintable_Pausable.py
@@ -1,11 +1,12 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    Signer, str_to_felt, TRUE, FALSE, get_contract_def, cached_contract, assert_revert, to_uint
+    ActivatedSigner, str_to_felt, TRUE, FALSE, get_contract_def, cached_contract, 
+    assert_revert, to_uint
 )
 
 
-signer = Signer(123456789987654321)
+signer = ActivatedSigner(123456789987654321)
 
 # random token IDs
 TOKENS = [to_uint(5042), to_uint(793)]

--- a/tests/token/erc721/test_ERC721_Mintable_Pausable.py
+++ b/tests/token/erc721/test_ERC721_Mintable_Pausable.py
@@ -1,12 +1,12 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    ActivatedSigner, str_to_felt, TRUE, FALSE, get_contract_def, cached_contract, 
+    TestSigner, str_to_felt, TRUE, FALSE, get_contract_def, cached_contract, 
     assert_revert, to_uint
 )
 
 
-signer = ActivatedSigner(123456789987654321)
+signer = TestSigner(123456789987654321)
 
 # random token IDs
 TOKENS = [to_uint(5042), to_uint(793)]

--- a/tests/token/erc721/test_ERC721_SafeMintable_mock.py
+++ b/tests/token/erc721/test_ERC721_SafeMintable_mock.py
@@ -1,12 +1,12 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    ActivatedSigner, str_to_felt, ZERO_ADDRESS, INVALID_UINT256, assert_revert,
+    TestSigner, str_to_felt, ZERO_ADDRESS, INVALID_UINT256, assert_revert,
     assert_event_emitted, get_contract_def, cached_contract, to_uint
 )
 
 
-signer = ActivatedSigner(123456789987654321)
+signer = TestSigner(123456789987654321)
 
 # random token id
 TOKEN = to_uint(5042)

--- a/tests/token/erc721/test_ERC721_SafeMintable_mock.py
+++ b/tests/token/erc721/test_ERC721_SafeMintable_mock.py
@@ -1,12 +1,12 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    Signer, str_to_felt, ZERO_ADDRESS, INVALID_UINT256, assert_revert,
+    ActivatedSigner, str_to_felt, ZERO_ADDRESS, INVALID_UINT256, assert_revert,
     assert_event_emitted, get_contract_def, cached_contract, to_uint
 )
 
 
-signer = Signer(123456789987654321)
+signer = ActivatedSigner(123456789987654321)
 
 # random token id
 TOKEN = to_uint(5042)

--- a/tests/token/erc721_enumerable/test_ERC721_Enumerable_Mintable_Burnable.py
+++ b/tests/token/erc721_enumerable/test_ERC721_Enumerable_Mintable_Burnable.py
@@ -1,12 +1,12 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    ActivatedSigner, str_to_felt, MAX_UINT256, get_contract_def, cached_contract,
+    TestSigner, str_to_felt, MAX_UINT256, get_contract_def, cached_contract,
     TRUE, assert_revert, to_uint, sub_uint, add_uint
 )
 
 
-signer = ActivatedSigner(123456789987654321)
+signer = TestSigner(123456789987654321)
 
 # random token IDs
 TOKENS = [

--- a/tests/token/erc721_enumerable/test_ERC721_Enumerable_Mintable_Burnable.py
+++ b/tests/token/erc721_enumerable/test_ERC721_Enumerable_Mintable_Burnable.py
@@ -1,12 +1,12 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    Signer, str_to_felt, MAX_UINT256, get_contract_def, cached_contract,
+    ActivatedSigner, str_to_felt, MAX_UINT256, get_contract_def, cached_contract,
     TRUE, assert_revert, to_uint, sub_uint, add_uint
 )
 
 
-signer = Signer(123456789987654321)
+signer = ActivatedSigner(123456789987654321)
 
 # random token IDs
 TOKENS = [

--- a/tests/upgrades/test_Proxy.py
+++ b/tests/upgrades/test_Proxy.py
@@ -1,14 +1,14 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    Signer, assert_revert, get_contract_def, cached_contract
+    ActivatedSigner, assert_revert, get_contract_def, cached_contract
 )
 
 
 # random value
 VALUE = 123
 
-signer = Signer(123456789987654321)
+signer = ActivatedSigner(123456789987654321)
 
 
 @pytest.fixture(scope='module')

--- a/tests/upgrades/test_Proxy.py
+++ b/tests/upgrades/test_Proxy.py
@@ -1,14 +1,14 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    ActivatedSigner, assert_revert, get_contract_def, cached_contract
+    TestSigner, assert_revert, get_contract_def, cached_contract
 )
 
 
 # random value
 VALUE = 123
 
-signer = ActivatedSigner(123456789987654321)
+signer = TestSigner(123456789987654321)
 
 
 @pytest.fixture(scope='module')

--- a/tests/upgrades/test_upgrades.py
+++ b/tests/upgrades/test_upgrades.py
@@ -1,7 +1,7 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    ActivatedSigner, assert_revert, assert_event_emitted, get_contract_def, cached_contract
+    TestSigner, assert_revert, assert_event_emitted, get_contract_def, cached_contract
 )
 
 
@@ -9,7 +9,7 @@ from utils import (
 VALUE_1 = 123
 VALUE_2 = 987
 
-signer = ActivatedSigner(123456789987654321)
+signer = TestSigner(123456789987654321)
 
 
 @pytest.fixture(scope='module')

--- a/tests/upgrades/test_upgrades.py
+++ b/tests/upgrades/test_upgrades.py
@@ -1,7 +1,7 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    Signer, assert_revert, assert_event_emitted, get_contract_def, cached_contract
+    ActivatedSigner, assert_revert, assert_event_emitted, get_contract_def, cached_contract
 )
 
 
@@ -9,7 +9,7 @@ from utils import (
 VALUE_1 = 123
 VALUE_2 = 987
 
-signer = Signer(123456789987654321)
+signer = ActivatedSigner(123456789987654321)
 
 
 @pytest.fixture(scope='module')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -125,7 +125,7 @@ def cached_contract(state, definition, deployed):
     return contract
 
 
-class ActivatedSigner():
+class TestSigner():
     """
     Utility for sending signed transactions to an Account on Starknet.
 
@@ -136,9 +136,9 @@ class ActivatedSigner():
 
     Examples
     ---------
-    Constructing an ActivatedSigner object
+    Constructing an TestSigner object
 
-    >>> signer = ActivatedSigner(1234)
+    >>> signer = TestSigner(1234)
 
     Sending a transaction
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,6 +10,8 @@ from starkware.starknet.testing.starknet import StarknetContract
 from starkware.starknet.definitions.general_config import StarknetChainId
 from starkware.starknet.business_logic.execution.objects import Event
 from starkware.starknet.core.os.transaction_hash.transaction_hash import calculate_transaction_hash_common, TransactionHashPrefix
+from nile.signer import Signer
+
 
 
 
@@ -128,7 +130,7 @@ def cached_contract(state, definition, deployed):
     return contract
 
 
-class Signer():
+class ActivatedSigner():
     """
     Utility for sending signed transactions to an Account on Starknet.
 
@@ -139,27 +141,30 @@ class Signer():
 
     Examples
     ---------
-    Constructing a Signer object
+    Constructing an ActivatedSigner object
 
-    >>> signer = Signer(1234)
+    >>> signer = ActivatedSigner(1234)
 
     Sending a transaction
 
-    >>> await signer.send_transaction(account,
-                                      account.contract_address,
-                                      'set_public_key',
-                                      [other.public_key]
-                                     )
+    >>> await signer.send_transaction(
+            account, contract_address, 'contract_method', [arg_1]
+        )
 
+    Sending multiple transactions
+
+    >>> await signer.send_transaction(
+            account, [
+                (contract_address, 'contract_method', [arg_1]),
+                (contract_address, 'another_method', [arg_1, arg_2])
+            ]
+        )
+                           
     """
-
     def __init__(self, private_key):
-        self.private_key = private_key
-        self.public_key = private_to_stark_key(private_key)
-
-    def sign(self, message_hash):
-        return sign(msg_hash=message_hash, priv_key=self.private_key)
-
+        self.signer = Signer(private_key)
+        self.public_key = self.signer.public_key
+        
     async def send_transaction(self, account, to, selector_name, calldata, nonce=None, max_fee=0):
         return await self.send_transactions(account, [(to, selector_name, calldata)], nonce, max_fee)
 
@@ -168,40 +173,11 @@ class Signer():
             execution_info = await account.get_nonce().call()
             nonce, = execution_info.result
 
-        (call_array, calldata) = from_call_to_call_array(calls)
+        build_calls = []
+        for call in calls:
+            build_call = list(call)
+            build_call[0] = hex(build_call[0])
+            build_calls.append(build_call)
 
-        message_hash = get_transaction_hash(account.contract_address, call_array, calldata, nonce, max_fee)
-        sig_r, sig_s = self.sign(message_hash)
-
+        (call_array, calldata, sig_r, sig_s) = self.signer.sign_transaction(hex(account.contract_address), build_calls, nonce, max_fee)
         return await account.__execute__(call_array, calldata, nonce).invoke(signature=[sig_r, sig_s])
-
-
-def from_call_to_call_array(calls):
-    call_array = []
-    calldata = []
-    for i, call in enumerate(calls):
-        assert len(call) == 3, "Invalid call parameters"
-        entry = (call[0], get_selector_from_name(
-            call[1]), len(calldata), len(call[2]))
-        call_array.append(entry)
-        calldata.extend(call[2])
-    return (call_array, calldata)
-
-def get_transaction_hash(account, call_array, calldata, nonce, max_fee):
-    execute_calldata = [
-        len(call_array),
-        *[x for t in call_array for x in t],
-        len(calldata),
-        *calldata,
-        nonce]
-
-    return calculate_transaction_hash_common(
-        TransactionHashPrefix.INVOKE,
-        TRANSACTION_VERSION,
-        account,
-        get_selector_from_name('__execute__'),
-        execute_calldata,
-        max_fee,
-        StarknetChainId.TESTNET.value,
-        []
-    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -136,7 +136,7 @@ class TestSigner():
 
     Examples
     ---------
-    Constructing an TestSigner object
+    Constructing a TestSigner object
 
     >>> signer = TestSigner(1234)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,17 +2,12 @@
 
 from pathlib import Path
 import math
-from starkware.crypto.signature.signature import private_to_stark_key, sign
 from starkware.starknet.public.abi import get_selector_from_name
 from starkware.starknet.compiler.compile import compile_starknet_files
 from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.testing.starknet import StarknetContract
-from starkware.starknet.definitions.general_config import StarknetChainId
 from starkware.starknet.business_logic.execution.objects import Event
-from starkware.starknet.core.os.transaction_hash.transaction_hash import calculate_transaction_hash_common, TransactionHashPrefix
 from nile.signer import Signer
-
-
 
 
 MAX_UINT256 = (2**128 - 1, 2**128 - 1)

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps =
     cairo-lang
     cairo-nile
     pytest-xdist
+    marshmallow-dataclass==8.5.3
 extras =
     testing
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ passenv =
     PYTHONPATH
 deps =
     cairo-lang==0.8.1
-    cairo-nile
+    cairo-nile==0.6.1
     pytest-xdist
     # See https://github.com/starkware-libs/cairo-lang/issues/52
     marshmallow-dataclass==8.5.3

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ passenv =
     PYTHONPATH
 deps =
     cairo-lang
+    cairo-nile
     pytest-xdist
 extras =
     testing


### PR DESCRIPTION
This PR removes the local `Signer` in utils.py and instead imports/uses Nile's `Signer` class. This PR proposes to include the `ActivatedSigner` class. `ActivatedSigner` performs the following:
- manage nonces
- format and pass data to Nile's `Signer`
- invoke `__execute__` with the tx signature returned from Nile's Signer

Further, this PR includes updated documentation regarding how `ActivatedSigner` works with Nile's `Signer`. This resolves #221.