### PR TITLE
Pin marshmallow and cairo-lang, gitignore node.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# nile
+*node.json*

--- a/tox.ini
+++ b/tox.ini
@@ -15,12 +15,10 @@ passenv =
     HOME
     PYTHONPATH
 deps =
-    #cairo-lang
     cairo-lang==0.8.1
     pytest-xdist
     # See https://github.com/starkware-libs/cairo-lang/issues/52
     marshmallow-dataclass==8.5.3
-    #starknet-devnet
 extras =
     testing
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -15,10 +15,12 @@ passenv =
     HOME
     PYTHONPATH
 deps =
-    cairo-lang
+    #cairo-lang
+    cairo-lang==0.8.1
     pytest-xdist
     # See https://github.com/starkware-libs/cairo-lang/issues/52
     marshmallow-dataclass==8.5.3
+    #starknet-devnet
 extras =
     testing
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,8 @@ passenv =
 deps =
     cairo-lang
     pytest-xdist
+    # See https://github.com/starkware-libs/cairo-lang/issues/52
+    marshmallow-dataclass==8.5.3
 extras =
     testing
 commands =


### PR DESCRIPTION
This PR proposes to pin the the `marshmallow-dataclass` dependency to its previous (working) version v8.5.3 ([issue here](https://github.com/starkware-libs/cairo-lang/issues/52)). Further, this PR proposes to pin `cairo-lang` to v.0.8.1. There appears to be an issue with its release in pip, and I suspect it has to do with the yanked version ([see here](https://pypi.org/project/cairo-lang/#history)).

Finally, this PR adds `node.json` to `.gitignore` as suggested [here](https://github.com/OpenZeppelin/cairo-contracts/pull/240#discussion_r858493888) by @Amxx.