### PR TITLE
Simplify paths for fetching contract classes in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ from utils import get_contract_class, cached_contract
 @pytest.fixture(scope='module')
 def foo_factory():
     # get contract class
-    foo_cls = get_contract_class('path/to/foo.cairo')
+    foo_cls = get_contract_class('Foo')
 
     # deploy contract
     starknet = await Starknet.empty()

--- a/docs/Utilities.md
+++ b/docs/Utilities.md
@@ -207,6 +207,12 @@ A helper method that returns the contract class from the contract's name. To cap
 contract_class = get_contract_class('ContractName')
 ```
 
+If multiple contracts exist with the same name, then the contract's path must be used instead of the name. To pass the contract's path:
+
+```python
+contract_class = get_contract_class('path/to/Contract.cairo', is_path=True)
+```
+
 ### `cached_contract`
 
 A helper method that returns the cached state of a given contract. It's recommended to first deploy all the relevant contracts before caching the state. The requisite contracts in the testing module should each be instantiated with `cached_contract` in a fixture after the state has been copied. The memoization pattern with `cached_contract` should look something like this:

--- a/docs/Utilities.md
+++ b/docs/Utilities.md
@@ -207,7 +207,7 @@ A helper method that returns the contract class from the contract's name. To cap
 contract_class = get_contract_class('ContractName')
 ```
 
-If multiple contracts exist with the same name, then the contract's path must be used instead of the name. To pass the contract's path:
+If multiple contracts exist with the same name, then the contract's path must be passed along with the `is_path` flag instead of the name. To pass the contract's path:
 
 ```python
 contract_class = get_contract_class('path/to/Contract.cairo', is_path=True)

--- a/docs/Utilities.md
+++ b/docs/Utilities.md
@@ -201,10 +201,10 @@ Memoizing functions allow for quicker and computationally cheaper calculations w
 
 ### `get_contract_class`
 
-A helper method that returns the contract class from the given path. To capture the contract class, simply add the contract path as an argument like this:
+A helper method that returns the contract class from the contract's name. To capture the contract class, simply add the contract's name as an argument like this:
 
 ```python
