### PR TITLE
Add return value to is_valid_signature

### DIFF
--- a/docs/Account.md
+++ b/docs/Account.md
@@ -75,7 +75,7 @@ namespace IAccount:
             hash: felt,
             signature_len: felt,
             signature: felt*
-        ):
+        ) -> (is_valid: felt):
     end
 
     func __execute__(
@@ -282,7 +282,7 @@ end
 func is_valid_signature(hash: felt,
         signature_len: felt,
         signature: felt*
-    ):
+    ) -> (is_valid: felt):
 end
 
 func __execute__(
@@ -339,7 +339,7 @@ None.
 
 ### `is_valid_signature`
 
-This function is inspired by [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) and checks whether a given signature is valid, otherwise it reverts.
+This function is inspired by [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) and returns `TRUE` if a given signature is valid, otherwise it reverts. In the future it will return `FALSE` if a given signature is invalid (for more info please check [this issue](https://github.com/OpenZeppelin/cairo-contracts/issues/327)).
 
 Parameters:
 

--- a/docs/Account.md
+++ b/docs/Account.md
@@ -351,7 +351,8 @@ signature: felt*
 
 Returns:
 
-None.
+`TRUE` if a given signature is valid. Otherwise, reverts. In the future it will return `FALSE` if a given signature is invalid (for more info please check [this issue](https://github.com/OpenZeppelin/cairo-contracts/issues/327)).
+
 
 ### `__execute__`
 

--- a/docs/Account.md
+++ b/docs/Account.md
@@ -351,8 +351,11 @@ signature: felt*
 
 Returns:
 
-`TRUE` if a given signature is valid. Otherwise, reverts. In the future it will return `FALSE` if a given signature is invalid (for more info please check [this issue](https://github.com/OpenZeppelin/cairo-contracts/issues/327)).
+```cairo
+is_valid: felt
+```
 
+> returns `TRUE` if a given signature is valid. Otherwise, reverts. In the future it will return `FALSE` if a given signature is invalid (for more info please check [this issue](https://github.com/OpenZeppelin/cairo-contracts/issues/327)).
 
 ### `__execute__`
 

--- a/src/openzeppelin/account/Account.cairo
+++ b/src/openzeppelin/account/Account.cairo
@@ -85,9 +85,9 @@ func is_valid_signature{
         hash: felt,
         signature_len: felt,
         signature: felt*
-    ) -> ():
-    Account.is_valid_signature(hash, signature_len, signature)
-    return ()
+    ) -> (is_valid: felt):
+    let (is_valid) = Account.is_valid_signature(hash, signature_len, signature)
+    return (is_valid=is_valid)
 end
 
 @external

--- a/src/openzeppelin/account/IAccount.cairo
+++ b/src/openzeppelin/account/IAccount.cairo
@@ -23,7 +23,7 @@ namespace IAccount:
             hash: felt,
             signature_len: felt,
             signature: felt*
-        ):
+        ) -> (is_valid: felt):
     end
 
     func __execute__(

--- a/src/openzeppelin/account/library.cairo
+++ b/src/openzeppelin/account/library.cairo
@@ -170,7 +170,7 @@ namespace Account:
 
         # validate transaction
         let (is_valid) = is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature)
-        with_attr error_message("Invalid signature"):
+        with_attr error_message("Account: invalid signature"):
             assert is_valid = TRUE
         end
 

--- a/src/openzeppelin/account/library.cairo
+++ b/src/openzeppelin/account/library.cairo
@@ -6,6 +6,7 @@ from starkware.cairo.common.signature import verify_ecdsa_signature
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.memcpy import memcpy
+from starkware.cairo.common.bool import TRUE
 from starkware.starknet.common.syscalls import call_contract, get_caller_address, get_tx_info
 
 from openzeppelin.introspection.ERC165 import ERC165
@@ -122,7 +123,7 @@ namespace Account:
             hash: felt,
             signature_len: felt,
             signature: felt*
-        ) -> ():
+        ) -> (is_valid: felt):
         let (_public_key) = Account_public_key.read()
 
         # This interface expects a signature pointer and length to make
@@ -137,7 +138,7 @@ namespace Account:
             signature_r=sig_r,
             signature_s=sig_s)
 
-        return ()
+        return (is_valid=TRUE)
     end
 
 
@@ -168,7 +169,10 @@ namespace Account:
         let calls_len = call_array_len
 
         # validate transaction
-        is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature)
+        let (is_valid) = is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature)
+        with_attr error_message("Invalid signature"):
+            assert is_valid = TRUE
+        end
 
         # bump nonce
         Account_current_nonce.write(_current_nonce + 1)


### PR DESCRIPTION
Fixes #327

This PR adds a return value to `is_valid_signature` when the signature is valid (the return value is `TRUE` from `common.bool` lib).

The intention behind this is to make the API more intuitive and to prepare developers for the future when this function will return `FALSE` when a signature is invalid.

Replaces #337 