### PR TITLE
Optimize `_remove_token_from_all_tokens_enumeration`

### DIFF
--- a/src/openzeppelin/token/erc721_enumerable/library.cairo
+++ b/src/openzeppelin/token/erc721_enumerable/library.cairo
@@ -6,7 +6,7 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
 from starkware.cairo.common.math import assert_not_equal
-from starkware.cairo.common.bool import TRUE
+from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.uint256 import (
     Uint256, uint256_lt, uint256_eq, uint256_check
 )
@@ -199,22 +199,22 @@ func _remove_token_from_all_tokens_enumeration{
     let (supply: Uint256) = ERC721_Enumerable_all_tokens_len.read()
     let (last_token_index: Uint256) = uint256_checked_sub_le(supply, Uint256(1, 0))
     let (token_index: Uint256) = ERC721_Enumerable_all_tokens_index.read(token_id)
-
-    # When the token to delete is the last token, the swap operation is unnecessary. However,
-    # since this occurs so rarely (when the last minted token is burnt), we still do the swap
-    # here to avoid the gas cost of adding an 'if' statement (like in _remove_token_from_owner_enumeration)
     let (last_token_id: Uint256) = ERC721_Enumerable_all_tokens.read(last_token_index)
 
     ERC721_Enumerable_all_tokens.write(last_token_index, Uint256(0, 0))
-    ERC721_Enumerable_all_tokens.write(token_index, last_token_id)
-
-    ERC721_Enumerable_all_tokens_index.write(last_token_id, token_index)
     ERC721_Enumerable_all_tokens_index.write(token_id, Uint256(0, 0))
+    ERC721_Enumerable_all_tokens_len.write(last_token_index)
 
-    let (new_supply: Uint256) = uint256_checked_sub_le(supply, Uint256(1, 0))
-    ERC721_Enumerable_all_tokens_len.write(new_supply)
+    let (is_equal) = uint256_eq(last_token_index, token_index)
+    if is_equal == FALSE:
+        ERC721_Enumerable_all_tokens_index.write(last_token_id, token_index)
+        ERC721_Enumerable_all_tokens.write(token_index, last_token_id)
+        return ()
+    end
+
     return ()
 end
+
 
 func _add_token_to_owner_enumeration{
         pedersen_ptr: HashBuiltin*, 

--- a/src/openzeppelin/token/erc721_enumerable/library.cairo
+++ b/src/openzeppelin/token/erc721_enumerable/library.cairo
@@ -211,7 +211,6 @@ func _remove_token_from_all_tokens_enumeration{
         ERC721_Enumerable_all_tokens.write(token_index, last_token_id)
         return ()
     end
-
     return ()
 end
 
@@ -226,6 +225,7 @@ func _add_token_to_owner_enumeration{
     ERC721_Enumerable_owned_tokens_index.write(token_id, length)
     return ()
 end
+
 
 func _remove_token_from_owner_enumeration{
         pedersen_ptr: HashBuiltin*, 


### PR DESCRIPTION
This PR proposes to optimize the ERC721 Enumerable library—specifically, the `_remove_token_from_all_tokens_enumeration` method. Below is a table comparison based on the current tests and [here's a gist ](https://gist.github.com/andrew-fleming/ec0ce2612755049998b6bd63a5a497fa)with the updated library, tests with print statements to replicate the numbers, and a modified tox.ini to print the results.

| Burn first token | Current      | New     | Saves |
| :---        | :---        | :---       |  :---       
| `burn`   | 2334 steps        | 2211 steps      | 5.26% |

---

| Burn last token | Current      | New     | Saves |
| :---        | :---        | :---       |  :---       |
| `burn`   | 2254 steps        | 1975 steps      | 12.37% |