-contract_class = get_contract_class('path/to/contract.cairo')
+contract_class = get_contract_class('ContractName')
 ```
 
 ### `cached_contract`
@@ -215,7 +215,7 @@ A helper method that returns the cached state of a given contract. It's recommen
 # get contract classes
 @pytest.fixture(scope='module')
 def contract_classes():
-  foo_cls = get_contract_class('path/to/foo.cairo')
+  foo_cls = get_contract_class('Foo')
   return foo_cls
 
 # deploy contracts

--- a/tests/access/test_AccessControl.py
+++ b/tests/access/test_AccessControl.py
@@ -20,8 +20,8 @@ def contract_classes():
     return {
         Path(key).stem: get_contract_class(key)
         for key in [
-            'openzeppelin/account/Account.cairo',
-            'tests/mocks/AccessControl.cairo',
+            'Account',
+            'AccessControl',
         ]
     }
 

--- a/tests/access/test_Ownable.py
+++ b/tests/access/test_Ownable.py
@@ -15,8 +15,8 @@ signer = MockSigner(123456789987654321)
 @pytest.fixture(scope='module')
 def contract_classes():
     return (
-        get_contract_class('openzeppelin/account/Account.cairo'),
-        get_contract_class('tests/mocks/Ownable.cairo')
+        get_contract_class('Account'),
+        get_contract_class('Ownable')
     )
 
 

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -12,9 +12,9 @@ IACCOUNT_ID = 0xf10dbd44
 
 @pytest.fixture(scope='module')
 def contract_classes():
-    account_cls = get_contract_class('openzeppelin/account/Account.cairo')
-    init_cls = get_contract_class("tests/mocks/Initializable.cairo")
-    attacker_cls = get_contract_class("tests/mocks/account_reentrancy.cairo")
+    account_cls = get_contract_class('Account')
+    init_cls = get_contract_class("Initializable")
+    attacker_cls = get_contract_class("account_reentrancy")
 
     return account_cls, init_cls, attacker_cls
 

--- a/tests/account/test_AddressRegistry.py
+++ b/tests/account/test_AddressRegistry.py
@@ -12,8 +12,8 @@ ANOTHER_ADDRESS = 0xd9e1ce17f2641f24ae83637ab66a2cca9c378b9f
 @pytest.fixture(scope='module')
 async def registry_factory():
     # contract classes
-    registry_cls = get_contract_class("openzeppelin/account/AddressRegistry.cairo")
-    account_cls = get_contract_class('openzeppelin/account/Account.cairo')
+    registry_cls = get_contract_class("AddressRegistry")
+    account_cls = get_contract_class('Account')
 
     # deployments
     starknet = await Starknet.empty()

--- a/tests/account/test_EthAccount.py
+++ b/tests/account/test_EthAccount.py
@@ -14,9 +14,9 @@ IACCOUNT_ID = 0xf10dbd44
 
 @pytest.fixture(scope='module')
 def contract_defs():
-    account_cls = get_contract_class('openzeppelin/account/EthAccount.cairo')
-    init_cls = get_contract_class("tests/mocks/Initializable.cairo")
-    attacker_cls = get_contract_class("tests/mocks/account_reentrancy.cairo")
+    account_cls = get_contract_class('EthAccount')
+    init_cls = get_contract_class("Initializable")
+    attacker_cls = get_contract_class("account_reentrancy")
 
     return account_cls, init_cls, attacker_cls
 

--- a/tests/introspection/test_ERC165.py
+++ b/tests/introspection/test_ERC165.py
@@ -18,7 +18,7 @@ OTHER_ID = 0x12345678
 @pytest.fixture(scope='module')
 async def erc165_factory():
     # class
-    erc165_cls = get_contract_class("ERC165")
+    erc165_cls = get_contract_class("tests/mocks/ERC165.cairo", is_path=True)
 
     # deployment
     starknet = await Starknet.empty()

--- a/tests/introspection/test_ERC165.py
+++ b/tests/introspection/test_ERC165.py
@@ -18,7 +18,7 @@ OTHER_ID = 0x12345678
 @pytest.fixture(scope='module')
 async def erc165_factory():
     # class
-    erc165_cls = get_contract_class("tests/mocks/ERC165.cairo")
+    erc165_cls = get_contract_class("ERC165")
 
     # deployment
     starknet = await Starknet.empty()

--- a/tests/security/test_initializable.py
+++ b/tests/security/test_initializable.py
@@ -1,9 +1,7 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import TRUE, FALSE, assert_revert, get_contract_class
-from signers import MockSigner
 
-signer = MockSigner(12345678987654321)
 
 @pytest.mark.asyncio
 async def test_initializer():

--- a/tests/security/test_initializable.py
+++ b/tests/security/test_initializable.py
@@ -1,13 +1,15 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
-from utils import TRUE, FALSE, assert_revert, contract_path
+from utils import TRUE, FALSE, assert_revert, get_contract_class
+from signers import MockSigner
 
+signer = MockSigner(12345678987654321)
 
 @pytest.mark.asyncio
 async def test_initializer():
     starknet = await Starknet.empty()
     initializable = await starknet.deploy(
-        contract_path("tests/mocks/Initializable.cairo")
+        contract_class=get_contract_class("Initializable")
     )
     expected = await initializable.initialized().call()
     assert expected.result == (FALSE,)

--- a/tests/security/test_pausable.py
+++ b/tests/security/test_pausable.py
@@ -12,8 +12,8 @@ signer = MockSigner(12345678987654321)
 @pytest.fixture
 async def pausable_factory():
     # class
-    pausable_cls = get_contract_class("tests/mocks/Pausable.cairo")
-    account_cls = get_contract_class("openzeppelin/account/Account.cairo")
+    pausable_cls = get_contract_class("Pausable")
+    account_cls = get_contract_class("Account")
 
     starknet = await Starknet.empty()
     pausable = await starknet.deploy(

--- a/tests/security/test_reentrancy.py
+++ b/tests/security/test_reentrancy.py
@@ -12,7 +12,6 @@ async def reentrancy_mock():
     starknet = await Starknet.empty()
     contract = await starknet.deploy(
         contract_class=get_contract_class("reentrancy_mock"),
-        #"tests/mocks/reentrancy_mock.cairo",
         constructor_calldata=[INITIAL_COUNTER]
     )
 

--- a/tests/security/test_reentrancy.py
+++ b/tests/security/test_reentrancy.py
@@ -1,7 +1,7 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    assert_revert
+    assert_revert, get_contract_class
 )
 
 INITIAL_COUNTER = 0
@@ -11,7 +11,8 @@ INITIAL_COUNTER = 0
 async def reentrancy_mock():
     starknet = await Starknet.empty()
     contract = await starknet.deploy(
-        "tests/mocks/reentrancy_mock.cairo",
+        contract_class=get_contract_class("reentrancy_mock"),
+        #"tests/mocks/reentrancy_mock.cairo",
         constructor_calldata=[INITIAL_COUNTER]
     )
 

--- a/tests/security/test_safemath.py
+++ b/tests/security/test_safemath.py
@@ -2,7 +2,8 @@ import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
     MAX_UINT256, assert_revert, add_uint, sub_uint,
-    mul_uint, div_rem_uint, to_uint, contract_path
+    mul_uint, div_rem_uint, to_uint, contract_path,
+    get_contract_class
 )
 
 
@@ -10,7 +11,7 @@ from utils import (
 async def safemath_mock():
     starknet = await Starknet.empty()
     safemath = await starknet.deploy(
-        contract_path("tests/mocks/safemath_mock.cairo")
+        contract_class=get_contract_class("safemath_mock")
     )
 
     return safemath

--- a/tests/token/erc20/test_ERC20.py
+++ b/tests/token/erc20/test_ERC20.py
@@ -23,9 +23,8 @@ DECIMALS = 18
 
 @pytest.fixture(scope='module')
 def contract_classes():
-    account_cls = get_contract_class('openzeppelin/account/Account.cairo')
-    erc20_cls = get_contract_class(
-        'openzeppelin/token/erc20/ERC20.cairo')
+    account_cls = get_contract_class('Account')
+    erc20_cls = get_contract_class('ERC20')
 
     return account_cls, erc20_cls
 

--- a/tests/token/erc20/test_ERC20_Burnable_mock.py
+++ b/tests/token/erc20/test_ERC20_Burnable_mock.py
@@ -20,9 +20,8 @@ DECIMALS = 18
 
 @pytest.fixture(scope='module')
 def contract_classes():
-    account_cls = get_contract_class('openzeppelin/account/Account.cairo')
-    erc20_cls = get_contract_class(
-        'tests/mocks/ERC20_Burnable_mock.cairo')
+    account_cls = get_contract_class('Account')
+    erc20_cls = get_contract_class('ERC20_Burnable_mock')
 
     return account_cls, erc20_cls
 

--- a/tests/token/erc20/test_ERC20_Mintable.py
+++ b/tests/token/erc20/test_ERC20_Mintable.py
@@ -22,9 +22,8 @@ DECIMALS = 18
 
 @pytest.fixture(scope='module')
 def contract_classes():
-    account_cls = get_contract_class('openzeppelin/account/Account.cairo')
-    erc20_cls = get_contract_class(
-        'openzeppelin/token/erc20/ERC20_Mintable.cairo')
+    account_cls = get_contract_class('Account')
+    erc20_cls = get_contract_class('ERC20_Mintable')
 
     return account_cls, erc20_cls
 

--- a/tests/token/erc20/test_ERC20_Pausable.py
+++ b/tests/token/erc20/test_ERC20_Pausable.py
@@ -19,9 +19,8 @@ DECIMALS = 18
 
 @pytest.fixture(scope='module')
 def contract_classes():
-    account_cls = get_contract_class('openzeppelin/account/Account.cairo')
-    erc20_cls = get_contract_class(
-        'openzeppelin/token/erc20/ERC20_Pausable.cairo')
+    account_cls = get_contract_class('Account')
+    erc20_cls = get_contract_class('ERC20_Pausable')
 
     return account_cls, erc20_cls
 

--- a/tests/token/erc20/test_ERC20_Upgradeable.py
+++ b/tests/token/erc20/test_ERC20_Upgradeable.py
@@ -20,10 +20,9 @@ DECIMALS = 18
 
 @pytest.fixture(scope='module')
 def contract_classes():
-    account_cls = get_contract_class('openzeppelin/account/Account.cairo')
-    token_cls = get_contract_class(
-        'openzeppelin/token/erc20/ERC20_Upgradeable.cairo')
-    proxy_cls = get_contract_class('openzeppelin/upgrades/Proxy.cairo')
+    account_cls = get_contract_class('Account')
+    token_cls = get_contract_class('ERC20_Upgradeable')
+    proxy_cls = get_contract_class('Proxy')
 
     return account_cls, token_cls, proxy_cls
 

--- a/tests/token/erc721/test_ERC721_Mintable_Burnable.py
+++ b/tests/token/erc721/test_ERC721_Mintable_Burnable.py
@@ -32,13 +32,10 @@ UNSUPPORTED_ID = 0xabcd1234
 
 @pytest.fixture(scope='module')
 def contract_classes():
-    account_cls = get_contract_class('openzeppelin/account/Account.cairo')
-    erc721_cls = get_contract_class(
-        'openzeppelin/token/erc721/ERC721_Mintable_Burnable.cairo')
-    erc721_holder_cls = get_contract_class(
-        'openzeppelin/token/erc721/utils/ERC721_Holder.cairo')
-    unsupported_cls = get_contract_class(
-        'tests/mocks/Initializable.cairo')
+    account_cls = get_contract_class('Account')
+    erc721_cls = get_contract_class('ERC721_Mintable_Burnable')
+    erc721_holder_cls = get_contract_class('ERC721_Holder')
+    unsupported_cls = get_contract_class('Initializable')
 
     return account_cls, erc721_cls, erc721_holder_cls, unsupported_cls
 

--- a/tests/token/erc721/test_ERC721_Mintable_Pausable.py
+++ b/tests/token/erc721/test_ERC721_Mintable_Pausable.py
@@ -18,11 +18,9 @@ DATA = [0x42, 0x89, 0x55]
 
 @pytest.fixture(scope='module')
 def contract_classes():
-    account_cls = get_contract_class('openzeppelin/account/Account.cairo')
-    erc721_cls = get_contract_class(
-        'openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo')
-    erc721_holder_cls = get_contract_class(
-        'openzeppelin/token/erc721/utils/ERC721_Holder.cairo')
+    account_cls = get_contract_class('Account')
+    erc721_cls = get_contract_class('ERC721_Mintable_Pausable')
+    erc721_holder_cls = get_contract_class('ERC721_Holder')
 
     return account_cls, erc721_cls, erc721_holder_cls
 

--- a/tests/token/erc721/test_ERC721_SafeMintable_mock.py
+++ b/tests/token/erc721/test_ERC721_SafeMintable_mock.py
@@ -17,12 +17,10 @@ DATA = [0x42, 0x89, 0x55]
 
 @pytest.fixture(scope='module')
 def contract_classes():
-    account_cls = get_contract_class('openzeppelin/account/Account.cairo')
-    erc721_cls = get_contract_class('tests/mocks/ERC721_SafeMintable_mock.cairo')
-    erc721_holder_cls = get_contract_class(
-        'openzeppelin/token/erc721/utils/ERC721_Holder.cairo')
-    unsupported_cls = get_contract_class(
-        'tests/mocks/Initializable.cairo')
+    account_cls = get_contract_class('Account')
+    erc721_cls = get_contract_class('ERC721_SafeMintable_mock')
+    erc721_holder_cls = get_contract_class('ERC721_Holder')
+    unsupported_cls = get_contract_class('Initializable')
 
     return account_cls, erc721_cls, erc721_holder_cls, unsupported_cls
 

--- a/tests/token/erc721_enumerable/test_ERC721_Enumerable_Mintable_Burnable.py
+++ b/tests/token/erc721_enumerable/test_ERC721_Enumerable_Mintable_Burnable.py
@@ -25,9 +25,8 @@ ENUMERABLE_INTERFACE_ID = 0x780e9d63
 
 @pytest.fixture(scope='module')
 def contract_classes():
-    account_cls = get_contract_class('openzeppelin/account/Account.cairo')
-    erc721_cls = get_contract_class(
-        'openzeppelin/token/erc721_enumerable/ERC721_Enumerable_Mintable_Burnable.cairo')
+    account_cls = get_contract_class('Account')
+    erc721_cls = get_contract_class('ERC721_Enumerable_Mintable_Burnable')
 
     return account_cls, erc721_cls
 

--- a/tests/upgrades/test_Proxy.py
+++ b/tests/upgrades/test_Proxy.py
@@ -17,11 +17,9 @@ signer = MockSigner(123456789987654321)
 
 @pytest.fixture(scope='module')
 def contract_classes():
-    account_cls = get_contract_class('openzeppelin/account/Account.cairo')
-    implementation_cls = get_contract_class(
-        'tests/mocks/proxiable_implementation.cairo'
-    )
-    proxy_cls = get_contract_class('openzeppelin/upgrades/Proxy.cairo')
+    account_cls = get_contract_class('Account')
+    implementation_cls = get_contract_class('proxiable_implementation')
+    proxy_cls = get_contract_class('Proxy')
 
     return account_cls, implementation_cls, proxy_cls
 

--- a/tests/upgrades/test_upgrades.py
+++ b/tests/upgrades/test_upgrades.py
@@ -19,10 +19,10 @@ signer = MockSigner(123456789987654321)
 
 @pytest.fixture(scope='module')
 def contract_classes():
-    account_cls = get_contract_class('openzeppelin/account/Account.cairo')
-    v1_cls = get_contract_class('tests/mocks/upgrades_v1_mock.cairo')
-    v2_cls = get_contract_class('tests/mocks/upgrades_v2_mock.cairo')
-    proxy_cls = get_contract_class('openzeppelin/upgrades/Proxy.cairo')
+    account_cls = get_contract_class('Account')
+    v1_cls = get_contract_class('upgrades_v1_mock')
+    v2_cls = get_contract_class('upgrades_v2_mock')
+    proxy_cls = get_contract_class('Proxy')
 
     return account_cls, v1_cls, v2_cls, proxy_cls
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -123,12 +123,12 @@ def _get_path_from_name(name):
     raise FileNotFoundError(f"Cannot find '{name}'.")
 
 
-def get_contract_class(name, is_path=False):
+def get_contract_class(contract, is_path=False):
     """Return the contract class from the contract name or path"""
     if is_path is not False:
-        path = contract_path(name)
+        path = contract_path(contract)
     else:
-        path = _get_path_from_name(name)
+        path = _get_path_from_name(contract)
 
     contract_class = compile_starknet_files(
         files=[path],

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -125,7 +125,7 @@ def _get_path_from_name(name):
 
 def get_contract_class(contract, is_path=False):
     """Return the contract class from the contract name or path"""
-    if is_path is not False:
+    if is_path:
         path = contract_path(contract)
     else:
         path = _get_path_from_name(contract)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -123,9 +123,13 @@ def _get_path_from_name(name):
     raise FileNotFoundError(f"Cannot find '{name}'.")
 
 
-def get_contract_class(name):
-    """Return the contract class from the contract name"""
-    path = _get_path_from_name(name)
+def get_contract_class(name, is_path=False):
+    """Return the contract class from the contract name or path"""
+    if is_path is not False:
+        path = contract_path(name)
+    else:
+        path = _get_path_from_name(name)
+
     contract_class = compile_starknet_files(
         files=[path],
         debug_info=True

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import math
+import os
 from starkware.starknet.public.abi import get_selector_from_name
 from starkware.starknet.compiler.compile import compile_starknet_files
 from starkware.starkware_utils.error_handling import StarkException
@@ -110,9 +111,21 @@ def assert_event_emitted(tx_exec_info, from_address, name, data):
     ) in tx_exec_info.raw_events
 
 
-def get_contract_class(path):
-    """Return the contract class from the contract path"""
-    path = contract_path(path)
+def _get_path_from_name(name):
+    """Return the contract path by contract name."""
+    dirs = ["src", "tests/mocks"]
+    for dir in dirs:
+        for (dirpath, _, filenames) in os.walk(dir):
+            for file in filenames:
+                if file == f"{name}.cairo":
+                    return os.path.join(dirpath, file)
+
+    raise FileNotFoundError(f"Cannot find '{name}'.")
+
+
+def get_contract_class(name):
+    """Return the contract class from the contract name"""
+    path = _get_path_from_name(name)
     contract_class = compile_starknet_files(
         files=[path],
         debug_info=True


### PR DESCRIPTION
This PR proposes to simplify getting contract classes in the test environment. Instead of passing the entire path as an argument to `get_contract_class`, this PR proposes to pass just the contract name. For example:

```
account_cls = get_contract_class('Account')
erc20_cls = get_contract_class('ERC20')
```

as opposed to:

```
account_cls = get_contract_class('openzeppelin/account/Account.cairo')
erc20_cls = get_contract_class('openzeppelin/token/erc20/ERC20.cairo')
```

---

In the event that multiple preset contracts share the same name, `get_contract_class` includes the optional param `is_path`. The syntax looks like this:

```
account_cls = get_contract_class('openzeppelin/account/Account.cairo', is_path=True)
```

Resolves #379.