### PR TITLE
Fix IAccount import

### DIFF
--- a/src/openzeppelin/account/IAccount.cairo
+++ b/src/openzeppelin/account/IAccount.cairo
@@ -3,7 +3,7 @@
 
 %lang starknet
 
-from openzeppelin.account.Account import AccountCallArray
+from openzeppelin.account.library import AccountCallArray
 
 @contract_interface
 namespace IAccount:


### PR DESCRIPTION
This PR changes IAccount's import of `AccountCallArray` from the library instead of the contract. This resolves #291.