### PR TITLE
Removed syscall_ptr and pedersen_ptr from SafeUint256 functions

### DIFF
--- a/src/openzeppelin/security/safemath/library.cairo
+++ b/src/openzeppelin/security/safemath/library.cairo
@@ -20,9 +20,7 @@ from starkware.cairo.common.uint256 import (
 namespace SafeUint256 {
     // Adds two integers.
     // Reverts if the sum overflows.
-    func add{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        a: Uint256, b: Uint256
-    ) -> (c: Uint256) {
+    func add{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
         uint256_check(a);
         uint256_check(b);
         let (c: Uint256, is_overflow) = uint256_add(a, b);
@@ -34,9 +32,7 @@ namespace SafeUint256 {
 
     // Subtracts two integers.
     // Reverts if subtrahend (`b`) is greater than minuend (`a`).
-    func sub_le{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        a: Uint256, b: Uint256
-    ) -> (c: Uint256) {
+    func sub_le{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
         alloc_locals;
         uint256_check(a);
         uint256_check(b);
@@ -50,9 +46,7 @@ namespace SafeUint256 {
 
     // Subtracts two integers.
     // Reverts if subtrahend (`b`) is greater than or equal to minuend (`a`).
-    func sub_lt{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        a: Uint256, b: Uint256
-    ) -> (c: Uint256) {
+    func sub_lt{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
         alloc_locals;
         uint256_check(a);
         uint256_check(b);
@@ -67,9 +61,7 @@ namespace SafeUint256 {
 
     // Multiplies two integers.
     // Reverts if product is greater than 2^256.
-    func mul{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        a: Uint256, b: Uint256
-    ) -> (c: Uint256) {
+    func mul{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
         alloc_locals;
         uint256_check(a);
         uint256_check(b);
@@ -95,9 +87,7 @@ namespace SafeUint256 {
     // Cairo's `uint256_unsigned_div_rem` already checks:
     //    remainder < divisor
     //    quotient * divisor + remainder == dividend
-    func div_rem{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        a: Uint256, b: Uint256
-    ) -> (c: Uint256, rem: Uint256) {
+    func div_rem{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256, rem: Uint256) {
         alloc_locals;
         uint256_check(a);
         uint256_check(b);

--- a/tests/mocks/SafeMathMock.cairo
+++ b/tests/mocks/SafeMathMock.cairo
@@ -8,36 +8,26 @@ from starkware.cairo.common.uint256 import Uint256
 from openzeppelin.security.safemath.library import SafeUint256
 
 @view
-func uint256_add{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    a: Uint256, b: Uint256
-) -> (c: Uint256) {
+func uint256_add{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
     return SafeUint256.add(a, b);
 }
 
 @view
-func uint256_sub_le{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    a: Uint256, b: Uint256
-) -> (c: Uint256) {
+func uint256_sub_le{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
     return SafeUint256.sub_le(a, b);
 }
 
 @view
-func uint256_sub_lt{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    a: Uint256, b: Uint256
-) -> (c: Uint256) {
+func uint256_sub_lt{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
     return SafeUint256.sub_lt(a, b);
 }
 
 @view
-func uint256_mul{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    a: Uint256, b: Uint256
-) -> (c: Uint256) {
+func uint256_mul{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
     return SafeUint256.mul(a, b);
 }
 
 @view
-func uint256_div{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    a: Uint256, b: Uint256
-) -> (c: Uint256, rem: Uint256) {
+func uint256_div{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256, rem: Uint256) {
     return SafeUint256.div_rem(a, b);
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #495  <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

The functions under [SafeUint256](https://github.com/OpenZeppelin/cairo-contracts/blob/main/src/openzeppelin/security/safemath/library.cairo) have syscall_ptr and pedersen_ptr as implicit arguments. However, they are never called in any of these functions. The problem is that every function that relies on SafeUint256 must also have them as implicit argument.

This PR removes `pedersen_ptr` and `syscall_ptr` from the implicit arguments of `SafeUint256` functions.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [X] Tests
- [ ] Tried the feature on a public network
- [ ] Documentation
