### PR TITLE
Replace is_valid_signature with assert_valid_signature

### DIFF
--- a/docs/Account.md
+++ b/docs/Account.md
@@ -22,7 +22,7 @@ A more detailed writeup on the topic can be found on [Perama's blogpost](https:/
   * [`get_public_key`](#get_public_key)
   * [`get_nonce`](#get_nonce)
   * [`set_public_key`](#set_public_key)
-  * [`is_valid_signature`](#is_valid_signature)
+  * [`assert_valid_signature`](#assert_valid_signature)
   * [`__execute__`](#__execute__)
 * [Account differentiation with ERC165](#account-differentiation-with-erc165)
 * [Extending the Account contract](#extending-the-account-contract)
@@ -71,7 +71,7 @@ namespace IAccount:
     # Business logic
     #
 
-    func is_valid_signature(
+    func assert_valid_signature(
             hash: felt,
             signature_len: felt,
             signature: felt*
@@ -279,7 +279,7 @@ end
 func set_public_key(new_public_key: felt):
 end
 
-func is_valid_signature(hash: felt,
+func assert_valid_signature(hash: felt,
         signature_len: felt,
         signature: felt*
     ):
@@ -337,7 +337,7 @@ Returns:
 
 None.
 
-### `is_valid_signature`
+### `assert_valid_signature`
 
 This function is inspired by [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) and checks whether a given signature is valid, otherwise it reverts.
 

--- a/src/openzeppelin/account/Account.cairo
+++ b/src/openzeppelin/account/Account.cairo
@@ -76,7 +76,7 @@ end
 #
 
 @view
-func is_valid_signature{
+func assert_valid_signature{
         syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr,
@@ -86,7 +86,7 @@ func is_valid_signature{
         signature_len: felt,
         signature: felt*
     ) -> ():
-    Account.is_valid_signature(hash, signature_len, signature)
+    Account.assert_valid_signature(hash, signature_len, signature)
     return ()
 end
 

--- a/src/openzeppelin/account/IAccount.cairo
+++ b/src/openzeppelin/account/IAccount.cairo
@@ -19,7 +19,7 @@ namespace IAccount:
     # Business logic
     #
 
-    func is_valid_signature(
+    func assert_valid_signature(
             hash: felt,
             signature_len: felt,
             signature: felt*

--- a/src/openzeppelin/account/library.cairo
+++ b/src/openzeppelin/account/library.cairo
@@ -113,7 +113,7 @@ namespace Account:
     # Business logic
     #
 
-    func is_valid_signature{
+    func assert_valid_signature{
             syscall_ptr : felt*,
             pedersen_ptr : HashBuiltin*,
             range_check_ptr,
@@ -168,7 +168,7 @@ namespace Account:
         let calls_len = call_array_len
 
         # validate transaction
-        is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature)
+        assert_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature)
 
         # bump nonce
         Account_current_nonce.write(_current_nonce + 1)


### PR DESCRIPTION
Fixes #327

This PR removes the `is_valid_signature` method on the `Account` and replaces it with `assert_valid_signature` to make the API more intuitive. It introduces breaking changes (`is_valid_signature` no longer exists ^^).

For rationale behind this PR, see #327 :)
