### PR TITLE
Add security advisory about Account vulnerability in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@
 
 **A library for secure smart contract development** written in Cairo for [StarkNet](https://starkware.co/product/starknet/), a decentralized ZK Rollup.
 
+## Security Advisory ⚠️
+
+- A critical [vulnerability](https://github.com/OpenZeppelin/cairo-contracts/issues/344) was found in an **unreleased** version of the Account contract. It was [introduced in March 25th](https://github.com/OpenZeppelin/cairo-contracts/pull/233) and has been [patched as of June 1st](https://github.com/OpenZeppelin/cairo-contracts/pull/347). If you copied the Account contract code into your project during that period, please update to the patched version. Note that 0.1.0 users are not affected.
+
 ## Usage
 
-> ## ⚠️ WARNING! ⚠️
+> ## ⚠️ Warning! ⚠️
 > This repo contains highly experimental code.
 > Expect rapid iteration.
 > **Use at your own risk.**


### PR DESCRIPTION
Not creating a security advisory on github since this was unreleased, but given many users seem to copy-paste code (due to the rapid iteration), we should let them know. And if they're copy-pasting, it means they come to the repo often, so what better place to notify than in the readme?