### PR TITLE
Support Cairo 0.10.1

### DIFF
--- a/docs/modules/ROOT/pages/accounts.adoc
+++ b/docs/modules/ROOT/pages/accounts.adoc
@@ -244,7 +244,7 @@ A `MockSigner` instance exposes the following methods:
 
 * `send_transaction(account, to, selector_name, calldata, nonce=None, max_fee=0)` returns a link:https://docs.python.org/3/library/asyncio-future.html[future] of a signed transaction, ready to be sent.
 * `send_transactions(account, calls, nonce=None, max_fee=0)` returns a future of batched signed transactions, ready to be sent.
-* `declare_class(state, contract_name)` returns a future of a declaration transaction.
+* `declare_class(account, contract_name, nonce=None, max_fee=0)` returns a future of a declaration transaction.
 * `deploy_account(state, calldata, salt=0, nonce=0, max_fee=0)`: returns s future of a counterfactual deployment.
 
 To use `MockSigner`, pass a private key when instantiating the class:
@@ -281,7 +281,7 @@ Use `declare_class` to declare a contract:
 
 [,python]
 ----
-await signer.declare_class(state, "Account")
+await signer.declare_class(account, "MyToken")
 ----
 
 And `deploy_account` to <<counterfactual_deployments,counterfactually>> deploy an account:

--- a/docs/modules/ROOT/pages/accounts.adoc
+++ b/docs/modules/ROOT/pages/accounts.adoc
@@ -245,7 +245,7 @@ A `MockSigner` instance exposes the following methods:
 * `send_transaction(account, to, selector_name, calldata, nonce=None, max_fee=0)` returns a link:https://docs.python.org/3/library/asyncio-future.html[future] of a signed transaction, ready to be sent.
 * `send_transactions(account, calls, nonce=None, max_fee=0)` returns a future of batched signed transactions, ready to be sent.
 * `declare_class(account, contract_name, nonce=None, max_fee=0)` returns a future of a declaration transaction.
-* `deploy_account(state, calldata, salt=0, nonce=0, max_fee=0)`: returns s future of a counterfactual deployment.
+* `deploy_account(state, calldata, salt=0, nonce=0, max_fee=0)`: returns a future of a counterfactual deployment.
 
 To use `MockSigner`, pass a private key when instantiating the class:
 

--- a/docs/modules/ROOT/pages/accounts.adoc
+++ b/docs/modules/ROOT/pages/accounts.adoc
@@ -142,7 +142,7 @@ The steps are the following:
 2. Send funds to `address`.
 3. Send a `DeployAccount` type transaction.
 4. The protocol will then validate with `\\__validate_deploy__`.
-5. If successful, it deploys it and the transaction is paid by the contract.
+5. If successful, the protocol deploys the contract and the contract itself pays for the transaction.
 
 Since `address` will utimately depend on the `class_hash` and `calldata`, it's safe for the protocol to validate the signature and spend the funds on that address.
 

--- a/docs/modules/ROOT/pages/accounts.adoc
+++ b/docs/modules/ROOT/pages/accounts.adoc
@@ -144,7 +144,7 @@ The steps are the following:
 4. The protocol will then validate with `\\__validate_deploy__`.
 5. If successful, the protocol deploys the contract and the contract itself pays for the transaction.
 
-Since `address` will utimately depend on the `class_hash` and `calldata`, it's safe for the protocol to validate the signature and spend the funds on that address.
+Since `address` will ultimately depend on the `class_hash` and `calldata`, it's safe for the protocol to validate the signature and spend the funds on that address.
 
 == Standard interface
 

--- a/docs/modules/ROOT/pages/accounts.adoc
+++ b/docs/modules/ROOT/pages/accounts.adoc
@@ -284,7 +284,7 @@ Use `declare_class` to declare a contract:
 await signer.declare_class(state, "Account")
 ----
 
-And `deploy_account` to <<counterfactual-deployments,counterfactually>> deploy an account:
+And `deploy_account` to <<counterfactual_deployments,counterfactually>> deploy an account:
 
 [,python]
 ----

--- a/docs/modules/ROOT/pages/accounts.adoc
+++ b/docs/modules/ROOT/pages/accounts.adoc
@@ -14,6 +14,7 @@ A more detailed discussion on the topic can be found in https://community.starkn
 
 * <<quickstart,Quickstart>>
 * <<account_entrypoints,Account entrypoints>>
+ ** <<counterfactual_deployments,`Counterfactual deployments`>>
 * <<standard_interface,Standard interface>>
 * <<keys_signatures_and_signers,Keys, signatures and signers>>
 ** <<signature_validation, Signature validation>>
@@ -32,6 +33,7 @@ A more detailed discussion on the topic can be found in https://community.starkn
  ** <<isvalidsignature,`isValidSignature`>>
  ** <<validate,`\\__validate__`>>
  ** <<validate_declare,`\\__validate_declare__`>>
+ ** <<validate_deploy,`\\__validate_deploy__`>>
  ** <<execute,`\\__execute__`>>
 * <<presets,Presets>>
  ** <<account,Account>>
