### PR TITLE
Integrate namespace into ReentrancyGuard

### DIFF
--- a/docs/Security.md
+++ b/docs/Security.md
@@ -50,7 +50,7 @@ func test_function{
     }():
    ReentrancyGuard._start()
    # function body
-   ReentrancyGuard._end_()
+   ReentrancyGuard._end()
    return ()
 end
 ```

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -38,7 +38,7 @@ end
 
 A [reentrancy attack](https://gus-tavo-guim.medium.com/reentrancy-attack-on-smart-contracts-how-to-identify-the-exploitable-and-an-example-of-an-attack-4470a2d8dfe4) occurs when the caller is able to obtain more resources than allowed by recursively calling a target’s function.
 
-Since Cairo does not support modifiers like Solidity, the [`reentrancy_guard`](../src/openzeppelin/security/reentrancy_guard.cairo) library exposes two methods `start` and `end_` to protect functions against reentrancy attacks. The protected function must call `ReentrancyGuard.start` before the first function statement, and `ReentrancyGuard.end_` before the return statement, as shown below:
+Since Cairo does not support modifiers like Solidity, the [`reentrancy_guard`](../src/openzeppelin/security/reentrancy_guard.cairo) library exposes two methods `_start` and `_end` to protect functions against reentrancy attacks. The protected function must call `ReentrancyGuard._start` before the first function statement, and `ReentrancyGuard._end` before the return statement, as shown below:
 
 ```cairo
 from openzeppelin.security.reentrancy_guard import ReentrancyGuard
@@ -48,11 +48,9 @@ func test_function{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }():
-   ReentrancyGuard.start()
+   ReentrancyGuard._start()
    # function body
-   ReentrancyGuard.end_()
+   ReentrancyGuard._end_()
    return ()
 end
 ```
-
-> Note that `Reentrancy.end_` includes the appended underscore because `end` itself is a [protected keyword](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/lang/ide/vim/syntax/cairo.vim) in Cairo.

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -38,22 +38,21 @@ end
 
 A [reentrancy attack](https://gus-tavo-guim.medium.com/reentrancy-attack-on-smart-contracts-how-to-identify-the-exploitable-and-an-example-of-an-attack-4470a2d8dfe4) occurs when the caller is able to obtain more resources than allowed by recursively calling a target’s function.
 
-Since Cairo does not support modifiers like Solidity, the [`reentrancy_guard`](../src/openzeppelin/security/reentrancy_guard.cairo) library exposes two methods `ReentrancyGuard_start` and `ReentrancyGuard_end` to protect functions against reentrancy attacks. The protected function must call `ReentrancyGuard_start` before the first function statement, and `ReentrancyGuard_end` before the return statement, as shown below:
+Since Cairo does not support modifiers like Solidity, the [`reentrancy_guard`](../src/openzeppelin/security/reentrancy_guard.cairo) library exposes two methods `start` and `end_` to protect functions against reentrancy attacks. The protected function must call `ReentrancyGuard.start` before the first function statement, and `ReentrancyGuard.end_` before the return statement, as shown below:
 
 ```cairo
-from openzeppelin.security.reentrancy_guard import (
-    ReentrancyGuard_start,
-    ReentrancyGuard_end
-)
+from openzeppelin.security.reentrancy_guard import ReentrancyGuard
 
 func test_function{
         syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }():
-   ReentrancyGuard_start()
+   ReentrancyGuard.start()
    # function body
