### PR TITLE
Reformat docs and fix ERC721 import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # OpenZeppelin Contracts for Cairo
+
 [![Tests and linter](https://github.com/OpenZeppelin/cairo-contracts/actions/workflows/python-app.yml/badge.svg)](https://github.com/OpenZeppelin/cairo-contracts/actions/workflows/python-app.yml)
 
 **A library for secure smart contract development** written in Cairo for [StarkNet](https://starkware.co/product/starknet/), a decentralized ZK Rollup.
@@ -13,13 +14,15 @@
 ### First time?
 
 Before installing Cairo on your machine, you need to install `gmp`:
+
 ```bash
 sudo apt install -y libgmp3-dev # linux
 brew install gmp # mac
 ```
+
 > If you have any troubles installing gmp on your Apple M1 computer, [here’s a list of potential solutions](https://github.com/OpenZeppelin/nile/issues/22).
 
-### Set up the project
+### Set up your project
 
 Create a directory for your project, then `cd` into it and create a Python virtual environment.
 
@@ -56,6 +59,7 @@ from openzeppelin.token.erc20.ERC20 import constructor
 ```
 
 Compile and deploy it right away:
+
 ```bash
 nile compile
 
@@ -65,6 +69,7 @@ nile deploy MyToken <name> <symbol> <decimals> <initial_supply> <recipient> --al
 > Note that `<initial_supply>` is expected to be two integers i.e. `1` `0`. See [Uint256](docs/Utilities.md#Uint256) for more information.
 
 ### Write a custom contract using library modules
+
 [Read more about libraries](docs/Extensibility.md#libraries).
 
 ```cairo
@@ -107,24 +112,31 @@ end
 ## Learn
 
 ### Contract documentation
+
 * [Account](docs/Account.md)
 * [ERC20](docs/ERC20.md)
 * [ERC721](docs/ERC721.md)
 * [Contract extensibility pattern](docs/Extensibility.md)
 * [Proxies and upgrades](docs/Proxies.md)
+* [Security](docs/Security.md)
 * [Utilities](docs/Utilities.md)
+
 ### Cairo
+
 * [StarkNet official documentation](https://www.cairo-lang.org/docs/hello_starknet/index.html#hello-starknet)
 * [Cairo language documentation](https://www.cairo-lang.org/docs/hello_cairo/index.html#hello-cairo)
 * Perama's [Cairo by example](https://perama-v.github.io/cairo/by-example/)
 * [Cairo 101 workshops](https://www.youtube.com/playlist?list=PLcIyXLwiPilV5RBZj43AX1FY4FJMWHFTY)
+
 ### Nile
+
 * [Getting started with StarkNet using Nile](https://medium.com/coinmonks/starknet-tutorial-for-beginners-using-nile-6af9c2270c15)
 * [How to manage smart contract deployments with Nile](https://medium.com/@martriay/manage-your-starknet-deployments-with-nile-%EF%B8%8F-e849d40546dd)
 
 ## Development
 
 ### Set up the project
+
 Clone the repository
 
 ```bash
@@ -140,12 +152,14 @@ source env/bin/activate
 ```
 
 Install Nile:
+
 ```bash
 pip install cairo-nile
 nile install
 ```
 
 ### Compile the contracts
+
 ```bash
 nile compile --directory src
 
@@ -205,6 +219,7 @@ This project is still in a very early and experimental phase. It has never been 
 Please report any security issues you find to security@openzeppelin.org.
 
 ## Contribute
+
 OpenZeppelin Contracts for Cairo exists thanks to its contributors. There are many ways you can participate and help build high quality software. Check out the [contribution](CONTRIBUTING.md) guide!
 
 ## License

--- a/docs/Account.md
+++ b/docs/Account.md
@@ -1,4 +1,5 @@
 # Accounts
+
 Unlike Ethereum where accounts are directly derived from a private key, there's no native account concept on StarkNet.
 
 Instead, signature validation has to be done at the contract level. To relieve smart contract applications such as ERC20 tokens or exchanges from this responsibility, we make use of Account contracts to deal with transaction authentication.
@@ -26,6 +27,7 @@ A more detailed writeup on the topic can be found on [Perama's blogpost](https:/
 ## Quickstart
 
 The general workflow is:
+
 1. Account contract is deployed to StarkNet
 2. Signed transactions can now be sent to the Account contract which validates and executes them
 
@@ -170,6 +172,7 @@ Where:
 * `version` is a fixed number which is used to invalidate old transactions
 
 This `MultiCall` message is built within the `__execute__` method which has the following interface:
+
 ```cairo
 func __execute__(
         call_array_len: felt,
@@ -206,6 +209,7 @@ await signer.send_transaction(account, registry.contract_address, 'set_L1_addres
 You can read more about how messages are structured and hashed in the [Account message scheme  discussion](https://github.com/OpenZeppelin/cairo-contracts/discussions/24). For more information on the design choices and implementation of multicall, you can read the [How should Account multicall work discussion](https://github.com/OpenZeppelin/cairo-contracts/discussions/27).
 
 > Note that the scheme of building multicall transactions within the `__execute__` method will change once StarkNet allows for pointers in struct arrays. In which case, multiple transactions can be passed to (as opposed to built within) `__execute__`.
+
 ## API Specification
 
 This in a nutshell is the Account contract public API:
@@ -236,63 +240,65 @@ func __execute__(
 end
 ```
 
-#### `get_public_key`
+### `get_public_key`
 
 Returns the public key associated with the Account contract.
 
-##### Parameters:
+Parameters:
 
 None.
 
-##### Returns:
+Returns:
 
 ```cairo
 public_key: felt
 ```
 
-#### `get_nonce`
+### `get_nonce`
 
 Returns the current transaction nonce for the Account.
 
-##### Parameters:
+Parameters:
 
 None.
 
-##### Returns:
+Returns:
 
 ```cairo
 nonce: felt
 ```
 
-#### `set_public_key`
+### `set_public_key`
 
 Sets the public key that will control this Account. It can be used to rotate keys for security, change them in case of compromised keys or even transferring ownership of the account.
 
-##### Parameters:
+Parameters:
+
 ```cairo
 public_key: felt
 ```
 
-##### Returns:
+Returns:
 
 None.
 
-#### `is_valid_signature`
+### `is_valid_signature`
 
 This function is inspired by [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) and checks whether a given signature is valid, otherwise it reverts.
 
-##### Parameters:
+Parameters:
+
 ```cairo
 hash: felt
 signature_len: felt
 signature: felt*
 ```
 
-##### Returns:
+Returns:
 
 None.
 
-#### `__execute__`
+### `__execute__`
 
 This is the only external entrypoint to interact with the Account contract. It:
 
@@ -302,7 +308,8 @@ This is the only external entrypoint to interact with the Account contract. It:
 4. Calls the target contract with the intended function selector and calldata parameters
 5. Forwards the contract call response data as return value
 
-##### Parameters:
+Parameters:
+
 ```cairo
 call_array_len: felt
 call_array: AccountCallArray*
@@ -313,7 +320,8 @@ nonce: felt
 
 > Note that the current signature scheme expects a 2-element array like `[sig_r, sig_s]`.
 
-##### Returns:
+Returns:
+
 ```cairo
 response_len: felt
 response: felt*
@@ -338,6 +346,7 @@ Currently, there's only a single library/preset Account scheme, but we're lookin
 ## L1 escape hatch mechanism
 
 *[unknown, to be defined]*
+
 ## Paying for gas
 
 *[unknown, to be defined]*

--- a/docs/ERC721.md
+++ b/docs/ERC721.md
@@ -256,7 +256,7 @@ Following the [contracts extensibility pattern](Extensibility.md), this implemen
 Just be sure that the exposed `external` methods invoke their imported function logic a la `approve` invokes `ERC721_approve`. As an example, see below.
 
 ```python
-from contracts.token.ERC721_base import ERC721_approve
+from openzeppelin.token.erc721.library import ERC721_approve
 
 @external
 func approve{

--- a/docs/ERC721.md
+++ b/docs/ERC721.md
@@ -7,24 +7,24 @@ The ERC721 token standard is a specification for [non-fungible tokens](https://d
 - [IERC721](#ierc721)
 - [ERC721 Compatibility](#erc721-compatibility)
 - [Usage](#usage)
-  *  [Token Transfers](#token-transfers)
-  *  [Interpreting ERC721 URIs](#interpreting-erc721-uris)
-  *  [ERC721Received](#erc721received)
-      -  [IERC721_Receiver](#ierc721_receiver)
-  *  [Supporting Interfaces](#supporting-interfaces)
-  *  [Ready-to-Use Presets](#ready-to-use-presets)
+  - [Token Transfers](#token-transfers)
+  - [Interpreting ERC721 URIs](#interpreting-erc721-uris)
+  - [ERC721Received](#erc721received)
+    - [IERC721_Receiver](#ierc721_receiver)
+  - [Supporting Interfaces](#supporting-interfaces)
+  - [Ready-to-Use Presets](#ready-to-use-presets)
 - [Extensibility](#extensibility)
 - [Presets](#presets)
-  *  [ERC721_Mintable_Burnable](#erc721_mintable_burnable)
-  *  [ERC721_Mintable_Pausable](#erc721_mintable_pausable)
-  *  [ERC721_Enumerable_Mintable_Burnable](#erc721_enumerable_mintable_burnable)
-      -  [IERC721_Enumerable](#ierc721_enumerable)
-  *  [ERC721_Metadata](#erc721_metadata)
-      -  [IERC721_Metadata](#ierc721_metadata)
+  - [ERC721_Mintable_Burnable](#erc721_mintable_burnable)
+  - [ERC721_Mintable_Pausable](#erc721_mintable_pausable)
+  - [ERC721_Enumerable_Mintable_Burnable](#erc721_enumerable_mintable_burnable)
+    - [IERC721_Enumerable](#ierc721_enumerable)
+  - [ERC721_Metadata](#erc721_metadata)
+    - [IERC721_Metadata](#ierc721_metadata)
 - [Utilities](#utilities)
-  *  [ERC721_Holder](#erc721_holder)
+  - [ERC721_Holder](#erc721_holder)
 - [API Specification](#api-specification)
-  * [`IERC721`](#ierc721-api)
+  - [`IERC721`](#ierc721-api)
     - [`balanceOf`](#balanceof)
     - [`ownerOf`](#ownerof)
     - [`safeTransferFrom`](#safetransferfrom)
@@ -33,27 +33,26 @@ The ERC721 token standard is a specification for [non-fungible tokens](https://d
     - [`setApprovalForAll`](#setapprovalforall)
     - [`getApproved`](#getapproved)
     - [`isApprovedForAll`](#isapprovedforall)
-  * [Events](#events)
+  - [Events](#events)
     - [`Approval (event)`](#approval-event)
     - [`ApprovalForAll (event)`](#approvalforall-event)
     - [`Transfer (event)`](#transfer-event)
-  * [`IERC721_Metadata`](#ierc721_metadata)
+  - [`IERC721_Metadata`](#ierc721_metadata)
     - [`name`](#name)
     - [`symbol`](#symbol)
     - [`tokenURI`](#tokenuri)
-  * [`IERC721_Enumerable`](#ierc721_enumerable)
+  - [`IERC721_Enumerable`](#ierc721_enumerable)
     - [`totalSupply`](#totalsupply)
     - [`tokenByIndex`](#tokenbyindex)
     - [`tokenOfOwnerByIndex`](#tokenofownerbyindex)
-  * [`IERC721_Receiver`](#ierc721_receiver)
+  - [`IERC721_Receiver`](#ierc721_receiver)
     - [`onERC721Received`](#onerc721received)
 
 - [ERC165](#erc165)
-  * [IERC165](#ierc165)
-  * [ERC165 API Specification](#erc165-api-specification)
+  - [IERC165](#ierc165)
+  - [ERC165 API Specification](#erc165-api-specification)
     - [`IERC165`](#ierc165)
       - [`supportsInterface`](#supportsinterface)
-
 
 ## IERC721
 
@@ -168,6 +167,7 @@ await signer.send_transaction(
 ### Token Transfers
 
 EIP721 discourages the use of `transferFrom` and favors `safeTransferFrom` in regard to token transfers. The safe function adds the following conditional logic:
+
 1. if the calling address is an account contract, the token transfer will behave as if `transferFrom` was called
 2. if the calling address is not an account contract, the safe function will check that the contract supports ERC721 tokens
 
@@ -176,6 +176,7 @@ The current implementation of `safeTansferFrom` checks for `onERC721Received` an
 Please be aware that transferring tokens with `transferFrom` to a contract that does not support ERC721 can result in lost tokens forever.
 
 ### Interpreting ERC721 URIs
+
 Token URIs in Cairo are stored as single field elements. Each field element equates to 252-bits (or  31.5 bytes) which means that a token's URI can be no longer than 31 characters.
 > Note that storing the URI as an array of felts was considered to accommodate larger strings. While this approach is more flexible regarding URIs, a returned array further deviates from the standard set in [EIP721](https://eips.ethereum.org/EIPS/eip-721). Therefore, this library's ERC721 implementation sets URIs as a single field element.
 
@@ -237,15 +238,17 @@ Further, this implementation stores supported interfaces in a mapping (similar t
 ### Ready-to-Use Presets
 
 ERC721 presets have been created to allow for quick deployments as-is. To be as explicit as possible, each preset includes the additional features they offer in the contract name. For example:
--  `ERC721_Mintable_Burnable` includes `mint` and `burn`
--  `ERC721_Mintable_Pausable` includes `mint`, `pause`, and `unpause`
--  `ERC721_Enumerable_Mintable_Burnable` includes `mint`, `burn`, and [IERC721_Enumerable](#ierc721_enumerable) methods
+
+- `ERC721_Mintable_Burnable` includes `mint` and `burn`
+- `ERC721_Mintable_Pausable` includes `mint`, `pause`, and `unpause`
+- `ERC721_Enumerable_Mintable_Burnable` includes `mint`, `burn`, and [IERC721_Enumerable](#ierc721_enumerable) methods
 
 Ready-to-use presets are a great option for testing and prototyping. See [Presets](#presets).
 
 ## Extensibility
 
 Following the [contracts extensibility pattern](Extensibility.md), this implementation is set up to include all ERC721 storage and function logic within the `ERC721_base.cairo` library. Library methods with the prefix `ERC721_` must be imported in the smart contract and inserted into an `external` method with the requisite name. This is already done in the [preset contracts](#presets); however, additional functionality can be added. For instance, you could:
+
 - Implement a pausing mechanism
 - Add roles such as _owner_ or _minter_
 - Modify the `transferFrom` function to mimic the [`_beforeTokenTransfer` and `_afterTokenTransfer` hooks](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol#L335)
@@ -284,15 +287,17 @@ The `ERC721_Mintable_Pausable` preset creates a contract with pausable token tra
 The `ERC721_Enumerable_Mintable_Burnable` preset adds enumerability of all the token ids in the contract as well as all token ids owned by each account. This allows contracts to publish its full list of NFTs and make them discoverable.
 
 In regard to implementation, contracts should import the following view methods:
--  `ERC721_Enumerable_totalSupply`
--  `ERC721_Enumerable_tokenByIndex`
--  `ERC721_Enumerable_tokenOfOwnerByIndex`
+
+- `ERC721_Enumerable_totalSupply`
+- `ERC721_Enumerable_tokenByIndex`
+- `ERC721_Enumerable_tokenOfOwnerByIndex`
 
 In order for the tokens to be correctly indexed, the contract should also import the following methods (which supercede some of the `ERC721_base` methods):
--  `ERC721_Enumerable_transferFrom`
--  `ERC721_Enumerable_safeTransferFrom`
--  `ERC721_Enumerable_mint`
--  `ERC721_Enumerable_burn`
+
+- `ERC721_Enumerable_transferFrom`
+- `ERC721_Enumerable_safeTransferFrom`
+- `ERC721_Enumerable_mint`
+- `ERC721_Enumerable_burn`
 
 #### IERC721_Enumerable
 
@@ -558,6 +563,7 @@ tokenId: Uint256
 ---
 
 ### IERC721_Metadata API
+
 ```cairo
 func name() -> (name: felt):
 end
@@ -616,6 +622,7 @@ tokenURI: felt
 ---
 
 ### IERC721_Enumerable API
+
 ```cairo
 
 func totalSupply() -> (totalSupply: Uint256):
@@ -676,6 +683,7 @@ tokenId: Uint256
 ---
 
 ### IERC721_Receiver API
+
 ```cairo
 func onERC721Received(
         operator: felt,
@@ -690,7 +698,6 @@ end
 #### `onERC721Received`
 
 Whenever an IERC721 `tokenId` token is transferred to this non-account contract via `safeTransferFrom` by `operator` from `from_`, this function is called.
-
 
 Parameters:
 
@@ -716,8 +723,8 @@ Cairo contracts, like Ethereum contracts, have no native concept of an interface
 
 It should be noted that the [constants library](../src/openzeppelin/utils/constants.cairo) includes constant variables referencing all of the interface ids used in these contracts. This allows for more legible code i.e. using `IERC165_ID` instead of `0x01ffc9a7`.
 
-
 ### IERC165
+
 ```cairo
 @contract_interface
 namespace IERC165:
@@ -727,6 +734,7 @@ end
 ```
 
 ### ERC165 API Specification
+
 ```cairo
 func supportsInterface(interfaceId: felt) -> (success: felt):
 end

--- a/docs/Extensibility.md
+++ b/docs/Extensibility.md
@@ -15,9 +15,9 @@ Smart contract development is a critical task. As with all software development,
 
 One of the best approaches to minimize introducing bugs is to reuse existing, battle-tested code, a.k.a. using libraries. But code reutilization in StarkNet’s smart contracts is not easy:
 
-- Cairo has no explicit smart contract extension mechanisms such as inheritance or composability
-- Using imports for modularity can result in clashes (more so given that arguments are not part of the selector), and lack of overrides or aliasing leaves no way to resolve them
-- Any `@external` function defined in an imported module will be automatically re-exposed by the importer (i.e. the smart contract)
+* Cairo has no explicit smart contract extension mechanisms such as inheritance or composability
+* Using imports for modularity can result in clashes (more so given that arguments are not part of the selector), and lack of overrides or aliasing leaves no way to resolve them
+* Any `@external` function defined in an imported module will be automatically re-exposed by the importer (i.e. the smart contract)
 
 To overcome these problems, this project builds on the following guidelines™.
 
@@ -29,18 +29,18 @@ To minimize risk, boilerplate, and avoid function naming clashes, we follow thes
 
 ### Libraries
 
-- All function and storage variable names must be prefixed with the file name to prevent clashing with other libraries (e.g. `ERC20_approve` in the `ERC20` library)
-- Must not implement any `@external` or `@view` functions
-- Must not implement constructors
-- Must not call initializers on any function
-- Should implement initializer functions to mimic construction logic if needed (as any other library function, never as `@external`)
+* All function and storage variable names must be prefixed with the file name to prevent clashing with other libraries (e.g. `ERC20_approve` in the `ERC20` library)
+* Must not implement any `@external` or `@view` functions
+* Must not implement constructors
+* Must not call initializers on any function
+* Should implement initializer functions to mimic construction logic if needed (as any other library function, never as `@external`)
 
 ### Contracts
 
-- Can import from libraries
-- Should implement `@external` functions if needed
-- Should implement a constructor that calls initializers
-- Must not call initializers in any function beside the constructor
+* Can import from libraries
+* Should implement `@external` functions if needed
+* Should implement a constructor that calls initializers
+* Must not call initializers in any function beside the constructor
 
 Note that since initializers will never be marked as `@external` and they won’t be called from anywhere but the contract constructor, there’s no risk of re-initialization after deployment. It’s up to the library developers not to make initializers interdependent to avoid weird dependency paths that may lead to double initialization of libraries.
 
@@ -50,15 +50,15 @@ Presets are pre-written contracts that extend from our library of contracts. The
 
 Some presets are:
 
-- [Account](../src/openzeppelin/account/Account.cairo)
-- [ERC165](../tests/mocks/ERC165.cairo)
-- [ERC20_Mintable](../src/openzeppelin/token/erc20/ERC20_Mintable.cairo)
-- [ERC20_Pausable](../src/openzeppelin/token/erc20/ERC20_Pausable.cairo)
-- [ERC20_Upgradeable](../src/openzeppelin/token/erc20/ERC20_Upgradeable.cairo)
-- [ERC20](../src/openzeppelin/token/erc20/ERC20.cairo)
-- [ERC721_Mintable_Burnable](../src/openzeppelin/token/erc721/ERC721_Mintable_Burnable.cairo)
-- [ERC721_Mintable_Pausable](../src/openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo)
-- [ERC721_Enumerable_Mintable_Burnable](../src/openzeppelin/token/erc721_enumerable/ERC721_Enumerable_Mintable_Burnable.cairo)
+* [Account](../src/openzeppelin/account/Account.cairo)
+* [ERC165](../tests/mocks/ERC165.cairo)
+* [ERC20_Mintable](../src/openzeppelin/token/erc20/ERC20_Mintable.cairo)
+* [ERC20_Pausable](../src/openzeppelin/token/erc20/ERC20_Pausable.cairo)
+* [ERC20_Upgradeable](../src/openzeppelin/token/erc20/ERC20_Upgradeable.cairo)
+* [ERC20](../src/openzeppelin/token/erc20/ERC20.cairo)
+* [ERC721_Mintable_Burnable](../src/openzeppelin/token/erc721/ERC721_Mintable_Burnable.cairo)
+* [ERC721_Mintable_Pausable](../src/openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo)
+* [ERC721_Enumerable_Mintable_Burnable](../src/openzeppelin/token/erc721_enumerable/ERC721_Enumerable_Mintable_Burnable.cairo)
 
 ## Emulating hooks
 

--- a/docs/Proxies.md
+++ b/docs/Proxies.md
@@ -3,6 +3,7 @@
 > Expect rapid iteration as this pattern matures and more patterns potentially emerge.
 
 ## Table of Contents
+
 * [Quickstart](#quickstart)
 * [Proxies](#proxies)
   * [Proxy contract](#proxy-contract)
@@ -18,6 +19,7 @@
 ## Quickstart
 
 The general workflow is:
+
 1. deploy implementation contract
 2. deploy proxy contract with the implementation contract's address set in the proxy's constructor calldata
 3. initialize the implementation contract by sending a call to the proxy contract. This will redirect the call to the implementation contract and behave like the implementation contract's constructor
@@ -66,31 +68,34 @@ Since this proxy is designed to work both as an [UUPS-flavored upgrade proxy](ht
 
 When interacting with the contract, function calls should be sent by the user to the proxy. The proxy's fallback function redirects the function call to the implementation contract to execute.
 
-
 ### Implementation contract
 
 The implementation contract, also known as the logic contract, receives the redirected function calls from the proxy contract. The implementation contract should follow the [Extensibility pattern](../docs/Extensibility.md#the-pattern) and import directly from the [Proxy library](../src/openzeppelin/upgrades/library.cairo).
 
-
 The implementation contract should:
-- import `Proxy_initializer` and `Proxy_set_implementation`
-- initialize the proxy immediately after contract deployment.
+
+* import `Proxy_initializer` and `Proxy_set_implementation`
+* initialize the proxy immediately after contract deployment.
 
 If the implementation is upgradeable, it should:
-- include a method to upgrade the implementation (i.e. `upgrade`)
-- use access control to protect the contract's upgradeability.
+
+* include a method to upgrade the implementation (i.e. `upgrade`)
+* use access control to protect the contract's upgradeability.
 
 The implementation contract should NOT:
-- deploy with a traditional constructor. Instead, use an initializer method that invokes `Proxy_initializer`.
+
+* deploy with a traditional constructor. Instead, use an initializer method that invokes `Proxy_initializer`.
 
 > Note that the imported `Proxy_initializer` includes a check the ensures the initializer can only be called once; however, `Proxy_set_implementation` does not include this check. It's up to the developers to protect their implementation contract's upgradeability with access controls such as [`Proxy_only_admin`](#proxy_only_admin).
 
 For a full implementation contract example, please see:
-- [Proxiable implementation](../tests/mocks/proxiable_implementation.cairo)
+
+* [Proxiable implementation](../tests/mocks/proxiable_implementation.cairo)
 
 ## Upgrades library API
 
 ### Methods
+
 ```cairo
 func Proxy_initializer(proxy_admin: felt):
 end
@@ -216,7 +221,6 @@ implementation: felt
 
 To upgrade a contract, the implementation contract should include an `upgrade` method that, when called, changes the reference to a new deployed contract like this:
 
-
 ```python
     # deploy first implementation
     IMPLEMENTATION = await starknet.deploy(
@@ -247,8 +251,9 @@ To upgrade a contract, the implementation contract should include an `upgrade` m
 ```
 
 For a full deployment and upgrade implementation, please see:
-- [Upgrades V1](../tests/mocks/upgrades_v1_mock.cairo)
-- [Upgrades V2](../tests/mocks/upgrades_v2_mock.cairo)
+
+* [Upgrades V1](../tests/mocks/upgrades_v1_mock.cairo)
+* [Upgrades V2](../tests/mocks/upgrades_v2_mock.cairo)
 
 ### Handling method calls
 
@@ -269,5 +274,6 @@ result = await signer.send_transaction(
 Presets are pre-written contracts that extend from our library of contracts. They can be deployed as-is or used as templates for customization.
 
 Some presets include:
-- [ERC20_Upgradeable](../src/openzeppelin/token/erc20/ERC20_Upgradeable.cairo)
-- more to come! have an idea? [open an issue](https://github.com/OpenZeppelin/cairo-contracts/issues/new/choose)!
+
+* [ERC20_Upgradeable](../src/openzeppelin/token/erc20/ERC20_Upgradeable.cairo)
+* more to come! have an idea? [open an issue](https://github.com/OpenZeppelin/cairo-contracts/issues/new/choose)!

--- a/docs/Utilities.md
+++ b/docs/Utilities.md
@@ -30,12 +30,11 @@ To ease the readability of Cairo contracts, this project includes reusable [cons
 
 ## Strings
 
-Cairo currently only provides support for short string literals (less than 32 characters). Note that short strings aren't really strings, rather, they're representations of Cairo field elements. The following methods provide a simple conversion to/from field elements. 
+Cairo currently only provides support for short string literals (less than 32 characters). Note that short strings aren't really strings, rather, they're representations of Cairo field elements. The following methods provide a simple conversion to/from field elements.
 
 ### `str_to_felt`
 
 Takes an ASCII string and converts it to a field element via big endian representation.
-
 
 ### `felt_to_str`
 
@@ -45,7 +44,7 @@ Takes an integer and converts it to an ASCII string by trimming the null bytes a
 
 Cairo's native data type is a field element (felt). Felts equate to 252 bits which poses a problem regarding 256-bit integer integration. To resolve the bit discrepancy, Cairo represents 256-bit integers as a struct of two 128-bit integers. Further, the low bits precede the high bits e.g.
 
-```
+```python
 1 = (1, 0)
 1 << 128 = (0, 1)
 (1 << 128) - 1 = (340282366920938463463374607431768211455, 0)
@@ -56,7 +55,6 @@ Cairo's native data type is a field element (felt). Felts equate to 252 bits whi
 Converts a simple integer into a uint256-ish tuple.
 
 > Note `to_uint` should be used in favor of `uint`, as `uint` only returns the low bits of the tuple.
-
 
 ### `to_uint`
 
@@ -185,7 +183,7 @@ assert_event_emitted(
 
 ## Memoization
 
-Memoizing functions allow for quicker and computationally cheaper calculations which is immensely beneficial while testing smart contracts. 
+Memoizing functions allow for quicker and computationally cheaper calculations which is immensely beneficial while testing smart contracts.
 
 ### `get_contract_def`
 


### PR DESCRIPTION
This PR proposes to fix the documentation according to the markdown linter—mostly just adding spaces between headers and consistent bullet points. This PR also fixes the ERC721 docs example which imports from the old repo structure: `contracts.token.ERC721_base`