### PR TITLE
Fix Wizard position in docs

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -15,4 +15,3 @@
 * xref:utilities.adoc[Utilities]
 
 * xref:contracts::index.adoc[Contracts for Solidity]
-* https://wizard.openzeppelin.com/cairo[Wizard]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,5 @@
 * xref:index.adoc[Overview]
+* xref:wizard.adoc[Wizard]
 * xref:extensibility.adoc[Extensibility]
 * xref:proxies.adoc[Proxies and Upgrades]
 

--- a/docs/modules/ROOT/pages/wizard.adoc
+++ b/docs/modules/ROOT/pages/wizard.adoc
@@ -1,0 +1,13 @@
+= Cairo Contracts Wizard
+:page-notoc:
+
+Not sure where to start? Use the interactive generator below to bootstrap your
+contract and learn about the components offered in OpenZeppelin Cairo Contracts.
+
+TIP: Place the resulting contract in your `contracts` directory in order to compile it with a tool like Nile.
+
+++++
+<script async src="https://wizard.openzeppelin.com/build/embed.js"></script>
+
+<oz-wizard style="display: block; min-height: 40rem;" data-lang="cairo"></oz-wizard>
+++++

--- a/docs/modules/ROOT/pages/wizard.adoc
+++ b/docs/modules/ROOT/pages/wizard.adoc
@@ -5,7 +5,7 @@ Not sure where to start? Use the interactive generator below to bootstrap your
 contract and learn about the components offered in OpenZeppelin Cairo Contracts.
 
 
-CAUTION: If you haven’t yet, before moving forward, we strongly recommend checking the xref:extensibility.adoc[Extensibility Pattern] section to understand how we manage extensibility in a language lacking inheritance.
+NOTE: We strongly recommend checking the xref:extensibility.adoc[Extensibility Pattern] to understand how to extend from our library.
 
 ++++
 <script async src="https://wizard.openzeppelin.com/build/embed.js"></script>

--- a/docs/modules/ROOT/pages/wizard.adoc
+++ b/docs/modules/ROOT/pages/wizard.adoc
@@ -4,7 +4,8 @@
 Not sure where to start? Use the interactive generator below to bootstrap your
 contract and learn about the components offered in OpenZeppelin Cairo Contracts.
 
-TIP: Place the resulting contract in your `contracts` directory in order to compile it with a tool like Nile.
+
+CAUTION: If you haven’t yet, before moving forward, we strongly recommend checking the xref:extensibility.adoc[Extensibility Pattern] section to understand how we manage extensibility in a language lacking inheritance.
 
 ++++
 <script async src="https://wizard.openzeppelin.com/build/embed.js"></script>

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ allowlist_externals =
     npm
     npx
 commands_pre = 
-    npm install npm
+    npm init -y
     npm i markdownlint-cli
 commands =
     npx markdownlint-cli README.md CONTRIBUTING.md docs


### PR DESCRIPTION
Fixes #462. Moving the Wizard nav element right below Overview, and showing it in the same page from embedding script (as is done in Solidity contracts docs site).
