### PR TITLE
Update extensibility pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,23 +77,8 @@ nile deploy MyToken <name> <symbol> <decimals> <initial_supply> <recipient> --al
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.uint256 import Uint256
-from openzeppelin.security.pausable import Pausable_when_not_paused
-from openzeppelin.token.erc20.library import (
-    ERC20_name,
-    ERC20_symbol,
-    ERC20_totalSupply,
-    ERC20_decimals,
-    ERC20_balanceOf,
-    ERC20_allowance,
-
-    ERC20_initializer,
-    ERC20_approve,
-    ERC20_increaseAllowance,
-    ERC20_decreaseAllowance,
-    ERC20_transfer,
-    ERC20_transferFrom,
-    ERC20_mint
-)
+from openzeppelin.security.pausable import Pausable
+from openzeppelin.token.erc20.library import ERC20
 
 (...)
 
@@ -103,8 +88,8 @@ func transfer{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(recipient: felt, amount: Uint256) -> (success: felt):
-    Pausable_when_not_paused()
-    ERC20_transfer(recipient, amount)
+    Pausable.assert_not_paused()
+    ERC20.transfer(recipient, amount)
     return (TRUE)
 end
 ```

--- a/docs/Extensibility.md
+++ b/docs/Extensibility.md
@@ -29,12 +29,12 @@ To minimize risk, boilerplate, and avoid function naming clashes, we follow thes
 
 ### Libraries
 
-Considering four type of functions:
+Considering four types of functions:
 
 - `internal`: internal to a library, not meant to be used outside the module or imported
 - `public`: part of the public API of a library
 - `external`: subset of `public` that is ready to be exported as-is by contracts
-- `storage`: storage variables
+- `storage`: storage variable functions
 
 Then:
 

--- a/docs/Extensibility.md
+++ b/docs/Extensibility.md
@@ -29,20 +29,20 @@ To minimize risk, boilerplate, and avoid function naming clashes, we follow thes
 
 ### Libraries
 
-* All function and storage variable names must be prefixed with the file name to prevent clashing with other libraries (e.g. `ERC20_approve` in the `ERC20` library)
-* Must not implement any `@external` or `@view` functions
-* Must not implement constructors
-* Must not call initializers on any function
-* Should implement initializer functions to mimic construction logic if needed (as any other library function, never as `@external`)
+* All exposed functions must be implemented under a `namespace`
+* All storage variable names must be prefixed with the namespace name to prevent clashing with other libraries (e.g. `ERC20_balances` in the `ERC20` library)
+* Must not implement any `@external`, `@view`, or `@constructor` functions
+* Can implement library constructor functions as long as they're not decorated with `@constructor` or `@external`
+* Must not call library constructors on any function
 
 ### Contracts
 
 * Can import from libraries
 * Should implement `@external` functions if needed
-* Should implement a constructor that calls initializers
-* Must not call initializers in any function beside the constructor
+* Should implement a `@constructor` function that calls library constructors
+* Must not call library constructors in any function beside the main constructor
 
-Note that since initializers will never be marked as `@external` and they won’t be called from anywhere but the contract constructor, there’s no risk of re-initialization after deployment. It’s up to the library developers not to make initializers interdependent to avoid weird dependency paths that may lead to double initialization of libraries.
+Note that since library constructors will never be marked as `@external` and they won’t be called from anywhere but the main constructor, there’s no risk of re-initialization after deployment. It’s up to the library developers not to make library constructors interdependent to avoid weird dependency paths that may lead to double construction of libraries.
 
 ## Presets
 
@@ -86,7 +86,7 @@ func transfer{
         range_check_ptr
     }(recipient: felt, amount: Uint256) -> (success: felt):
     Pausable_when_not_paused()
-    ERC20_transfer(recipient, amount)
+    ERC20.transfer(recipient, amount)
     return (TRUE)
 end
 ```

--- a/docs/Extensibility.md
+++ b/docs/Extensibility.md
@@ -29,8 +29,20 @@ To minimize risk, boilerplate, and avoid function naming clashes, we follow thes
 
 ### Libraries
 
-* All exposed functions must be implemented under a `namespace`
-* All storage variable names must be prefixed with the namespace name to prevent clashing with other libraries (e.g. `ERC20_balances` in the `ERC20` library)
+Considering four type of functions:
+
+- `A`: internal to a library, not meant to be used outside the module
+- `B`: part of the public API of a library
+- `C`: subset of B that is meant to be exported as-is by contracts
+- `S`: storage variables
+
+Then:
+
+* Must implement `B` and `C` functions under a namespace
+* Must implement type `A` functions outside the namespace to avoid exposing them
+* Must prefix type `B` functions with an underscore (e.g. `ERC20._mint`)
+* Must not prefix `C` functions with an underscore (e.g. `ERC20.transfer`)
+* Must prefix `S` functions with the name of the namespace to prevent clashing with other libraries (e.g. `ERC20_balances`)
 * Must not implement any `@external`, `@view`, or `@constructor` functions
 * Can implement library constructor functions as long as they're not decorated with `@constructor` or `@external`
 * Must not call library constructors on any function
@@ -59,6 +71,12 @@ Some presets are:
 * [ERC721_Mintable_Burnable](../src/openzeppelin/token/erc721/ERC721_Mintable_Burnable.cairo)
 * [ERC721_Mintable_Pausable](../src/openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo)
 * [ERC721_Enumerable_Mintable_Burnable](../src/openzeppelin/token/erc721_enumerable/ERC721_Enumerable_Mintable_Burnable.cairo)
+
+## Function names and Coding style
+
+* Following the Cairo programming style, we choose to stick with `snake_case` for library APIs (e.g. `ERC20.transfer_from`, `ERC721.safe_transfer_from`).
+  * Contract developers should then expose the `camelCase` version of the methods to comply with existing standards (e.g. `transferFrom` in a ERC20 contract)
+* Guard functions such as the so-called "only owner" are prefixed with `assert_` (e.g. `Ownable.assert_only_owner`).
 
 ## Emulating hooks
 

--- a/docs/Extensibility.md
+++ b/docs/Extensibility.md
@@ -31,18 +31,18 @@ To minimize risk, boilerplate, and avoid function naming clashes, we follow thes
 
 Considering four type of functions:
 
-- `A`: internal to a library, not meant to be used outside the module
-- `B`: part of the public API of a library
-- `C`: subset of B that is ready to be exported as-is by contracts
-- `S`: storage variables
+- `internal`: internal to a library, not meant to be used outside the module or imported
+- `public`: part of the public API of a library
+- `external`: subset of `public` that is ready to be exported as-is by contracts
+- `storage`: storage variables
 
 Then:
 
-* Must implement `B` and `C` functions under a namespace
-* Must implement type `A` functions outside the namespace to avoid exposing them
-* Must prefix type `B` functions with an underscore (e.g. `ERC20._mint`)
-* Must not prefix `C` functions with an underscore (e.g. `ERC20.transfer`)
-* Must prefix `S` functions with the name of the namespace to prevent clashing with other libraries (e.g. `ERC20_balances`)
+* Must implement `public` and `external` functions under a namespace
+* Must implement `internal` functions outside the namespace to avoid exposing them
+* Must prefix `public` functions with an underscore (e.g. `ERC20._mint`)
+* Must not prefix `external` functions with an underscore (e.g. `ERC20.transfer`)
+* Must prefix `storage` functions with the name of the namespace to prevent clashing with other libraries (e.g. `ERC20_balances`)
 * Must not implement any `@external`, `@view`, or `@constructor` functions
 * Can implement initializers (never as `@constructor` or `@external`)
 * Must not call initializers on any function

--- a/docs/Extensibility.md
+++ b/docs/Extensibility.md
@@ -33,7 +33,7 @@ Considering four type of functions:
 
 - `A`: internal to a library, not meant to be used outside the module
 - `B`: part of the public API of a library
-- `C`: subset of B that is meant to be exported as-is by contracts
+- `C`: subset of B that is ready to be exported as-is by contracts
 - `S`: storage variables
 
 Then:
@@ -44,17 +44,17 @@ Then:
 * Must not prefix `C` functions with an underscore (e.g. `ERC20.transfer`)
 * Must prefix `S` functions with the name of the namespace to prevent clashing with other libraries (e.g. `ERC20_balances`)
 * Must not implement any `@external`, `@view`, or `@constructor` functions
-* Can implement library constructor functions as long as they're not decorated with `@constructor` or `@external`
-* Must not call library constructors on any function
+* Can implement initializers (never as `@constructor` or `@external`)
+* Must not call initializers on any function
 
 ### Contracts
 
 * Can import from libraries
 * Should implement `@external` functions if needed
-* Should implement a `@constructor` function that calls library constructors
-* Must not call library constructors in any function beside the main constructor
+* Should implement a `@constructor` function that calls initializers
+* Must not call initializers in any function beside the constructor
 
-Note that since library constructors will never be marked as `@external` and they won’t be called from anywhere but the main constructor, there’s no risk of re-initialization after deployment. It’s up to the library developers not to make library constructors interdependent to avoid weird dependency paths that may lead to double construction of libraries.
+Note that since initializers will never be marked as `@external` and they won’t be called from anywhere but the constructor, there’s no risk of re-initialization after deployment. It’s up to the library developers not to make initializers interdependent to avoid weird dependency paths that may lead to double construction of libraries.
 
 ## Presets
 
@@ -74,8 +74,8 @@ Some presets are:
 
 ## Function names and Coding style
 
-* Following the Cairo programming style, we choose to stick with `snake_case` for library APIs (e.g. `ERC20.transfer_from`, `ERC721.safe_transfer_from`).
-  * Contract developers should then expose the `camelCase` version of the methods to comply with existing standards (e.g. `transferFrom` in a ERC20 contract)
+* Following Cairo's programming style, we use `snake_case` for library APIs (e.g. `ERC20.transfer_from`, `ERC721.safe_transfer_from`).
+* But for standard EVM ecosystem compatibility, we implement external functions in contracts using `camelCase` (e.g. `transferFrom` in a ERC20 contract).
 * Guard functions such as the so-called "only owner" are prefixed with `assert_` (e.g. `Ownable.assert_only_owner`).
 
 ## Emulating hooks
@@ -103,7 +103,7 @@ func transfer{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(recipient: felt, amount: Uint256) -> (success: felt):
-    Pausable_when_not_paused()
+    Pausable.assert_not_paused()
     ERC20.transfer(recipient, amount)
     return (TRUE)
 end


### PR DESCRIPTION
Resolves #295. I think the bits about constructors show that we need to differentiate between a contract constructor and a "library constructor". I think this is confusing enough to rollback and call them initializers.