### PR TITLE
Rename library constructors to initializers

### DIFF
--- a/docs/Proxies.md
+++ b/docs/Proxies.md
@@ -95,7 +95,7 @@ The implementation contract, also known as the logic contract, receives the redi
 The implementation contract should:
 
 * import `Proxy` namespace
-* initialize the proxy immediately after contract deployment with `Proxy.constructor`.
+* initialize the proxy immediately after contract deployment with `Proxy.initializer`.
 
 If the implementation is upgradeable, it should:
 

--- a/src/openzeppelin/account/Account.cairo
+++ b/src/openzeppelin/account/Account.cairo
@@ -19,7 +19,7 @@ func constructor{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(public_key: felt):
-    Account.constructor(public_key)
+    Account.initializer(public_key)
     return ()
 end
 

--- a/src/openzeppelin/account/library.cairo
+++ b/src/openzeppelin/account/library.cairo
@@ -47,10 +47,10 @@ end
 namespace Account:
 
     #
-    # Constructor
+    # Initializer
     #
 
-    func constructor{
+    func initializer{
             syscall_ptr : felt*,
             pedersen_ptr : HashBuiltin*,
             range_check_ptr

--- a/src/openzeppelin/token/erc20/ERC20.cairo
+++ b/src/openzeppelin/token/erc20/ERC20.cairo
@@ -21,7 +21,7 @@ func constructor{
         initial_supply: Uint256,
         recipient: felt
     ):
-    ERC20.constructor(name, symbol, decimals)
+    ERC20.initializer(name, symbol, decimals)
     ERC20._mint(recipient, initial_supply)
     return ()
 end

--- a/src/openzeppelin/token/erc20/ERC20_Mintable.cairo
+++ b/src/openzeppelin/token/erc20/ERC20_Mintable.cairo
@@ -27,7 +27,7 @@ func constructor{
         recipient: felt,
         owner: felt
     ):
-    ERC20.constructor(name, symbol, decimals)
+    ERC20.initializer(name, symbol, decimals)
     ERC20._mint(recipient, initial_supply)
     Ownable_initializer(owner)
     return ()

--- a/src/openzeppelin/token/erc20/ERC20_Pausable.cairo
+++ b/src/openzeppelin/token/erc20/ERC20_Pausable.cairo
@@ -29,7 +29,7 @@ func constructor{
         recipient: felt,
         owner: felt
     ):
-    ERC20.constructor(name, symbol, decimals)
+    ERC20.initializer(name, symbol, decimals)
     ERC20._mint(recipient, initial_supply)
     Ownable_initializer(owner)
     return ()

--- a/src/openzeppelin/token/erc20/ERC20_Upgradeable.cairo
+++ b/src/openzeppelin/token/erc20/ERC20_Upgradeable.cairo
@@ -29,9 +29,9 @@ func initializer{
         recipient: felt,
         proxy_admin: felt
     ):
-    ERC20.constructor(name, symbol, decimals)
+    ERC20.initializer(name, symbol, decimals)
     ERC20._mint(recipient, initial_supply)
-    Proxy.constructor(proxy_admin)
+    Proxy.initializer(proxy_admin)
     return ()
 end
 

--- a/src/openzeppelin/token/erc20/library.cairo
+++ b/src/openzeppelin/token/erc20/library.cairo
@@ -55,10 +55,10 @@ end
 namespace ERC20:
 
     #
-    # Constructor
+    # Initializer
     #
 
-    func constructor{
+    func initializer{
             syscall_ptr : felt*,
             pedersen_ptr : HashBuiltin*,
             range_check_ptr

--- a/src/openzeppelin/upgrades/library.cairo
+++ b/src/openzeppelin/upgrades/library.cairo
@@ -38,10 +38,10 @@ end
 namespace Proxy:
 
     #
-    # Constructor
+    # Initializer
     #
 
-    func constructor{
+    func initializer{
             syscall_ptr: felt*,
             pedersen_ptr: HashBuiltin*,
             range_check_ptr

--- a/tests/mocks/ERC20_Burnable_mock.cairo
+++ b/tests/mocks/ERC20_Burnable_mock.cairo
@@ -21,7 +21,7 @@ func constructor{
         initial_supply: Uint256,
         recipient: felt
     ):
-    ERC20.constructor(name, symbol, decimals)
+    ERC20.initializer(name, symbol, decimals)
     ERC20._mint(recipient, initial_supply)
     return ()
 end

--- a/tests/mocks/proxiable_implementation.cairo
+++ b/tests/mocks/proxiable_implementation.cairo
@@ -26,7 +26,7 @@ func initializer{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(proxy_admin: felt):
-    Proxy.constructor(proxy_admin)
+    Proxy.initializer(proxy_admin)
     return ()
 end
 

--- a/tests/mocks/upgrades_v1_mock.cairo
+++ b/tests/mocks/upgrades_v1_mock.cairo
@@ -26,7 +26,7 @@ func initializer{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(proxy_admin: felt):
-    Proxy.constructor(proxy_admin)
+    Proxy.initializer(proxy_admin)
     return ()
 end
 

--- a/tests/mocks/upgrades_v2_mock.cairo
+++ b/tests/mocks/upgrades_v2_mock.cairo
@@ -30,7 +30,7 @@ func initializer{
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(proxy_admin: felt):
-    Proxy.constructor(proxy_admin)
+    Proxy.initializer(proxy_admin)
     return ()
 end
 


### PR DESCRIPTION
Fixes #312. `initialize` or `initializer`? 🤔 