### PR TITLE
Add get_implementation view to proxy contract

### DIFF
--- a/src/openzeppelin/upgrades/Proxy.cairo
+++ b/src/openzeppelin/upgrades/Proxy.cairo
@@ -7,7 +7,8 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import delegate_l1_handler, delegate_call
 from openzeppelin.upgrades.library import (
     Proxy_implementation_address,
-    Proxy_set_implementation
+    Proxy_set_implementation,
+    Proxy_get_implementation,
 )
 
 #
@@ -76,4 +77,18 @@ func __l1_default__{
     )
 
     return ()
+end
+
+#
+# Views
+#
+
+@view
+func get_implementation{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }() -> (implementation: felt):
+    let (implementation) = Proxy_get_implementation()
+    return (implementation=implementation)
 end


### PR DESCRIPTION
Currently proxy contracts are not required to provide a view for accessing implementation address, instead it must be either added to the implementation contract, or address has to be accessed by making `get_storage_at` call with appropriate key. 

This PR adds `get_implementation` view to Proxy contract, to make it consistent with how [Argent proxy contract](https://github.com/argentlabs/argent-contracts-starknet/blob/develop/contracts/Proxy.cairo#L80) works.