### PR TITLE
Add error message for invalid nonce error

### DIFF
--- a/src/openzeppelin/account/library.cairo
+++ b/src/openzeppelin/account/library.cairo
@@ -166,7 +166,9 @@ namespace Account:
         let (_current_nonce) = Account_current_nonce.read()
 
         # validate nonce
-        assert _current_nonce = nonce
+        with_attr error_message("Account: nonce is invalid"):
+            assert _current_nonce = nonce
+        end
 
         # TMP: Convert `AccountCallArray` to 'Call'.
         let (calls : Call*) = alloc()

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -131,20 +131,17 @@ async def test_nonce(account_factory):
     current_nonce = execution_info.result.res
 
     # lower nonce
-    try:
-        await signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])], current_nonce - 1)
-        assert False
-    except StarkException as err:
-        _, error = err.args
-        assert error['code'] == StarknetErrorCode.TRANSACTION_FAILED
+    await assert_revert(
+        signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])], current_nonce - 1),
+        reverted_with="Account: nonce is invalid"
+    )
 
     # higher nonce
-    try:
-        await signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])], current_nonce + 1)
-        assert False
-    except StarkException as err:
-        _, error = err.args
-        assert error['code'] == StarknetErrorCode.TRANSACTION_FAILED
+    await assert_revert(
+        signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])], current_nonce + 1),
+        reverted_with="Account: nonce is invalid"
+    )
+
     # right nonce
     await signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])], current_nonce)
 


### PR DESCRIPTION
Adds an error message that gives context if the nonce is invalid. This will help with the UX of wallets and users deploying account contracts who currently see an error message that only talks about two felts being different when they should be the same, without any context.


#### PR Checklist

- [x] Tests
- [x] Documentation
- [ ] Changelog entry