@@ -72,7 +74,7 @@ await signer.send_transaction(account, some_contract_address, 'some_function', [
 
 == Account entrypoints
 
-Account contracts contain three entry points for all user interactions with any contract.
+Account contracts have only three entry points for all user interactions:
 
 1. <<validate_declare,`\\__validate_declare__`>> validates the declaration signature prior to the declaration.
 As of Cairo v0.10.0, contract classes should be declared from an Account contract.
@@ -99,7 +101,7 @@ Or if you want to update the Account's L1 address on the `AccountRegistry` contr
 await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [NEW_ADDRESS])
 ----
 
-You can read more about how messages are structured and hashed in the https://github.com/OpenZeppelin/cairo-contracts/discussions/24[Account message scheme  discussion].
+NOTE: You can read more about how messages are structured and hashed in the https://github.com/OpenZeppelin/cairo-contracts/discussions/24[Account message scheme  discussion].
 For more information on the design choices and implementation of multicall, you can read the https://github.com/OpenZeppelin/cairo-contracts/discussions/27[How should Account multicall work discussion].
 
 The `\\__validate__` and `\\__execute__` methods accept the same arguments; however, `\\__execute__` returns a transaction response:
@@ -126,10 +128,30 @@ Where:
 NOTE: The scheme of building multicall transactions within the `\\__execute__` method will change once StarkNet allows for pointers in struct arrays.
 In which case, multiple transactions can be passed to (as opposed to built within) `\\__execute__`.
 
+There's a fourth canonical entrypoint for accounts, the `\\__validate_deploy__` method. It is **only callable by the protocol** during the execution of a `DeployAccount` type of transaction, but not by any other contract. This entrypoint is for counterfactual deployments.
+
+=== Counterfactual Deployments
+
+Counterfactual means something that hasn't happened.
+
+A deployment is said to be counterfactual when the deployed contract pays for it. It's called like this because we need to send the funds to the address before deployment. A deployment that hasn't happened.
+
+The steps are the following:
+
+1. Precompute the `address` given a `class_hash`, `salt`, and constructor `calldata`.
+2. Send funds to `address`.
+3. Send a `DeployAccount` type transaction.
+4. The protocol will then validate with `\\__validate_deploy__`.
+5. If successful, it deploys it and the transaction is paid by the contract.
+
+Since `address` will utimately depend on the `class_hash` and `calldata`, it's safe for the protocol to validate the signature and spend the funds on that address.
+
 == Standard interface
 
 The https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.4.0b/src/openzeppelin/account/IAccount.cairo[`IAccount.cairo`] contract interface contains the standard account interface proposed in https://github.com/OpenZeppelin/cairo-contracts/discussions/41[#41] and adopted by OpenZeppelin and Argent.
 It implements https://eips.ethereum.org/EIPS/eip-1271[EIP-1271] and it is agnostic of signature validation. Further, nonce management is handled on the protocol level.
+
+NOTE: `\\__validate_deploy__` is not part of the interface since it's only callable by the protocol. Also contracts don't need to implement it to be considered accounts.
 
 [,cairo]
 ----
@@ -215,13 +237,6 @@ To simplify Account management, most of this is abstracted away with `MockSigner
 === MockSigner utility
 
 The `MockSigner` class in {test-signers}[signers.py] is used to perform transactions on a given Account, crafting the transaction and managing nonces.
-
-The flow of a transaction starts with checking the nonce and converting the `to` contract address of each call to hexadecimal format.
-The hexadecimal conversion is necessary because Nile's `Signer` converts the address to a base-16 integer (which requires a string argument).
-Note that directly converting `to` to a string will ultimately result in an integer exceeding Cairo's `FIELD_PRIME`.
-
-The values included in the transaction are passed to the `sign_transaction` method of Nile's `Signer` which creates and returns a signature.
-Finally, the `MockSigner` instance invokes the account contract's `\\__execute__` with the transaction data.
 
 NOTE: StarkNet's testing framework does not currently support transaction invocations from account contracts. `MockSigner` therefore utilizes StarkNet's API gateway to manually execute the `InvokeFunction` for testing.
 
@@ -492,6 +507,25 @@ Parameters:
 [,cairo]
 ----
 class_hash: felt
+----
+
+Returns: None.
+
+=== `\\__validate_deploy__`
+
+Validates the signature for counterfactual deployment transactions.
+
+It takes the `class_hash` of the account being deployed along with the `salt` and `calldata`, the latter being expanded. For example if the account is deployed with calldata `[arg_1, ..., arg_n]`:
+
+Parameters:
+
+[,cairo]
+----
+class_hash: felt
+salt: felt
+arg_1: felt
+...
+arg_n: felt
 ----
 
 Returns: None.

--- a/docs/modules/ROOT/pages/accounts.adoc
+++ b/docs/modules/ROOT/pages/accounts.adoc
@@ -240,10 +240,12 @@ The `MockSigner` class in {test-signers}[signers.py] is used to perform transact
 
 NOTE: StarkNet's testing framework does not currently support transaction invocations from account contracts. `MockSigner` therefore utilizes StarkNet's API gateway to manually execute the `InvokeFunction` for testing.
 
-Users only need to interact with the following exposed methods to perform a transaction:
+A `MockSigner` instance exposes the following methods:
 
-* `send_transaction(account, to, selector_name, calldata, nonce=None, max_fee=0)` returns a future of a signed transaction, ready to be sent.
+* `send_transaction(account, to, selector_name, calldata, nonce=None, max_fee=0)` returns a link:https://docs.python.org/3/library/asyncio-future.html[future] of a signed transaction, ready to be sent.
 * `send_transactions(account, calls, nonce=None, max_fee=0)` returns a future of batched signed transactions, ready to be sent.
+* `declare_class(state, contract_name)` returns a future of a declaration transaction.
+* `deploy_account(state, calldata, salt=0, nonce=0, max_fee=0)`: returns s future of a counterfactual deployment.
 
 To use `MockSigner`, pass a private key when instantiating the class:
 
@@ -274,6 +276,21 @@ await signer.send_transactions(
     ]
 )
 ----
+
+Use `declare_class` to declare a contract:
+
+[,python]
+----
+await signer.declare_class(state, "Account")
+----
+
+And `deploy_account` to <<counterfactual-deployments,counterfactually>> deploy an account:
+
+[,python]
+----
+await signer.deploy_account(state, [signer.public_key])
+----
+
 
 === MockEthSigner utility
 

--- a/src/openzeppelin/account/IAccount.cairo
+++ b/src/openzeppelin/account/IAccount.cairo
@@ -11,11 +11,18 @@ namespace IAccount {
     func supportsInterface(interfaceId: felt) -> (success: felt) {
     }
 
-    func isValidSignature(hash: felt, signature_len: felt, signature: felt*) -> (isValid: felt) {
+    func isValidSignature(
+        hash: felt,
+        signature_len: felt,
+        signature: felt*
+    ) -> (isValid: felt) {
     }
 
     func __validate__(
-        call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*
+        call_array_len: felt,
+        call_array: AccountCallArray*,
+        calldata_len: felt,
+        calldata: felt*
     ) {
     }
 
@@ -24,11 +31,24 @@ namespace IAccount {
     func __validate_declare__(cls_hash: felt) {
     }
 
-    func __validate_deploy__(selector: felt, calldata_size: felt, calldata: felt*) {
+    // Parameter temporarily named `cls_hash` instead of `class_hash` (expected).
+    // See https://github.com/starkware-libs/cairo-lang/issues/100 for details.
+    func __validate_deploy__(
+        cls_hash: felt,
+        salt: felt,
+        calldata_len: felt,
+        calldata: felt*
+    ) {
     }
 
     func __execute__(
-        call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*
-    ) -> (response_len: felt, response: felt*) {
+        call_array_len: felt,
+        call_array: AccountCallArray*,
+        calldata_len: felt,
+        calldata: felt*
+    ) -> (
+        response_len: felt,
+        response: felt*
+    ) {
     }
 }

--- a/src/openzeppelin/account/IAccount.cairo
+++ b/src/openzeppelin/account/IAccount.cairo
@@ -31,16 +31,6 @@ namespace IAccount {
     func __validate_declare__(cls_hash: felt) {
     }
 
-    // Parameter temporarily named `cls_hash` instead of `class_hash` (expected).
-    // See https://github.com/starkware-libs/cairo-lang/issues/100 for details.
-    func __validate_deploy__(
-        cls_hash: felt,
-        salt: felt,
-        calldata_len: felt,
-        calldata: felt*
-    ) {
-    }
-
     func __execute__(
         call_array_len: felt,
         call_array: AccountCallArray*,

--- a/src/openzeppelin/account/IAccount.cairo
+++ b/src/openzeppelin/account/IAccount.cairo
@@ -24,6 +24,9 @@ namespace IAccount {
     func __validate_declare__(cls_hash: felt) {
     }
 
+    func __validate_deploy__(selector: felt, calldata_size: felt, calldata: felt*) {
+    }
+
     func __execute__(
         call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*
     ) -> (response_len: felt, response: felt*) {

--- a/src/openzeppelin/account/presets/Account.cairo
+++ b/src/openzeppelin/account/presets/Account.cairo
@@ -18,11 +18,7 @@ func constructor{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     range_check_ptr
-}(
-    calldata_len: felt,
-    calldata: felt*
-) {
-    let publicKey = [calldata];
+}(publicKey: felt) {
     Account.initializer(publicKey);
     return ();
 }
@@ -121,8 +117,7 @@ func __validate_deploy__{
 } (
     class_hash: felt,
     salt: felt,
-    calldata_len: felt,
-    calldata: felt*
+    publicKey: felt
 ) {
     let (tx_info) = get_tx_info();
     Account.is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);

--- a/src/openzeppelin/account/presets/Account.cairo
+++ b/src/openzeppelin/account/presets/Account.cairo
@@ -18,9 +18,11 @@ func constructor{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     range_check_ptr
-}
-    (publicKey: felt)
-{
+}(
+    calldata_len: felt,
+    calldata: felt*
+) {
+    let publicKey = [calldata];
     Account.initializer(publicKey);
     return ();
 }
@@ -34,9 +36,7 @@ func getPublicKey{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     range_check_ptr
-}
-    () -> (publicKey: felt)
-{
+} () -> (publicKey: felt) {
     let (publicKey: felt) = Account.get_public_key();
     return (publicKey=publicKey);
 }
@@ -46,9 +46,7 @@ func supportsInterface{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     range_check_ptr
-}
-    (interfaceId: felt) -> (success: felt)
-{
+} (interfaceId: felt) -> (success: felt) {
     return Account.supports_interface(interfaceId);
 }
 
@@ -61,9 +59,7 @@ func setPublicKey{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     range_check_ptr
-}
-    (newPublicKey: felt)
-{
+} (newPublicKey: felt) {
     Account.set_public_key(newPublicKey);
     return ();
 }
@@ -82,8 +78,7 @@ func isValidSignature{
     hash: felt,
     signature_len: felt,
     signature: felt*
-) -> (isValid: felt)
-{
+) -> (isValid: felt) {
     let (isValid: felt) = Account.is_valid_signature(hash, signature_len, signature);
     return (isValid=isValid);
 }
@@ -111,9 +106,7 @@ func __validate_declare__{
     pedersen_ptr: HashBuiltin*,
     ecdsa_ptr: SignatureBuiltin*,
     range_check_ptr
-}
-    (class_hash: felt)
-{
+} (class_hash: felt) {
     let (tx_info) = get_tx_info();
     Account.is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);
     return ();
@@ -126,9 +119,10 @@ func __validate_deploy__{
     ecdsa_ptr: SignatureBuiltin*,
     range_check_ptr
 } (
-    classHash: felt,
+    class_hash: felt,
     salt: felt,
-    publicKey: felt
+    calldata_len: felt,
+    calldata: felt*
 ) {
     let (tx_info) = get_tx_info();
     Account.is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);

--- a/src/openzeppelin/account/presets/Account.cairo
+++ b/src/openzeppelin/account/presets/Account.cairo
@@ -119,7 +119,6 @@ func __validate_declare__{
     return ();
 }
 
-@raw_input
 @external
 func __validate_deploy__{
     syscall_ptr: felt*,
@@ -127,9 +126,9 @@ func __validate_deploy__{
     ecdsa_ptr: SignatureBuiltin*,
     range_check_ptr
 } (
-    selector: felt,
-    calldata_size: felt,
-    calldata: felt*
+    classHash: felt,
+    salt: felt,
+    publicKey: felt
 ) {
     let (tx_info) = get_tx_info();
     Account.is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);

--- a/src/openzeppelin/account/presets/Account.cairo
+++ b/src/openzeppelin/account/presets/Account.cairo
@@ -14,9 +14,13 @@ from openzeppelin.account.library import Account, AccountCallArray
 //
 
 @constructor
-func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    publicKey: felt
-) {
+func constructor{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+}
+    (publicKey: felt)
+{
     Account.initializer(publicKey);
     return ();
 }
@@ -26,17 +30,25 @@ func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 //
 
 @view
-func getPublicKey{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
-    publicKey: felt
-) {
+func getPublicKey{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+}
+    () -> (publicKey: felt)
+{
     let (publicKey: felt) = Account.get_public_key();
     return (publicKey=publicKey);
 }
 
 @view
-func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    interfaceId: felt
-) -> (success: felt) {
+func supportsInterface{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+}
+    (interfaceId: felt) -> (success: felt)
+{
     return Account.supports_interface(interfaceId);
 }
 
@@ -45,9 +57,13 @@ func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
 //
 
 @external
-func setPublicKey{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    newPublicKey: felt
-) {
+func setPublicKey{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+}
+    (newPublicKey: felt)
+{
     Account.set_public_key(newPublicKey);
     return ();
 }
@@ -58,16 +74,32 @@ func setPublicKey{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_pt
 
 @view
 func isValidSignature{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ecdsa_ptr: SignatureBuiltin*, range_check_ptr
-}(hash: felt, signature_len: felt, signature: felt*) -> (isValid: felt) {
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    ecdsa_ptr: SignatureBuiltin*,
+    range_check_ptr
+}(
+    hash: felt,
+    signature_len: felt,
+    signature: felt*
+) -> (isValid: felt)
+{
     let (isValid: felt) = Account.is_valid_signature(hash, signature_len, signature);
     return (isValid=isValid);
 }
 
 @external
 func __validate__{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ecdsa_ptr: SignatureBuiltin*, range_check_ptr
-}(call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*) {
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    ecdsa_ptr: SignatureBuiltin*,
+    range_check_ptr
+}(
+    call_array_len: felt,
+    call_array: AccountCallArray*,
+    calldata_len: felt,
+    calldata: felt*
+) {
     let (tx_info) = get_tx_info();
     Account.is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);
     return ();
@@ -75,8 +107,30 @@ func __validate__{
 
 @external
 func __validate_declare__{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ecdsa_ptr: SignatureBuiltin*, range_check_ptr
-}(class_hash: felt) {
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    ecdsa_ptr: SignatureBuiltin*,
+    range_check_ptr
+}
+    (class_hash: felt)
+{
+    let (tx_info) = get_tx_info();
+    Account.is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);
+    return ();
+}
+
+@raw_input
+@external
+func __validate_deploy__{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    ecdsa_ptr: SignatureBuiltin*,
+    range_check_ptr
+} (
+    selector: felt,
+    calldata_size: felt,
+    calldata: felt*
+) {
     let (tx_info) = get_tx_info();
     Account.is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);
     return ();
@@ -89,8 +143,14 @@ func __execute__{
     ecdsa_ptr: SignatureBuiltin*,
     bitwise_ptr: BitwiseBuiltin*,
     range_check_ptr,
-}(call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*) -> (
-    response_len: felt, response: felt*
+}(
+    call_array_len: felt,
+    call_array: AccountCallArray*,
+    calldata_len: felt,
+    calldata: felt*
+) -> (
+    response_len: felt,
+    response: felt*
 ) {
     let (response_len, response) = Account.execute(
         call_array_len, call_array, calldata_len, calldata

--- a/src/openzeppelin/account/presets/EthAccount.cairo
+++ b/src/openzeppelin/account/presets/EthAccount.cairo
@@ -12,9 +12,13 @@ from openzeppelin.account.library import Account, AccountCallArray
 //
 
 @constructor
-func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    eth_address: felt
-) {
+func constructor{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+}
+    (eth_address: felt)
+{
     Account.initializer(eth_address);
     return ();
 }
@@ -24,17 +28,25 @@ func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 //
 
 @view
-func getEthAddress{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
-    ethAddress: felt
-) {
+func getEthAddress{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+}
+    () -> (ethAddress: felt)
+{
     let (ethAddress: felt) = Account.get_public_key();
     return (ethAddress=ethAddress);
 }
 
 @view
-func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    interfaceId: felt
-) -> (success: felt) {
+func supportsInterface{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+}
+    (interfaceId: felt) -> (success: felt)
+{
     return Account.supports_interface(interfaceId);
 }
 
@@ -43,9 +55,13 @@ func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
 //
 
 @external
-func setEthAddress{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    newEthAddress: felt
-) {
+func setEthAddress{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+}
+    (newEthAddress: felt)
+{
     Account.set_public_key(newEthAddress);
     return ();
 }
@@ -60,7 +76,12 @@ func isValidSignature{
     pedersen_ptr: HashBuiltin*,
     bitwise_ptr: BitwiseBuiltin*,
     range_check_ptr,
-}(hash: felt, signature_len: felt, signature: felt*) -> (isValid: felt) {
+}(
+    hash: felt,
+    signature_len: felt,
+    signature: felt*
+) -> (isValid: felt)
+{
     let (isValid) = Account.is_valid_eth_signature(hash, signature_len, signature);
     return (isValid=isValid);
 }
@@ -71,7 +92,12 @@ func __validate__{
     pedersen_ptr: HashBuiltin*,
     bitwise_ptr: BitwiseBuiltin*,
     range_check_ptr,
-}(call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*) {
+}(
+    call_array_len: felt,
+    call_array: AccountCallArray*,
+    calldata_len: felt,
+    calldata: felt*
+) {
     let (tx_info) = get_tx_info();
     Account.is_valid_eth_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);
     return ();
@@ -83,7 +109,27 @@ func __validate_declare__{
     pedersen_ptr: HashBuiltin*,
     bitwise_ptr: BitwiseBuiltin*,
     range_check_ptr,
-}(class_hash: felt) {
+}
+    (class_hash: felt)
+{
+    let (tx_info) = get_tx_info();
+    Account.is_valid_eth_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);
+    return ();
+}
+
+
+@raw_input
+@external
+func __validate_deploy__{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    ecdsa_ptr: SignatureBuiltin*,
+    range_check_ptr
+} (
+    selector: felt,
+    calldata_size: felt,
+    calldata: felt*
+) {
     let (tx_info) = get_tx_info();
     Account.is_valid_eth_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);
     return ();
@@ -96,8 +142,14 @@ func __execute__{
     ecdsa_ptr: SignatureBuiltin*,
     bitwise_ptr: BitwiseBuiltin*,
     range_check_ptr,
-}(call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*) -> (
-    response_len: felt, response: felt*
+}(
+    call_array_len: felt,
+    call_array: AccountCallArray*,
+    calldata_len: felt,
+    calldata: felt*
+) -> (
+    response_len: felt,
+    response: felt*
 ) {
     let (response_len, response) = Account.execute(
         call_array_len, call_array, calldata_len, calldata

--- a/src/openzeppelin/account/presets/EthAccount.cairo
+++ b/src/openzeppelin/account/presets/EthAccount.cairo
@@ -17,9 +17,9 @@ func constructor{
     pedersen_ptr: HashBuiltin*,
     range_check_ptr
 }
-    (eth_address: felt)
+    (ethAddress: felt)
 {
-    Account.initializer(eth_address);
+    Account.initializer(ethAddress);
     return ();
 }
 
@@ -118,7 +118,6 @@ func __validate_declare__{
 }
 
 
-@raw_input
 @external
 func __validate_deploy__{
     syscall_ptr: felt*,
@@ -126,9 +125,9 @@ func __validate_deploy__{
     ecdsa_ptr: SignatureBuiltin*,
     range_check_ptr
 } (
-    selector: felt,
-    calldata_size: felt,
-    calldata: felt*
+    classHash: felt,
+    salt: felt,
+    ethAddress: felt
 ) {
     let (tx_info) = get_tx_info();
     Account.is_valid_eth_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);

--- a/src/openzeppelin/account/presets/EthAccount.cairo
+++ b/src/openzeppelin/account/presets/EthAccount.cairo
@@ -16,11 +16,7 @@ func constructor{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     range_check_ptr
-}(
-    calldata_len: felt,
-    calldata: felt*
-) {
-    let ethAddress = [calldata];
+}(ethAddress: felt) {
     Account.initializer(ethAddress);
     return ();
 }
@@ -120,8 +116,7 @@ func __validate_deploy__{
 } (
     class_hash: felt,
     salt: felt,
-    calldata_len: felt,
-    calldata: felt*
+    ethAddress: felt
 ) {
     let (tx_info) = get_tx_info();
     Account.is_valid_eth_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);

--- a/src/openzeppelin/account/presets/EthAccount.cairo
+++ b/src/openzeppelin/account/presets/EthAccount.cairo
@@ -16,9 +16,11 @@ func constructor{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     range_check_ptr
-}
-    (ethAddress: felt)
-{
+}(
+    calldata_len: felt,
+    calldata: felt*
+) {
+    let ethAddress = [calldata];
     Account.initializer(ethAddress);
     return ();
 }
@@ -32,9 +34,7 @@ func getEthAddress{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     range_check_ptr
-}
-    () -> (ethAddress: felt)
-{
+} () -> (ethAddress: felt) {
     let (ethAddress: felt) = Account.get_public_key();
     return (ethAddress=ethAddress);
 }
@@ -44,9 +44,7 @@ func supportsInterface{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     range_check_ptr
-}
-    (interfaceId: felt) -> (success: felt)
-{
+} (interfaceId: felt) -> (success: felt) {
     return Account.supports_interface(interfaceId);
 }
 
@@ -59,9 +57,7 @@ func setEthAddress{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     range_check_ptr
-}
-    (newEthAddress: felt)
-{
+} (newEthAddress: felt) {
     Account.set_public_key(newEthAddress);
     return ();
 }
@@ -80,8 +76,7 @@ func isValidSignature{
     hash: felt,
     signature_len: felt,
     signature: felt*
-) -> (isValid: felt)
-{
+) -> (isValid: felt) {
     let (isValid) = Account.is_valid_eth_signature(hash, signature_len, signature);
     return (isValid=isValid);
 }
@@ -109,9 +104,7 @@ func __validate_declare__{
     pedersen_ptr: HashBuiltin*,
     bitwise_ptr: BitwiseBuiltin*,
     range_check_ptr,
-}
-    (class_hash: felt)
-{
+} (class_hash: felt) {
     let (tx_info) = get_tx_info();
     Account.is_valid_eth_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);
     return ();
@@ -122,12 +115,13 @@ func __validate_declare__{
 func __validate_deploy__{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
-    ecdsa_ptr: SignatureBuiltin*,
+    bitwise_ptr: BitwiseBuiltin*,
     range_check_ptr
 } (
-    classHash: felt,
+    class_hash: felt,
     salt: felt,
-    ethAddress: felt
+    calldata_len: felt,
+    calldata: felt*
 ) {
     let (tx_info) = get_tx_info();
     Account.is_valid_eth_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -19,7 +19,7 @@ def contract_classes():
 
 @pytest.fixture(scope='module')
 async def account_init(contract_classes):
-    account_cls, init_cls, attacker_cls = contract_classes
+    _, init_cls, attacker_cls = contract_classes
     starknet = await State.init()
     account1 = await Account.deploy(signer.public_key)
     account2 = await Account.deploy(signer.public_key)

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -78,6 +78,22 @@ async def test_constructor(account_factory):
 
 
 @pytest.mark.asyncio
+async def test_is_valid_signature(account_factory):
+    account, *_ = account_factory
+    hash = 0x23564
+    signature = signer.sign(hash)
+
+    execution_info = await account.isValidSignature(hash, signature).call()
+    assert execution_info.result == (TRUE,)
+
+    # should revert if signature is not correct
+    await assert_revert(
+        account.isValidSignature(hash + 1, signature).call(),
+        reverted_with="Invalid signature"
+    )
+
+
+@pytest.mark.asyncio
 async def test_execute(account_factory):
     account, _, initializable, *_ = account_factory
 

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -63,7 +63,7 @@ async def test_counterfactual_deployment(account_factory):
     address = execution_info.validate_info.contract_address
 
     execution_info = await signer.send_transaction(account, address, 'getPublicKey', [])
-    assert execution_info[0].call_info.retdata[1] == signer.public_key
+    assert execution_info.call_info.retdata[1] == signer.public_key
 
 
 @pytest.mark.asyncio
@@ -120,7 +120,7 @@ async def test_return_value(account_factory):
     # initialize, set `initialized = 1`
     await signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])])
 
-    read_info, _, _ = await signer.send_transactions(account, [(initializable.contract_address, 'initialized', [])])
+    read_info = await signer.send_transactions(account, [(initializable.contract_address, 'initialized', [])])
     call_info = await initializable.initialized().call()
     (call_result, ) = call_info.result
     assert read_info.call_info.retdata[1] == call_result  # 1
@@ -134,8 +134,8 @@ async def test_nonce(account_factory):
     await signer.send_transactions(account, [(initializable.contract_address, 'initialized', [])])
 
     # get nonce
-    hex_args = [(initializable.contract_address, 'initialized', [])]
-    raw_invocation = get_raw_invoke(account, hex_args)
+    args = [(initializable.contract_address, 'initialized', [])]
+    raw_invocation = get_raw_invoke(account, args)
     current_nonce = await raw_invocation.state.state.get_nonce_at(account.contract_address)
 
     # lower nonce

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -55,6 +55,20 @@ def account_factory(contract_classes, account_init):
 
 
 @pytest.mark.asyncio
+async def test_tcounterfactual_deployment(account_factory):
+    account, *_ = account_factory
+    await signer.declare_class(account, "Account")
+
+    execution_info = await signer.deploy_account(account.state, [signer.public_key])
+    address = execution_info.validate_info.contract_address
+
+    execution_info = await signer.send_transaction(account, address, 'getPublicKey', [])
+    key = execution_info[0].call_info.retdata[1]
+
+    assert key == signer.public_key
+
+
+@pytest.mark.asyncio
 async def test_constructor(account_factory):
     account, *_ = account_factory
 
@@ -122,7 +136,7 @@ async def test_nonce(account_factory):
     await signer.send_transactions(account, [(initializable.contract_address, 'initialized', [])])
 
     # get nonce
-    hex_args = [(hex(initializable.contract_address), 'initialized', [])]
+    hex_args = [(initializable.contract_address, 'initialized', [])]
     raw_invocation = get_raw_invoke(account, hex_args)
     current_nonce = await raw_invocation.state.state.get_nonce_at(account.contract_address)
 

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -57,7 +57,7 @@ def account_factory(contract_classes, account_init):
 @pytest.mark.asyncio
 async def test_counterfactual_deployment(account_factory):
     account, *_ = account_factory
-    await signer.declare_class(account, "Account")
+    await signer.declare_class(account.state, "Account")
 
     execution_info = await signer.deploy_account(account.state, [signer.public_key])
     address = execution_info.validate_info.contract_address

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -89,7 +89,10 @@ async def test_is_valid_signature(account_factory):
     # should revert if signature is not correct
     await assert_revert(
         account.isValidSignature(hash + 1, signature).call(),
-        reverted_with="Invalid signature"
+        reverted_with=(
+            f"Signature {tuple(signature)}, is invalid, with respect to the public key {signer.public_key}, "
+            f"and the message hash {hash + 1}."
+        )
     )
 
 

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -55,7 +55,7 @@ def account_factory(contract_classes, account_init):
 
 
 @pytest.mark.asyncio
-async def test_tcounterfactual_deployment(account_factory):
+async def test_counterfactual_deployment(account_factory):
     account, *_ = account_factory
     await signer.declare_class(account, "Account")
 

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -57,7 +57,7 @@ def account_factory(contract_classes, account_init):
 @pytest.mark.asyncio
 async def test_counterfactual_deployment(account_factory):
     account, *_ = account_factory
-    await signer.declare_class(account.state, "Account")
+    await signer.declare_class(account, "Account")
 
     execution_info = await signer.deploy_account(account.state, [signer.public_key])
     address = execution_info.validate_info.contract_address
@@ -97,16 +97,36 @@ async def test_is_valid_signature(account_factory):
 
 
 @pytest.mark.asyncio
+async def test_declare(account_factory):
+    account, *_ = account_factory
+
+    # regular declare works
+    await signer.declare_class(account, "ERC20")
+
+    # wrong signer fails
+    await assert_revert(
+        other.declare_class(account, "ERC20"),
+        reverted_with="is invalid, with respect to the public key"
+    )
+
+
+@pytest.mark.asyncio
 async def test_execute(account_factory):
     account, _, initializable, *_ = account_factory
 
     execution_info = await initializable.initialized().call()
     assert execution_info.result == (0,)
 
-    await signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])])
+    await signer.send_transaction(account, initializable.contract_address, 'initialize', [])
 
     execution_info = await initializable.initialized().call()
     assert execution_info.result == (1,)
+
+    # wrong signer fails
+    await assert_revert(
+        other.send_transaction(account, initializable.contract_address, 'initialize', []),
+        reverted_with="is invalid, with respect to the public key"
+    )
 
 
 @pytest.mark.asyncio
@@ -137,9 +157,9 @@ async def test_return_value(account_factory):
     account, _, initializable, *_ = account_factory
 
     # initialize, set `initialized = 1`
-    await signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])])
+    await signer.send_transaction(account, initializable.contract_address, 'initialize', [])
 
-    read_info = await signer.send_transactions(account, [(initializable.contract_address, 'initialized', [])])
+    read_info = await signer.send_transaction(account, initializable.contract_address, 'initialized', [])
     call_info = await initializable.initialized().call()
     (call_result, ) = call_info.result
     assert read_info.call_info.retdata[1] == call_result  # 1
@@ -150,7 +170,7 @@ async def test_nonce(account_factory):
     account, _, initializable, *_ = account_factory
 
     # bump nonce
-    await signer.send_transactions(account, [(initializable.contract_address, 'initialized', [])])
+    await signer.send_transaction(account, initializable.contract_address, 'initialized', [])
 
     # get nonce
     args = [(initializable.contract_address, 'initialized', [])]
@@ -159,8 +179,7 @@ async def test_nonce(account_factory):
 
     # lower nonce
     await assert_revert(
-        signer.send_transactions(
-            account, [(initializable.contract_address, 'initialize', [])], nonce=current_nonce - 1),
+        signer.send_transaction(account, initializable.contract_address, 'initialize', [], nonce=current_nonce - 1),
         reverted_with="Invalid transaction nonce. Expected: {}, got: {}.".format(
             current_nonce, current_nonce - 1
         )
@@ -168,15 +187,14 @@ async def test_nonce(account_factory):
 
     # higher nonce
     await assert_revert(
-        signer.send_transactions(account, [(
-            initializable.contract_address, 'initialize', [])], nonce=current_nonce + 1),
+        signer.send_transaction(account, initializable.contract_address, 'initialize', [], nonce=current_nonce + 1),
         reverted_with="Invalid transaction nonce. Expected: {}, got: {}.".format(
             current_nonce, current_nonce + 1
         )
     )
 
     # right nonce
-    await signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])], nonce=current_nonce)
+    await signer.send_transaction(account, initializable.contract_address, 'initialize', [], nonce=current_nonce)
 
     execution_info = await initializable.initialized().call()
     assert execution_info.result == (1,)
@@ -190,7 +208,7 @@ async def test_public_key_setter(account_factory):
     assert execution_info.result == (signer.public_key,)
 
     # set new pubkey
-    await signer.send_transactions(account, [(account.contract_address, 'setPublicKey', [other.public_key])])
+    await signer.send_transaction(account, account.contract_address, 'setPublicKey', [other.public_key])
 
     execution_info = await account.getPublicKey().call()
     assert execution_info.result == (other.public_key,)
@@ -202,10 +220,7 @@ async def test_public_key_setter_different_account(account_factory):
 
     # set new pubkey
     await assert_revert(
-        signer.send_transactions(
-            bad_account,
-            [(account.contract_address, 'setPublicKey', [other.public_key])]
-        ),
+        signer.send_transaction(bad_account, account.contract_address, 'setPublicKey', [other.public_key]),
         reverted_with="Account: caller is not this account"
     )
 

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -63,9 +63,7 @@ async def test_counterfactual_deployment(account_factory):
     address = execution_info.validate_info.contract_address
 
     execution_info = await signer.send_transaction(account, address, 'getPublicKey', [])
-    key = execution_info[0].call_info.retdata[1]
-
-    assert key == signer.public_key
+    assert execution_info[0].call_info.retdata[1] == signer.public_key
 
 
 @pytest.mark.asyncio

--- a/tests/account/test_Account.py
+++ b/tests/account/test_Account.py
@@ -19,7 +19,7 @@ def contract_classes():
 
 @pytest.fixture(scope='module')
 async def account_init(contract_classes):
-    _, init_cls, attacker_cls = contract_classes
+    account_cls, init_cls, attacker_cls = contract_classes
     starknet = await State.init()
     account1 = await Account.deploy(signer.public_key)
     account2 = await Account.deploy(signer.public_key)
@@ -108,7 +108,7 @@ async def test_return_value(account_factory):
     # initialize, set `initialized = 1`
     await signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])])
 
-    read_info = await signer.send_transactions(account, [(initializable.contract_address, 'initialized', [])])
+    read_info, _, _ = await signer.send_transactions(account, [(initializable.contract_address, 'initialized', [])])
     call_info = await initializable.initialized().call()
     (call_result, ) = call_info.result
     assert read_info.call_info.retdata[1] == call_result  # 1

--- a/tests/account/test_EthAccount.py
+++ b/tests/account/test_EthAccount.py
@@ -24,11 +24,11 @@ async def account_init(contract_defs):
 
     account1 = await starknet.deploy(
         contract_class=account_cls,
-        constructor_calldata=[1, signer.eth_address]
+        constructor_calldata=[signer.eth_address]
     )
     account2 = await starknet.deploy(
         contract_class=account_cls,
-        constructor_calldata=[1, signer.eth_address]
+        constructor_calldata=[signer.eth_address]
     )
     initializable1 = await starknet.deploy(
         contract_class=init_cls,

--- a/tests/account/test_EthAccount.py
+++ b/tests/account/test_EthAccount.py
@@ -61,6 +61,18 @@ def account_factory(contract_defs, account_init):
 
 
 @pytest.mark.asyncio
+async def test_counterfactual_deployment(account_factory):
+    account, *_ = account_factory
+    await signer.declare_class(account, "EthAccount")
+
+    execution_info = await signer.deploy_account(account.state, [signer.eth_address])
+    address = execution_info.validate_info.contract_address
+
+    execution_info = await signer.send_transaction(account, address, 'getEthAddress', [])
+    assert execution_info[0].call_info.retdata[1] == signer.eth_address
+
+
+@pytest.mark.asyncio
 async def test_constructor(account_factory):
     account, *_ = account_factory
 

--- a/tests/account/test_EthAccount.py
+++ b/tests/account/test_EthAccount.py
@@ -84,6 +84,22 @@ async def test_constructor(account_factory):
 
 
 @pytest.mark.asyncio
+async def test_is_valid_signature(account_factory):
+    account, *_ = account_factory
+    hash = 0x23564
+    signature = signer.sign(hash)
+
+    execution_info = await account.isValidSignature(hash, signature).call()
+    assert execution_info.result == (TRUE,)
+
+    # should revert if signature is not correct
+    await assert_revert(
+        account.isValidSignature(hash + 1, signature).call(),
+        reverted_with="Invalid signature"
+    )
+
+
+@pytest.mark.asyncio
 async def test_execute(account_factory):
     account, _, initializable, *_ = account_factory
 
@@ -94,15 +110,6 @@ async def test_execute(account_factory):
 
     execution_info = await initializable.initialized().call()
     assert execution_info.result == (TRUE,)
-
-    # should revert if signature is not correct
-    hash = 0x23564
-    signature = signer.sign(hash)
-    await assert_revert(
-        signer.send_transactions(account, [(account.contract_address, 'isValidSignature', [
-                                 hash + 1, len(signature), *signature])]),
-        reverted_with="Invalid signature"
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/account/test_EthAccount.py
+++ b/tests/account/test_EthAccount.py
@@ -24,11 +24,11 @@ async def account_init(contract_defs):
 
     account1 = await starknet.deploy(
         contract_class=account_cls,
-        constructor_calldata=[signer.eth_address]
+        constructor_calldata=[1, signer.eth_address]
     )
     account2 = await starknet.deploy(
         contract_class=account_cls,
-        constructor_calldata=[signer.eth_address]
+        constructor_calldata=[1, signer.eth_address]
     )
     initializable1 = await starknet.deploy(
         contract_class=init_cls,

--- a/tests/account/test_EthAccount.py
+++ b/tests/account/test_EthAccount.py
@@ -63,7 +63,7 @@ def account_factory(contract_defs, account_init):
 @pytest.mark.asyncio
 async def test_counterfactual_deployment(account_factory):
     account, *_ = account_factory
-    await signer.declare_class(account, "EthAccount")
+    await signer.declare_class(account.state, "EthAccount")
 
     execution_info = await signer.deploy_account(account.state, [signer.eth_address])
     address = execution_info.validate_info.contract_address

--- a/tests/signers.py
+++ b/tests/signers.py
@@ -1,12 +1,105 @@
+from lib2to3.pytree import Base
 from starkware.starknet.core.os.transaction_hash.transaction_hash import TransactionHashPrefix
-from starkware.starknet.services.api.gateway.transaction import InvokeFunction
+from starkware.starknet.services.api.gateway.transaction import InvokeFunction, Declare
 from starkware.starknet.business_logic.transaction.objects import InternalTransaction, TransactionExecutionInfo
 from nile.signer import Signer, from_call_to_call_array, get_transaction_hash, TRANSACTION_VERSION
-from nile.utils import to_uint
+from nile.utils import to_uint, get_contract_class, get_hash
 import eth_keys
 
 
-class MockSigner():
+class BaseSigner():
+    async def send_transaction(self, account, to, selector_name, calldata, nonce=None, max_fee=0):
+        return await self.send_transactions(account, [(to, selector_name, calldata)], nonce, max_fee)
+
+    async def send_transactions(
+        self,
+        account,
+        calls,
+        nonce=None,
+        max_fee=0
+    ) -> TransactionExecutionInfo:
+        # hexify address before passing to from_call_to_call_array
+        build_calls = []
+        for call in calls:
+            build_call = list(call)
+            build_call[0] = hex(build_call[0])
+            build_calls.append(build_call)
+
+        raw_invocation = get_raw_invoke(account, build_calls)
+        state = raw_invocation.state
+
+        if nonce is None:
+            nonce = await state.state.get_nonce_at(account.contract_address)
+
+        transaction_hash = get_transaction_hash(
+            prefix=TransactionHashPrefix.INVOKE,
+            account=account.contract_address,
+            calldata=raw_invocation.calldata,
+            nonce=nonce,
+            max_fee=max_fee
+        )
+
+        signature = self.get_signature(transaction_hash)
+
+        external_tx = InvokeFunction(
+            contract_address=account.contract_address,
+            calldata=raw_invocation.calldata,
+            entry_point_selector=None,
+            signature=signature,
+            max_fee=max_fee,
+            version=TRANSACTION_VERSION,
+            nonce=nonce,
+        )
+
+        tx = InternalTransaction.from_external(
+            external_tx=external_tx, general_config=state.general_config
+        )
+        execution_info = await state.execute_tx(tx=tx)
+        # the hash and signature are returned for other tests to use
+        return execution_info, transaction_hash, signature
+
+    async def declare_class(
+        self,
+        account,
+        contract_name,
+        nonce=None,
+        max_fee=0,
+    ) -> TransactionExecutionInfo:
+        state = self.account.state
+
+        if nonce is None:
+            nonce = await state.state.get_nonce_at(contract_address=self.account.contract_address)
+
+        contract_class = get_contract_class(contract_name)
+        class_hash = get_hash(contract_name)
+
+        transaction_hash = get_transaction_hash(
+            prefix=TransactionHashPrefix.DECLARE,
+            account=account.contract_address,
+            calldata=[class_hash],
+            nonce=nonce,
+            max_fee=max_fee
+        )
+
+        signature = self.get_signature(transaction_hash)
+
+        external_tx = Declare(
+            sender_address=self.account.contract_address,
+            contract_class=contract_class,
+            signature=signature,
+            max_fee=max_fee,
+            version=TRANSACTION_VERSION,
+            nonce=nonce,
+        )
+
+        tx = InternalTransaction.from_external(
+            external_tx=external_tx, general_config=state.general_config
+        )
+
+        execution_info = await state.execute_tx(tx=tx)
+        return execution_info
+
+class MockSigner(BaseSigner):
     """
     Utility for sending signed transactions to an Account on Starknet.
 
@@ -37,55 +130,16 @@ class MockSigner():
         )
 
     """
-
     def __init__(self, private_key):
         self.signer = Signer(private_key)
         self.public_key = self.signer.public_key
 
-    async def send_transaction(self, account, to, selector_name, calldata, nonce=None, max_fee=0):
-        return await self.send_transactions(account, [(to, selector_name, calldata)], nonce, max_fee)
-
-    async def send_transactions(
-        self,
-        account,
-        calls,
-        nonce=None,
-        max_fee=0
-    ) -> TransactionExecutionInfo:
-        # hexify address before passing to from_call_to_call_array
-        build_calls = []
-        for call in calls:
-            build_call = list(call)
-            build_call[0] = hex(build_call[0])
-            build_calls.append(build_call)
-
-        raw_invocation = get_raw_invoke(account, build_calls)
-        state = raw_invocation.state
-
-        if nonce is None:
-            nonce = await state.state.get_nonce_at(account.contract_address)
-
-        _, sig_r, sig_s = self.signer.sign_transaction(account.contract_address, build_calls, nonce, max_fee)
-
-        # craft invoke and execute tx
-        external_tx = InvokeFunction(
-            contract_address=account.contract_address,
-            calldata=raw_invocation.calldata,
-            entry_point_selector=None,
-            signature=[sig_r, sig_s],
-            max_fee=max_fee,
-            version=TRANSACTION_VERSION,
-            nonce=nonce,
-        )
-
-        tx = InternalTransaction.from_external(
-            external_tx=external_tx, general_config=state.general_config
-        )
-        execution_info = await state.execute_tx(tx=tx)
-        return execution_info
+    def get_signature(self, transaction_hash):
+        sig_r, sig_s = self.signer.sign(transaction_hash)
+        return [sig_r, sig_s]
 
 
-class MockEthSigner():
+class MockEthSigner(BaseSigner):
     """
     Utility for sending signed transactions to an Account on Starknet, like MockSigner, but using a secp256k1 signature.
     Parameters
@@ -93,57 +147,16 @@ class MockEthSigner():
     private_key : int
 
     """
-
     def __init__(self, private_key):
         self.signer = eth_keys.keys.PrivateKey(private_key)
         self.eth_address = int(self.signer.public_key.to_checksum_address(), 0)
 
-    async def send_transaction(self, account, to, selector_name, calldata, nonce=None, max_fee=0):
-        return await self.send_transactions(account, [(to, selector_name, calldata)], nonce, max_fee)
-
-    async def send_transactions(self, account, calls, nonce=None, max_fee=0):
-        build_calls = []
-        for call in calls:
-            build_call = list(call)
-            build_call[0] = hex(build_call[0])
-            build_calls.append(build_call)
-
-        raw_invocation = get_raw_invoke(account, build_calls)
-        state = raw_invocation.state
-
-        if nonce is None:
-            nonce = await state.state.get_nonce_at(account.contract_address)
-
-        transaction_hash = get_transaction_hash(
-            prefix=TransactionHashPrefix.INVOKE,
-            account=account.contract_address,
-            calldata=raw_invocation.calldata,
-            nonce=nonce,
-            max_fee=max_fee
-        )
-
+    def get_signature(self, transaction_hash):
         signature = self.signer.sign_msg_hash(
             (transaction_hash).to_bytes(32, byteorder="big"))
         sig_r = to_uint(signature.r)
         sig_s = to_uint(signature.s)
-
-        external_tx = InvokeFunction(
-            contract_address=account.contract_address,
-            calldata=raw_invocation.calldata,
-            entry_point_selector=None,
-            signature=[signature.v, *sig_r, *sig_s],
-            max_fee=max_fee,
-            version=TRANSACTION_VERSION,
-            nonce=nonce,
-        )
-
-        tx = InternalTransaction.from_external(
-            external_tx=external_tx, general_config=state.general_config
-        )
-
-        execution_info = await state.execute_tx(tx=tx)
-        # the hash and signature are returned for other tests to use
-        return execution_info, transaction_hash, [signature.v, *sig_r, *sig_s]
+        return [signature.v, *sig_r, *sig_s]
 
 
 def get_raw_invoke(sender, calls):

--- a/tests/signers.py
+++ b/tests/signers.py
@@ -3,7 +3,7 @@ from starkware.starknet.core.os.transaction_hash.transaction_hash import Transac
 from starkware.starknet.services.api.gateway.transaction import InvokeFunction, Declare, DeployAccount
 from starkware.starknet.business_logic.transaction.objects import InternalTransaction, TransactionExecutionInfo
 from nile.signer import Signer, from_call_to_call_array, get_transaction_hash, TRANSACTION_VERSION
-from nile.utils import to_uint, get_contract_class, get_hash
+from nile.common import to_uint, get_contract_class, get_hash
 import eth_keys
 
 

--- a/tests/signers.py
+++ b/tests/signers.py
@@ -54,12 +54,11 @@ class BaseSigner():
             external_tx=external_tx, general_config=state.general_config
         )
         execution_info = await state.execute_tx(tx=tx)
-        # the hash and signature are returned for other tests to use
         return execution_info
 
     async def declare_class(self, account, contract_name) -> TransactionExecutionInfo:
         contract_class = get_contract_class(contract_name)
-        execution_info = account.state.declare(contract_class)
+        execution_info = await account.state.declare(contract_class)
         return execution_info
 
     async def deploy_account(

--- a/tests/signers.py
+++ b/tests/signers.py
@@ -56,9 +56,9 @@ class BaseSigner():
         execution_info = await state.execute_tx(tx=tx)
         return execution_info
 
-    async def declare_class(self, account, contract_name) -> TransactionExecutionInfo:
+    async def declare_class(self, state, contract_name) -> TransactionExecutionInfo:
         contract_class = get_contract_class(contract_name)
-        execution_info = await account.state.declare(contract_class)
+        execution_info = await state.declare(contract_class)
         return execution_info
 
     async def deploy_account(

--- a/tests/signers.py
+++ b/tests/signers.py
@@ -3,7 +3,8 @@ from starkware.starknet.core.os.transaction_hash.transaction_hash import Transac
 from starkware.starknet.services.api.gateway.transaction import InvokeFunction, Declare, DeployAccount
 from starkware.starknet.business_logic.transaction.objects import InternalTransaction, TransactionExecutionInfo
 from nile.signer import Signer, from_call_to_call_array, get_transaction_hash, TRANSACTION_VERSION
-from nile.common import to_uint, get_contract_class, get_hash
+from nile.common import get_contract_class, get_hash
+from nile.utils import to_uint
 import eth_keys
 
 

--- a/tests/signers.py
+++ b/tests/signers.py
@@ -4,7 +4,7 @@ from starkware.starknet.core.os.contract_address.contract_address import (
 )
 from starkware.starknet.definitions.general_config import StarknetChainId
 from starkware.starknet.services.api.gateway.transaction import InvokeFunction, DeployAccount
-from starkware.starknet.business_logic.transaction.objects import InternalTransaction, InternalDeclare, TransactionExecutionInfo
+from starkware.starknet.business_logic.transaction.objects import InternalTransaction, TransactionExecutionInfo
 from nile.signer import Signer, from_call_to_call_array, get_transaction_hash, TRANSACTION_VERSION
 from nile.common import get_contract_class, get_class_hash
 from nile.utils import to_uint

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -129,6 +129,6 @@ class Account:
     async def deploy(public_key):
         account = await starknet.deploy(
             contract_class=Account.get_class,
-            constructor_calldata=[1, public_key]
+            constructor_calldata=[public_key]
         )
         return account

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -129,6 +129,6 @@ class Account:
     async def deploy(public_key):
         account = await starknet.deploy(
             contract_class=Account.get_class,
-            constructor_calldata=[public_key]
+            constructor_calldata=[1, public_key]
         )
         return account

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ setenv =
     CAIRO_PATH = src
 deps =
     {[testenv]deps}
-    nile-coverage==0.2.2
+    nile-coverage==0.2.4
 commands =
     nile coverage -s -c src {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,8 @@ passenv =
     HOME
     PYTHONPATH
 deps =
-    cairo-lang==0.10.0
-    cairo-nile==0.9.0
+    cairo-lang==0.10.1
+    cairo-nile==0.10.0
     pytest-xdist
     # See https://github.com/starkware-libs/cairo-lang/issues/52
     marshmallow-dataclass==8.5.3

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
     {[testenv]deps}
     nile-coverage==0.2.4
 commands =
-    nile coverage -s -c src {posargs}
+    nile coverage -c src {posargs}
 
 [testenv:build]
 description = Build the package in isolation according to PEP517, see https://github.com/pypa/build

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ isolated_build = True
 [pytest]
 filterwarnings =
     ignore::DeprecationWarning
-addopts= -n 1
+addopts= -n auto
 asyncio_mode = auto
 markers =
     only: marks a subset of tests to run (development purpose)

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ isolated_build = True
 [pytest]
 filterwarnings =
     ignore::DeprecationWarning
-addopts= -n auto
+addopts= -n 1
 asyncio_mode = auto
 markers =
     only: marks a subset of tests to run (development purpose)
@@ -27,6 +27,7 @@ deps =
 extras =
     testing
 commands =
+    nile compile --directory src/
     pytest {posargs}
 
 [testenv:coverage]
@@ -39,6 +40,7 @@ deps =
     {[testenv]deps}
     nile-coverage==0.2.4
 commands =
+    nile compile --directory src/
     nile coverage -c src {posargs}
 
 [testenv:build]


### PR DESCRIPTION
This PR:
- depends on: https://github.com/OpenZeppelin/nile/issues/267
- fixes #497, #508
- proposes a new format for function signature styling, with the goal of streamlining code editing as well as legibility
- abstracts common signer logic into a `BaseSigner` class
- leaves `__validate_deploy__` out of the `IAccount` interface since it's not callable once deployed
- adds docs for counterfactual deployments