### PR TITLE
Add parallel testing section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,16 +200,12 @@ Run tests using [tox](https://tox.wiki/en/latest/), tox automatically creates an
 tox
 
 ====================== test session starts ======================
-platform linux -- Python 3.7.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
-rootdir: /home/readme/cairo-contracts
-plugins: asyncio-0.16.0, web3-5.24.0, typeguard-2.13.0
-collected 19 items
-
-tests/test_Account.py ....                                 [ 21%]
-tests/test_AddressRegistry.py ..                           [ 31%]
-tests/test_ERC20.py ..........                             [ 84%]
-tests/test_Initializable.py .                              [ 89%]
-tests/test_Ownable.py ..                                   [100%]
+platform linux -- Python 3.7.2, pytest-7.1.2, py-1.11.0, pluggy-1.0.0
+rootdir: /home/readme/cairo-contracts, configfile: tox.ini
+plugins: asyncio-0.18.3, xdist-2.5.0, forked-1.4.0, web3-5.29.0, typeguard-2.13.3
+asyncio: mode=auto
+gw0 [185] / gw1 [185]
+........................................................................................................................................................................................    [100%]
 ```
 
 ### Run Tests in Docker
@@ -232,6 +228,33 @@ After its placed there run:
 docker build -t cairo-tests .
 docker run cairo-tests
 ```
+
+### Parallel Testing
+
+This repo integrates the [pytest-xdist](https://pytest-xdist.readthedocs.io/en/latest/) plugin which runs tests in parallel. This feature increases testing speed; however, conflicts with a shared state can occur since tests run in parallel—not in order. To overcome this, independent cached versions of contracts being tested should be provisioned to each test case. Here's a simple fixture example:
+
+```python
+from utils import get_contract_def, cached_contract
+
+@pytest.fixture(scope='module')
+def foo_factory():
+    # get contract definition
+    foo_def = get_contract_def('path/to/foo.cairo')
+
+    # deploy contract
+    starknet = await Starknet.empty()
+    foo = await starknet.deploy(contract_def=foo_def)
+
+    # copy the state and cache contract
+    state = starknet.state.copy()
+    cached_foo = cached_contract(state, foo_def, foo)
+
+    return cached_foo
+```
+
+See [Memoization](docs/Utilities.md#memoization) in the Utilities documentation for a more thorough example on caching contracts.
+
+> Note that this does not apply for stateless libraries such as SafeMath.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ docker run cairo-tests
 
 ### Parallel Testing
 
-This repo integrates the [pytest-xdist](https://pytest-xdist.readthedocs.io/en/latest/) plugin which runs tests in parallel. This feature increases testing speed; however, conflicts with a shared state can occur since tests run in parallel—not in order. To overcome this, independent cached versions of contracts being tested should be provisioned to each test case. Here's a simple fixture example:
+This repo utilizes the [pytest-xdist](https://pytest-xdist.readthedocs.io/en/latest/) plugin which runs tests in parallel. This feature increases testing speed; however, conflicts with a shared state can occur since tests run in parallel—not in order. To overcome this, independent cached versions of contracts being tested should be provisioned to each test case. Here's a simple fixture example:
 
 ```python
 from utils import get_contract_def, cached_contract

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ docker run cairo-tests
 
 ### Parallel Testing
 
-This repo utilizes the [pytest-xdist](https://pytest-xdist.readthedocs.io/en/latest/) plugin which runs tests in parallel. This feature increases testing speed; however, conflicts with a shared state can occur since tests run in parallel—not in order. To overcome this, independent cached versions of contracts being tested should be provisioned to each test case. Here's a simple fixture example:
+This repo utilizes the [pytest-xdist](https://pytest-xdist.readthedocs.io/en/latest/) plugin which runs tests in parallel. This feature increases testing speed; however, conflicts with a shared state can occur since tests do not run in order. To overcome this, independent cached versions of contracts being tested should be provisioned to each test case. Here's a simple fixture example:
 
 ```python
 from utils import get_contract_def, cached_contract

--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ tests/test_Ownable.py ..                                   [100%]
 ### Run Tests in Docker
 
 For M1 users or those who are having trouble with library/python versions you can alternatively run the tests within a docker container. Using the following as a Dockerfile placed in the root directory of the project:
-```
+
+```dockerfile
 FROM python:3.7
 
 RUN pip install tox
@@ -223,14 +224,14 @@ RUN mkdir cairo-contracts
 COPY . cairo-contracts
 WORKDIR cairo-contracts
 ENTRYPOINT tox
+```
 
-```
 After its placed there run:
-```
+
+```bash
 docker build -t cairo-tests .
 docker run cairo-tests
 ```
-
 
 ## Security
 


### PR DESCRIPTION
This PR documents this repo's use of parallel testing and includes a simple fixture example. This PR also proposes to update the testing output example. Finally, this PR fixes the Docker example to enable syntax highlighting.

Resolves #318.