-   ReentrancyGuard_end()
+   ReentrancyGuard.end_()
    return ()
 end
 ```
+
+> Note that `Reentrancy.end_` includes the appended underscore because `end` itself is a [protected keyword](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/lang/ide/vim/syntax/cairo.vim) in Cairo.

--- a/src/openzeppelin/security/reentrancy_guard.cairo
+++ b/src/openzeppelin/security/reentrancy_guard.cairo
@@ -10,25 +10,28 @@ from starkware.cairo.common.bool import TRUE, FALSE
 func ReentrancyGuard_entered() -> (res: felt):
 end
 
-func ReentrancyGuard_start{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }():
-    let (has_entered) = ReentrancyGuard_entered.read()
-    with_attr error_message("ReentrancyGuard: reentrant call"):
-        assert has_entered = FALSE
+namespace ReentrancyGuard:
+
+    func start{
+            syscall_ptr : felt*, 
+            pedersen_ptr : HashBuiltin*,
+            range_check_ptr
+        }():
+        let (has_entered) = ReentrancyGuard_entered.read()
+        with_attr error_message("ReentrancyGuard: reentrant call"):
+            assert has_entered = FALSE
+        end
+        ReentrancyGuard_entered.write(TRUE)
+        return ()
     end
-    ReentrancyGuard_entered.write(TRUE)
-    return ()
-end
 
-func ReentrancyGuard_end{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }():
-    ReentrancyGuard_entered.write(FALSE)
-    return ()
-end
+    func end_{
+            syscall_ptr : felt*, 
+            pedersen_ptr : HashBuiltin*,
+            range_check_ptr
+        }():
+        ReentrancyGuard_entered.write(FALSE)
+        return ()
+    end
 
+end

--- a/src/openzeppelin/security/reentrancy_guard.cairo
+++ b/src/openzeppelin/security/reentrancy_guard.cairo
@@ -12,7 +12,7 @@ end
 
 namespace ReentrancyGuard:
 
-    func start{
+    func _start{
             syscall_ptr : felt*,
             pedersen_ptr : HashBuiltin*,
             range_check_ptr
@@ -25,7 +25,7 @@ namespace ReentrancyGuard:
         return ()
     end
 
-    func end_{
+    func _end{
             syscall_ptr : felt*,
             pedersen_ptr : HashBuiltin*,
             range_check_ptr

--- a/src/openzeppelin/security/reentrancy_guard.cairo
+++ b/src/openzeppelin/security/reentrancy_guard.cairo
@@ -13,7 +13,7 @@ end
 namespace ReentrancyGuard:
 
     func start{
-            syscall_ptr : felt*, 
+            syscall_ptr : felt*,
             pedersen_ptr : HashBuiltin*,
             range_check_ptr
         }():
@@ -26,7 +26,7 @@ namespace ReentrancyGuard:
     end
 
     func end_{
-            syscall_ptr : felt*, 
+            syscall_ptr : felt*,
             pedersen_ptr : HashBuiltin*,
             range_check_ptr
         }():

--- a/src/openzeppelin/security/reentrancy_guard.cairo
+++ b/src/openzeppelin/security/reentrancy_guard.cairo
@@ -13,8 +13,8 @@ end
 namespace ReentrancyGuard:
 
     func _start{
-            syscall_ptr : felt*,
-            pedersen_ptr : HashBuiltin*,
+            syscall_ptr: felt*,
+            pedersen_ptr: HashBuiltin*,
             range_check_ptr
         }():
         let (has_entered) = ReentrancyGuard_entered.read()
@@ -26,8 +26,8 @@ namespace ReentrancyGuard:
     end
 
     func _end{
-            syscall_ptr : felt*,
-            pedersen_ptr : HashBuiltin*,
+            syscall_ptr: felt*,
+            pedersen_ptr: HashBuiltin*,
             range_check_ptr
         }():
         ReentrancyGuard_entered.write(FALSE)

--- a/tests/mocks/reentrancy_attacker_mock.cairo
+++ b/tests/mocks/reentrancy_attacker_mock.cairo
@@ -13,8 +13,8 @@ end
 
 @external
 func call_sender{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
     }():
     let (caller) = get_caller_address()

--- a/tests/mocks/reentrancy_mock.cairo
+++ b/tests/mocks/reentrancy_mock.cairo
@@ -17,18 +17,18 @@ end
 
 @contract_interface
 namespace IReentrancyGuard:
-    func count_this_recursive(n : felt):
+    func count_this_recursive(n: felt):
     end
 end
 
 @storage_var
-func counter() -> (res : felt):
+func counter() -> (res: felt):
 end
 
 @constructor
 func constructor{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
     }(initial_number: felt):
     counter.write(initial_number)
@@ -37,8 +37,8 @@ end
 
 @view
 func current_count{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
     }() -> (res: felt):
     let (res) = counter.read()
@@ -47,8 +47,8 @@ end
 
 @external
 func callback{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
     }():
    ReentrancyGuard._start()
@@ -59,10 +59,10 @@ end
 
 @external
 func count_local_recursive{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
-    } (n : felt):
+    } (n: felt):
     alloc_locals
     ReentrancyGuard._start()
     let (greater_zero) = is_le(1, n)
@@ -83,8 +83,8 @@ end
 
 @external
 func count_this_recursive{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
    } (n : felt):
     alloc_locals
@@ -109,10 +109,10 @@ end
 
 @external
 func count_and_call{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
-    }(attacker : felt):
+    }(attacker: felt):
     ReentrancyGuard._start()
     _count()
     IReentrancyGuardAttacker.call_sender(contract_address=attacker)
@@ -121,8 +121,8 @@ func count_and_call{
 end
 
 func _count{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
     }():
     let (current_count) = counter.read()

--- a/tests/mocks/reentrancy_mock.cairo
+++ b/tests/mocks/reentrancy_mock.cairo
@@ -6,10 +6,8 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.bool import TRUE
 from starkware.starknet.common.syscalls import get_contract_address
-from openzeppelin.security.reentrancy_guard import (
-    ReentrancyGuard_start,
-    ReentrancyGuard_end
-)
+
+from openzeppelin.security.reentrancy_guard import ReentrancyGuard
 
 @contract_interface
 namespace IReentrancyGuardAttacker:
@@ -53,9 +51,9 @@ func callback{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }():
-   ReentrancyGuard_start()
+   ReentrancyGuard.start()
    _count()
-   ReentrancyGuard_end()
+   ReentrancyGuard.end_()
    return ()
 end
 
@@ -66,7 +64,7 @@ func count_local_recursive {
         range_check_ptr
     } (n : felt):
     alloc_locals
-    ReentrancyGuard_start()
+    ReentrancyGuard.start()
     let (greater_zero) = is_le(1, n)
     if greater_zero == TRUE:           
         _count()
@@ -79,7 +77,7 @@ func count_local_recursive {
         tempvar pedersen_ptr=pedersen_ptr
         tempvar range_check_ptr=range_check_ptr
     end
-    ReentrancyGuard_end()
+    ReentrancyGuard.end_()
    return ()
 end
 
@@ -90,7 +88,7 @@ func count_this_recursive {
         range_check_ptr
    } (n : felt):
     alloc_locals
-    ReentrancyGuard_start()
+    ReentrancyGuard.start()
     let (greater_zero) = is_le(1, n)
     if greater_zero == TRUE:      
         _count()
@@ -105,7 +103,7 @@ func count_this_recursive {
         tempvar pedersen_ptr=pedersen_ptr
         tempvar range_check_ptr=range_check_ptr
     end
-    ReentrancyGuard_end()
+    ReentrancyGuard.end_()
     return ()    
 end
 
@@ -115,10 +113,10 @@ func count_and_call{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(attacker : felt):    
-    ReentrancyGuard_start()
+    ReentrancyGuard.start()
     _count()
     IReentrancyGuardAttacker.call_sender(contract_address=attacker)
-    ReentrancyGuard_end()
+    ReentrancyGuard.end_()
     return()
 end
 

--- a/tests/mocks/reentrancy_mock.cairo
+++ b/tests/mocks/reentrancy_mock.cairo
@@ -86,7 +86,7 @@ func count_this_recursive{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr
-   } (n : felt):
+   } (n: felt):
     alloc_locals
     ReentrancyGuard._start()
     let (greater_zero) = is_le(1, n)

--- a/tests/mocks/reentrancy_mock.cairo
+++ b/tests/mocks/reentrancy_mock.cairo
@@ -22,7 +22,7 @@ namespace IReentrancyGuard:
 end
 
 @storage_var
-func counter() -> (res : felt):  
+func counter() -> (res : felt):
 end
 
 @constructor

--- a/tests/mocks/reentrancy_mock.cairo
+++ b/tests/mocks/reentrancy_mock.cairo
@@ -27,7 +27,7 @@ end
 
 @constructor
 func constructor{
-        syscall_ptr : felt*, 
+        syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(initial_number: felt):
@@ -37,7 +37,7 @@ end
 
 @view
 func current_count{
-        syscall_ptr : felt*, 
+        syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }() -> (res: felt):
@@ -47,26 +47,26 @@ end
 
 @external
 func callback{
-        syscall_ptr : felt*, 
+        syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }():
-   ReentrancyGuard.start()
+   ReentrancyGuard._start()
    _count()
-   ReentrancyGuard.end_()
+   ReentrancyGuard._end()
    return ()
 end
 
 @external
-func count_local_recursive {
-        syscall_ptr : felt*, 
+func count_local_recursive{
+        syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     } (n : felt):
     alloc_locals
-    ReentrancyGuard.start()
+    ReentrancyGuard._start()
     let (greater_zero) = is_le(1, n)
-    if greater_zero == TRUE:           
+    if greater_zero == TRUE:
         _count()
         count_local_recursive(n - 1)
         tempvar syscall_ptr=syscall_ptr
@@ -77,20 +77,20 @@ func count_local_recursive {
         tempvar pedersen_ptr=pedersen_ptr
         tempvar range_check_ptr=range_check_ptr
     end
-    ReentrancyGuard.end_()
+    ReentrancyGuard._end()
    return ()
 end
 
 @external
-func count_this_recursive {
-        syscall_ptr : felt*, 
+func count_this_recursive{
+        syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
    } (n : felt):
     alloc_locals
-    ReentrancyGuard.start()
+    ReentrancyGuard._start()
     let (greater_zero) = is_le(1, n)
-    if greater_zero == TRUE:      
+    if greater_zero == TRUE:
         _count()
         let (contract_address) = get_contract_address()
         IReentrancyGuard.count_this_recursive(
@@ -103,25 +103,25 @@ func count_this_recursive {
         tempvar pedersen_ptr=pedersen_ptr
         tempvar range_check_ptr=range_check_ptr
     end
-    ReentrancyGuard.end_()
-    return ()    
+    ReentrancyGuard._end()
+    return ()
 end
 
 @external
-func count_and_call{ 
-        syscall_ptr : felt*, 
+func count_and_call{
+        syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(attacker : felt):    
-    ReentrancyGuard.start()
+    }(attacker : felt):
+    ReentrancyGuard._start()
     _count()
     IReentrancyGuardAttacker.call_sender(contract_address=attacker)
-    ReentrancyGuard.end_()
+    ReentrancyGuard._end()
     return()
 end
 
-func _count{ 
-        syscall_ptr : felt*, 
+func _count{
+        syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }():


### PR DESCRIPTION
Resolves #306. This PR updates ReentrancyGuard to utilize namespace and also proposes to append an underscore on the `end` method: `Reentrancy.end_`. The reason for the underscore is because `end` itself is a protected keyword in Cairo and prepending the underscore may conflict or cause confusion with the new extensibility pattern.