### PR TITLE
Fix Account reentrant signature reutilization

### DIFF
--- a/src/openzeppelin/account/library.cairo
+++ b/src/openzeppelin/account/library.cairo
@@ -173,6 +173,11 @@ func Account_execute{
     let (__fp__, _) = get_fp_and_pc()
     let (tx_info) = get_tx_info()
     let (_current_nonce) = Account_current_nonce.read()
+    
+    # Avoid contracts
+    # See https://github.com/OpenZeppelin/cairo-contracts/issues/344
+    let (caller) = get_caller_address()
+    assert caller = 0
 
     # validate nonce
     assert _current_nonce = nonce

--- a/src/openzeppelin/account/library.cairo
+++ b/src/openzeppelin/account/library.cairo
@@ -174,7 +174,7 @@ func Account_execute{
     let (tx_info) = get_tx_info()
     let (_current_nonce) = Account_current_nonce.read()
     
-    # Forbid non-external calls to prevent signature spoofing
+    # Forbid non-external calls to prevent reentrant signature reutilization
     # See https://github.com/OpenZeppelin/cairo-contracts/issues/344
     let (caller) = get_caller_address()
     assert caller = 0

--- a/src/openzeppelin/account/library.cairo
+++ b/src/openzeppelin/account/library.cairo
@@ -174,7 +174,7 @@ func Account_execute{
     let (tx_info) = get_tx_info()
     let (_current_nonce) = Account_current_nonce.read()
     
-    # Avoid contracts
+    # Forbid non-external calls to prevent signature spoofing
     # See https://github.com/OpenZeppelin/cairo-contracts/issues/344
     let (caller) = get_caller_address()
     assert caller = 0


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/cairo-contracts/issues/344.

The bug described in the issue would allow any malicious smart contract to take ownership of an account that interacts unknowingly with the contract (even if it’s behind another contract — any contract in the execution chain could take over the account initiating the transaction).