### PR TITLE
Integrate namespace and events to Pausable

### DIFF
--- a/docs/Security.md
+++ b/docs/Security.md
@@ -37,6 +37,45 @@ end
 
 ## Pausable
 
+The Pausable library allows contracts to implement an emergency stop mechanism. This can be useful for scenarios such as preventing trades until the end of an evaluation period and having an emergency switch to freeze all transactions in the event of a large bug.
+
+To use the Pausable library, the contract should include `pause` and `unpause` functions (which should be protected). For methods that should be available only when not paused, insert `assert_not_paused`. For methods that should be available only when paused, insert `assert_paused`. For example:
+
+```cairo
+from openzeppelin.security.pausable import Pausable
+
+@external
+func whenNotPaused{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }():
+    Pausable.assert_not_paused()
+
+    # function body
+    return ()
+end
+
+@external
+func whenPaused{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }():
+    Pausable.assert_paused()
+
+    # function body
+    return ()
+end
+```
+
+> Note that `pause` and `unpause` already include these assertions. In other words, `pause` cannot be invoked when already paused and vice versa.
+
+For a list of full implementations utilizing the Pausable library, see:
+
+* [ERC20_Pausable](../src/openzeppelin/token/erc20/ERC20_Pausable.cairo)
+* [ERC721_Mintable_Pausable](../src/openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo)
+
 ## Reentrancy Guard
 
 A [reentrancy attack](https://gus-tavo-guim.medium.com/reentrancy-attack-on-smart-contracts-how-to-identify-the-exploitable-and-an-example-of-an-attack-4470a2d8dfe4) occurs when the caller is able to obtain more resources than allowed by recursively calling a target’s function.

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -7,6 +7,7 @@
 ## Table of Contents
 
 * [Initializable](#initializable)
+* [Pausable](#pausable)
 * [Reentrancy Guard](#Reentrancy-Guard)
 
 ## Initializable
@@ -33,6 +34,8 @@ end
 ```
 
 > Please note that this Initializable pattern should only be used on one function.
+
+## Pausable
 
 ## Reentrancy Guard
 

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -37,7 +37,7 @@ end
 
 ## Pausable
 
-The Pausable library allows contracts to implement an emergency stop mechanism. This can be useful for scenarios such as preventing trades until the end of an evaluation period and having an emergency switch to freeze all transactions in the event of a large bug.
+The Pausable library allows contracts to implement an emergency stop mechanism. This can be useful for scenarios such as preventing trades until the end of an evaluation period or having an emergency switch to freeze all transactions in the event of a large bug.
 
 To use the Pausable library, the contract should include `pause` and `unpause` functions (which should be protected). For methods that should be available only when not paused, insert `assert_not_paused`. For methods that should be available only when paused, insert `assert_paused`. For example:
 

--- a/src/openzeppelin/security/pausable.cairo
+++ b/src/openzeppelin/security/pausable.cairo
@@ -44,7 +44,7 @@ namespace Pausable:
             range_check_ptr
         }():
         let (is_paused) = Pausable_paused.read()
-        with_attr error_message("Pausable: contract is paused"):
+        with_attr error_message("Pausable: paused"):
             assert is_paused = FALSE
         end
         return ()
@@ -56,7 +56,7 @@ namespace Pausable:
             range_check_ptr
         }():
         let (is_paused) = Pausable_paused.read()
-        with_attr error_message("Pausable: contract is not paused"):
+        with_attr error_message("Pausable: not paused"):
             assert is_paused = TRUE
         end
         return ()

--- a/src/openzeppelin/security/pausable.cairo
+++ b/src/openzeppelin/security/pausable.cairo
@@ -11,46 +11,59 @@ from starkware.cairo.common.bool import TRUE, FALSE
 func Pausable_paused() -> (paused: felt):
 end
 
-func Pausable_when_not_paused{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }():
-    let (is_paused) = Pausable_paused.read()
-    with_attr error_message("Pausable: contract is paused"):
-        assert is_paused = FALSE
+namespace Pausable:
+
+    func pause{
+            syscall_ptr : felt*, 
+            pedersen_ptr : HashBuiltin*,
+            range_check_ptr
+        }():
+        assert_not_paused()
+        Pausable_paused.write(TRUE)
+        return ()
     end
-    return ()
-end
 
-func Pausable_when_paused{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }():
-    let (is_paused) = Pausable_paused.read()
-    with_attr error_message("Pausable: contract is not paused"):
-        assert is_paused = TRUE
+    func unpause{
+            syscall_ptr : felt*, 
+            pedersen_ptr : HashBuiltin*,
+            range_check_ptr
+        }():
+        assert_paused()
+        Pausable_paused.write(FALSE)
+        return ()
     end
-    return ()
-end
 
-func Pausable_pause{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }():
-    Pausable_when_not_paused()
-    Pausable_paused.write(TRUE)
-    return ()
-end
+    func is_paused{
+            syscall_ptr : felt*, 
+            pedersen_ptr : HashBuiltin*,
+            range_check_ptr
+        }() -> (is_paused: felt):
+        let (is_paused) = Pausable_paused.read()
+        return (is_paused)
+    end
 
-func Pausable_unpause{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }():
-    Pausable_when_paused()
-    Pausable_paused.write(FALSE)
-    return ()
+    func assert_not_paused{
+            syscall_ptr : felt*, 
+            pedersen_ptr : HashBuiltin*,
+            range_check_ptr
+        }():
+        let (is_paused) = Pausable_paused.read()
+        with_attr error_message("Pausable: contract is paused"):
+            assert is_paused = FALSE
+        end
+        return ()
+    end
+
+    func assert_paused{
+            syscall_ptr : felt*, 
+            pedersen_ptr : HashBuiltin*,
+            range_check_ptr
+        }():
+        let (is_paused) = Pausable_paused.read()
+        with_attr error_message("Pausable: contract is not paused"):
+            assert is_paused = TRUE
+        end
+        return ()
+    end
+
 end

--- a/src/openzeppelin/security/pausable.cairo
+++ b/src/openzeppelin/security/pausable.cairo
@@ -7,35 +7,31 @@ from starkware.starknet.common.syscalls import get_caller_address
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.bool import TRUE, FALSE
 
+#
+# Storage
+#
+
 @storage_var
 func Pausable_paused() -> (paused: felt):
 end
 
+#
+# Events
+#
+
+@event
+func Paused(account: felt):
+end
+
+@event
+func Unpaused(account: felt):
+end
+
 namespace Pausable:
 
-    func pause{
-            syscall_ptr : felt*, 
-            pedersen_ptr : HashBuiltin*,
-            range_check_ptr
-        }():
-        assert_not_paused()
-        Pausable_paused.write(TRUE)
-        return ()
-    end
-
-    func unpause{
-            syscall_ptr : felt*, 
-            pedersen_ptr : HashBuiltin*,
-            range_check_ptr
-        }():
-        assert_paused()
-        Pausable_paused.write(FALSE)
-        return ()
-    end
-
     func is_paused{
-            syscall_ptr : felt*, 
-            pedersen_ptr : HashBuiltin*,
+            syscall_ptr: felt*,
+            pedersen_ptr: HashBuiltin*,
             range_check_ptr
         }() -> (is_paused: felt):
         let (is_paused) = Pausable_paused.read()
@@ -43,8 +39,8 @@ namespace Pausable:
     end
 
     func assert_not_paused{
-            syscall_ptr : felt*, 
-            pedersen_ptr : HashBuiltin*,
+            syscall_ptr: felt*,
+            pedersen_ptr: HashBuiltin*,
             range_check_ptr
         }():
         let (is_paused) = Pausable_paused.read()
@@ -55,14 +51,40 @@ namespace Pausable:
     end
 
     func assert_paused{
-            syscall_ptr : felt*, 
-            pedersen_ptr : HashBuiltin*,
+            syscall_ptr: felt*,
+            pedersen_ptr: HashBuiltin*,
             range_check_ptr
         }():
         let (is_paused) = Pausable_paused.read()
         with_attr error_message("Pausable: contract is not paused"):
             assert is_paused = TRUE
         end
+        return ()
+    end
+
+    func _pause{
+            syscall_ptr: felt*,
+            pedersen_ptr: HashBuiltin*,
+            range_check_ptr
+        }():
+        assert_not_paused()
+        Pausable_paused.write(TRUE)
+
+        let (account) = get_caller_address()
+        Paused.emit(account)
+        return ()
+    end
+
+    func _unpause{
+            syscall_ptr: felt*,
+            pedersen_ptr: HashBuiltin*,
+            range_check_ptr
+        }():
+        assert_paused()
+        Pausable_paused.write(FALSE)
+
+        let (account) = get_caller_address()
+        Unpaused.emit(account)
         return ()
     end
 

--- a/src/openzeppelin/token/erc20/ERC20_Pausable.cairo
+++ b/src/openzeppelin/token/erc20/ERC20_Pausable.cairo
@@ -14,12 +14,7 @@ from openzeppelin.access.ownable import (
     Ownable_only_owner
 )
 
-from openzeppelin.security.pausable import (
-    Pausable_paused,
-    Pausable_pause,
-    Pausable_unpause,
-    Pausable_when_not_paused
-)
+from openzeppelin.security.pausable import Pausable
 
 @constructor
 func constructor{
@@ -110,7 +105,7 @@ func paused{
         pedersen_ptr: HashBuiltin*,
         range_check_ptr
     }() -> (paused: felt):
-    let (paused) = Pausable_paused.read()
+    let (paused) = Pausable.is_paused()
     return (paused)
 end
 
@@ -124,7 +119,7 @@ func transfer{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(recipient: felt, amount: Uint256) -> (success: felt):
-    Pausable_when_not_paused()
+    Pausable.assert_not_paused()
     ERC20.transfer(recipient, amount)
     return (TRUE)
 end
@@ -139,7 +134,7 @@ func transferFrom{
         recipient: felt,
         amount: Uint256
     ) -> (success: felt):
-    Pausable_when_not_paused()
+    Pausable.assert_not_paused()
     ERC20.transfer_from(sender, recipient, amount)
     return (TRUE)
 end
@@ -150,7 +145,7 @@ func approve{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(spender: felt, amount: Uint256) -> (success: felt):
-    Pausable_when_not_paused()
+    Pausable.assert_not_paused()
     ERC20.approve(spender, amount)
     return (TRUE)
 end
@@ -161,7 +156,7 @@ func increaseAllowance{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(spender: felt, added_value: Uint256) -> (success: felt):
-    Pausable_when_not_paused()
+    Pausable.assert_not_paused()
     ERC20.increase_allowance(spender, added_value)
     return (TRUE)
 end
@@ -172,7 +167,7 @@ func decreaseAllowance{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(spender: felt, subtracted_value: Uint256) -> (success: felt):
-    Pausable_when_not_paused()
+    Pausable.assert_not_paused()
     ERC20.decrease_allowance(spender, subtracted_value)
     return (TRUE)
 end
@@ -184,7 +179,7 @@ func pause{
         range_check_ptr
     }():
     Ownable_only_owner()
-    Pausable_pause()
+    Pausable.pause()
     return ()
 end
 
@@ -195,6 +190,6 @@ func unpause{
         range_check_ptr
     }():
     Ownable_only_owner()
-    Pausable_unpause()
+    Pausable.unpause()
     return ()
 end

--- a/src/openzeppelin/token/erc20/ERC20_Pausable.cairo
+++ b/src/openzeppelin/token/erc20/ERC20_Pausable.cairo
@@ -179,7 +179,7 @@ func pause{
         range_check_ptr
     }():
     Ownable_only_owner()
-    Pausable.pause()
+    Pausable._pause()
     return ()
 end
 
@@ -190,6 +190,6 @@ func unpause{
         range_check_ptr
     }():
     Ownable_only_owner()
-    Pausable.unpause()
+    Pausable._unpause()
     return ()
 end

--- a/src/openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo
+++ b/src/openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo
@@ -235,7 +235,7 @@ func pause{
         range_check_ptr
     }():
     Ownable_only_owner()
-    Pausable.pause()
+    Pausable._pause()
     return ()
 end
 
@@ -246,6 +246,6 @@ func unpause{
         range_check_ptr
     }():
     Ownable_only_owner()
-    Pausable.unpause()
+    Pausable._unpause()
     return ()
 end

--- a/src/openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo
+++ b/src/openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo
@@ -26,12 +26,7 @@ from openzeppelin.token.erc721.library import (
 
 from openzeppelin.introspection.ERC165 import ERC165
 
-from openzeppelin.security.pausable import (
-    Pausable_paused,
-    Pausable_pause,
-    Pausable_unpause,
-    Pausable_when_not_paused
-)
+from openzeppelin.security.pausable import Pausable
 
 from openzeppelin.access.ownable import (
     Ownable_initializer,
@@ -147,7 +142,7 @@ func paused{
         pedersen_ptr: HashBuiltin*,
         range_check_ptr
     }() -> (paused: felt):
-    let (paused) = Pausable_paused.read()
+    let (paused) = Pausable.is_paused()
     return (paused)
 end
 
@@ -162,7 +157,7 @@ func approve{
         syscall_ptr: felt*, 
         range_check_ptr
     }(to: felt, tokenId: Uint256):
-    Pausable_when_not_paused()
+    Pausable.assert_not_paused()
     ERC721_approve(to, tokenId)
     return ()
 end
@@ -173,7 +168,7 @@ func setApprovalForAll{
         pedersen_ptr: HashBuiltin*, 
         range_check_ptr
     }(operator: felt, approved: felt):
-    Pausable_when_not_paused()
+    Pausable.assert_not_paused()
     ERC721_setApprovalForAll(operator, approved)
     return ()
 end
@@ -188,7 +183,7 @@ func transferFrom{
         to: felt, 
         tokenId: Uint256
     ):
-    Pausable_when_not_paused()
+    Pausable.assert_not_paused()
     ERC721_transferFrom(from_, to, tokenId)
     return ()
 end
@@ -205,7 +200,7 @@ func safeTransferFrom{
         data_len: felt, 
         data: felt*
     ):
-    Pausable_when_not_paused()
+    Pausable.assert_not_paused()
     ERC721_safeTransferFrom(from_, to, tokenId, data_len, data)
     return ()
 end
@@ -216,7 +211,7 @@ func mint{
         syscall_ptr: felt*, 
         range_check_ptr
     }(to: felt, tokenId: Uint256):
-    Pausable_when_not_paused()
+    Pausable.assert_not_paused()
     Ownable_only_owner()
     ERC721_mint(to, tokenId)
     return ()
@@ -240,7 +235,7 @@ func pause{
         range_check_ptr
     }():
     Ownable_only_owner()
-    Pausable_pause()
+    Pausable.pause()
     return ()
 end
 
@@ -251,6 +246,6 @@ func unpause{
         range_check_ptr
     }():
     Ownable_only_owner()
-    Pausable_unpause()
+    Pausable.unpause()
     return ()
 end

--- a/tests/mocks/Pausable.cairo
+++ b/tests/mocks/Pausable.cairo
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
-# OpenZeppelin Contracts for Cairo v0.1.0 (security/pausable.cairo)
 
 %lang starknet
 

--- a/tests/mocks/Pausable.cairo
+++ b/tests/mocks/Pausable.cairo
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Contracts for Cairo v0.1.0 (security/pausable.cairo)
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+
+from openzeppelin.security.pausable import Pausable
+
+@storage_var
+func drastic_measure_taken() -> (res: felt):
+end
+
+@storage_var
+func count() -> (res: felt):
+end
+
+@view
+func isPaused{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }() -> (isPaused: felt):
+    let (isPaused) = Pausable.is_paused()
+    return (isPaused)
+end
+
+@view
+func getCount{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }() -> (res: felt):
+    let (res) = count.read()
+    return (res)
+end
+
+@view
+func getDrasticMeasureTaken{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }() -> (res: felt):
+    let (res) = drastic_measure_taken.read()
+    return (res)
+end
+
+@external
+func normalProcess{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }():
+    Pausable.assert_not_paused()
+
+    let (currentCount) = count.read()
+    count.write(currentCount + 1)
+    return ()
+end
+
+@external
+func drasticMeasure{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }():
+    Pausable.assert_paused()
+
+    drastic_measure_taken.write(TRUE)
+    return ()
+end
+
+@external
+func pause{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }():
+    Pausable._pause()
+    return ()
+end
+
+@external
+func unpause{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }():
+    Pausable._unpause()
+    return ()
+end

--- a/tests/security/test_pausable.py
+++ b/tests/security/test_pausable.py
@@ -46,7 +46,7 @@ async def test_pausable_when_unpaused(pausable_factory):
 
     await assert_revert(
         contract.drasticMeasure().invoke(),
-        reverted_with="Pausable: contract is not paused"
+        reverted_with="Pausable: not paused"
     )
 
 @pytest.mark.asyncio
@@ -79,6 +79,9 @@ async def test_pausable_when_paused(pausable_factory):
     # unpause
     await contract.unpause().invoke()
 
+    execution_info = await contract.isPaused().call()
+    assert execution_info.result.isPaused == FALSE
+
     # check normal process after unpausing
     await contract.normalProcess().invoke()
 
@@ -87,7 +90,7 @@ async def test_pausable_when_paused(pausable_factory):
 
     await assert_revert(
         contract.drasticMeasure().invoke(),
-        reverted_with="Pausable: contract is not paused"
+        reverted_with="Pausable: not paused"
     )
 
 @pytest.mark.asyncio
@@ -100,7 +103,7 @@ async def test_pausable_pause_when_paused(pausable_factory):
     # re-pause
     await assert_revert(
         contract.pause().invoke(),
-        reverted_with="Pausable: contract is paused"
+        reverted_with="Pausable: paused"
     )
 
     # unpause
@@ -109,7 +112,7 @@ async def test_pausable_pause_when_paused(pausable_factory):
     # re-unpause
     await assert_revert(
         contract.unpause().invoke(),
-        reverted_with="Pausable: contract is not paused"
+        reverted_with="Pausable: not paused"
     )
 
 @pytest.mark.asyncio

--- a/tests/security/test_pausable.py
+++ b/tests/security/test_pausable.py
@@ -1,0 +1,141 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import (
+    TRUE, FALSE, assert_revert, assert_event_emitted, 
+    get_contract_def, cached_contract, TestSigner
+)
+
+signer = TestSigner(12345678987654321)
+
+@pytest.fixture
+async def pausable_factory():
+    pausable_def = get_contract_def("tests/mocks/Pausable.cairo")
+    account_def = get_contract_def("openzeppelin/account/Account.cairo")
+
+    starknet = await Starknet.empty()
+    pausable = await starknet.deploy(
+        contract_def=pausable_def,
+        constructor_calldata=[]
+    )
+    account = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    state = starknet.state.copy()
+
+    pausable = cached_contract(state, pausable_def, pausable)
+    account = cached_contract(state, account_def, account)
+    return pausable, account
+
+
+@pytest.mark.asyncio
+async def test_pausable_when_unpaused(pausable_factory):
+    contract, _ = pausable_factory
+
+    execution_info = await contract.isPaused().call()
+    assert execution_info.result.isPaused == FALSE
+
+    execution_info = await contract.getCount().call()
+    assert execution_info.result.res == 0
+    
+    # check that function executes when unpaused
+    await contract.normalProcess().invoke()
+
+    execution_info = await contract.getCount().call()
+    assert execution_info.result.res == 1
+
+    await assert_revert(
+        contract.drasticMeasure().invoke(),
+        reverted_with="Pausable: contract is not paused"
+    )
+
+@pytest.mark.asyncio
+async def test_pausable_when_paused(pausable_factory):
+    contract, _ = pausable_factory
+
+    execution_info = await contract.isPaused().call()
+    assert execution_info.result.isPaused == FALSE
+
+    # pause
+    await contract.pause().invoke()
+
+    execution_info = await contract.isPaused().call()
+    assert execution_info.result.isPaused == TRUE
+
+    await assert_revert(
+        contract.normalProcess().invoke(),
+        reverted_with="Pausable: contract is paused"
+    )
+
+    execution_info = await contract.getDrasticMeasureTaken().call()
+    assert execution_info.result.res == FALSE
+
+    # drastic measure
+    await contract.drasticMeasure().invoke()
+
+    execution_info = await contract.getDrasticMeasureTaken().call()
+    assert execution_info.result.res == TRUE
+
+    # unpause
+    await contract.unpause().invoke()
+
+    # check normal process after unpausing
+    await contract.normalProcess().invoke()
+
+    execution_info = await contract.getCount().call()
+    assert execution_info.result.res == 1
+
+    await assert_revert(
+        contract.drasticMeasure().invoke(),
+        reverted_with="Pausable: contract is not paused"
+    )
+
+@pytest.mark.asyncio
+async def test_pausable_pause_when_paused(pausable_factory):
+    contract, _ = pausable_factory
+
+    # pause
+    await contract.pause().invoke()
+
+    # re-pause
+    await assert_revert(
+        contract.pause().invoke(),
+        reverted_with="Pausable: contract is paused"
+    )
+
+    # unpause
+    await contract.unpause().invoke()
+
+    # re-unpause
+    await assert_revert(
+        contract.unpause().invoke(),
+        reverted_with="Pausable: contract is not paused"
+    )
+
+@pytest.mark.asyncio
+async def test_pausable_emits_events(pausable_factory):
+    contract, account = pausable_factory
+
+    # pause
+    tx_exec_info = await signer.send_transaction(
+        account, contract.contract_address, 'pause', []
+        )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=contract.contract_address,
+        name='Paused',
+        data=[account.contract_address]
+    )
+
+    # unpause
+    tx_exec_info = await signer.send_transaction(
+        account, contract.contract_address, 'unpause', []
+        )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=contract.contract_address,
+        name='Unpaused',
+        data=[account.contract_address]
+    )

--- a/tests/security/test_pausable.py
+++ b/tests/security/test_pausable.py
@@ -64,7 +64,7 @@ async def test_pausable_when_paused(pausable_factory):
 
     await assert_revert(
         contract.normalProcess().invoke(),
-        reverted_with="Pausable: contract is paused"
+        reverted_with="Pausable: paused"
     )
 
     execution_info = await contract.getDrasticMeasureTaken().call()

--- a/tests/token/erc20/test_ERC20_Pausable.py
+++ b/tests/token/erc20/test_ERC20_Pausable.py
@@ -102,7 +102,7 @@ async def test_pause(token_factory):
         'transfer',
         [other.contract_address, *AMOUNT]
     ),
-        reverted_with="Pausable: contract is paused"
+        reverted_with="Pausable: paused"
     )
 
     await assert_revert(signer.send_transaction(
@@ -111,7 +111,7 @@ async def test_pause(token_factory):
         'transferFrom',
         [other.contract_address, other.contract_address, *AMOUNT]
     ),
-        reverted_with="Pausable: contract is paused"
+        reverted_with="Pausable: paused"
     )
 
     await assert_revert(signer.send_transaction(
@@ -120,7 +120,7 @@ async def test_pause(token_factory):
         'approve',
         [other.contract_address, *AMOUNT]
     ),
-        reverted_with="Pausable: contract is paused"
+        reverted_with="Pausable: paused"
     )
 
     await assert_revert(signer.send_transaction(
@@ -129,7 +129,7 @@ async def test_pause(token_factory):
         'increaseAllowance',
         [other.contract_address, *AMOUNT]
     ),
-        reverted_with="Pausable: contract is paused"
+        reverted_with="Pausable: paused"
     )
 
     await assert_revert(signer.send_transaction(
@@ -138,7 +138,7 @@ async def test_pause(token_factory):
         'decreaseAllowance',
         [other.contract_address, *AMOUNT]
     ),
-        reverted_with="Pausable: contract is paused"
+        reverted_with="Pausable: paused"
     )
 
 

--- a/tests/token/erc721/test_ERC721_Mintable_Pausable.py
+++ b/tests/token/erc721/test_ERC721_Mintable_Pausable.py
@@ -100,7 +100,7 @@ async def test_pause(erc721_minted):
             other.contract_address,
             *TOKENS[0]
         ]),
-        reverted_with="Pausable: contract is paused"
+        reverted_with="Pausable: paused"
     )
 
     await assert_revert(signer.send_transaction(
@@ -108,7 +108,7 @@ async def test_pause(erc721_minted):
             other.contract_address,
             TRUE
         ]),
-        reverted_with="Pausable: contract is paused"
+        reverted_with="Pausable: paused"
     )
 
     await assert_revert(signer.send_transaction(
@@ -117,7 +117,7 @@ async def test_pause(erc721_minted):
             other.contract_address,
             *TOKENS[0]
         ]),
-        reverted_with="Pausable: contract is paused"
+        reverted_with="Pausable: paused"
     )
 
     await assert_revert(signer.send_transaction(
@@ -128,7 +128,7 @@ async def test_pause(erc721_minted):
             len(DATA),
             *DATA
         ]),
-        reverted_with="Pausable: contract is paused"
+        reverted_with="Pausable: paused"
     )
 
     await assert_revert(signer.send_transaction(
@@ -136,7 +136,7 @@ async def test_pause(erc721_minted):
             other.contract_address,
             *TOKEN_TO_MINT
         ]),
-        reverted_with="Pausable: contract is paused"
+        reverted_with="Pausable: paused"
     )
 
 


### PR DESCRIPTION
This PR integrates namespace into the Pausable library as well as events. This PR proposes to include a new mock and new test suite to fully test the Pausable methods and events (which follow the Solidity tests and mock). This resolves #308 and resolves #309.