### PR TITLE
ownableTwoSteps library

### DIFF
--- a/src/openzeppelin/access/ownableTwoSteps/README.md
+++ b/src/openzeppelin/access/ownableTwoSteps/README.md
@@ -1,0 +1,120 @@
+# OwnableTwoSteps
+
+This library allows contract ownership to be transferred via a two step method:
+
+1. The owner of a contract proposes a new owner
+2. The proposed owner can accept the request or cancel it. Until this is accepted, they do not have control of the privileged functionality of the contract.
+
+Both the current owner and the proposed owner can cancel the proposal, whereas only the proposed owner can accept it.
+
+## Benefits
+
+A two step transfer can prevent mistakes where the owner of a contract transfers ownership to the wrong address, as this is an irreparable mistake. This is particulary useful in protocols that hold large amount of funds, as losing access to the privileged functionality could result into loss of funds.
+Please note that the ownership of the contract can still be resigned by calling `renounce_ownership`.
+
+## How to use it
+
+Please look into the `tests/mocks/OwnableTwoSteps.cairo` mock contract to see a sample implementation.
+
+### Propose a new owner
+
+The contract owner should be calling the `transfer_ownership` function:
+
+```javascript
+func transfer_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(pending_owner: felt) {
+    with_attr error_message("OwnableTwoSteps: pending owner cannot be the zero address") {
+        assert_not_zero(pending_owner);
+    }
+
+    with_attr error_message("OwnableTwoSteps: a proposal is already in motion") {
+        let (current_pending_owner) = OwnableTwoSteps.pending_owner();
+        assert current_pending_owner = 0;
+    }
+
+    assert_only_owner();
+    _propose_owner(pending_owner);
+    return ();
+}
+```
+
+This function accepts one parameter, which is the pending owner. This cannot be the zero address, and the function can only be called by the contract owner. Furthermore, if a proposal is already in motion, this should first be cancelled by the owner or the pending owner.
+
+It will emit an event with `currentOwner` and `pendingOwner`.
+
+### Accept the ownership transfer
+
+Should the proposed owner decide to accept ownership of the contract, the can call the `accept_ownership` function:
+
+```javascript
+func accept_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {       
+    // Caller cannot be the address zero to avoid overwriting the owner when the pending_owner is not set
+    with_attr error_message("OwnableTwoSteps: caller is the zero address") {
+        let (caller) = get_caller_address();
+        assert_not_zero(caller);
+    }
+
+    let (pending_owner) = OwnableTwoSteps.pending_owner();
+
+    // Confirm that a proposal is in motion 
+    with_attr error_message("OwnableTwoSteps: a proposal is not in motion") {
+        assert_not_zero(pending_owner);
+    }
+
+    // Caller must be the proposed owner
+    with_attr error_message("OwnableTwoSteps: caller is not the pending owner") {
+        assert caller = pending_owner;
+    }
+
+    _transfer_ownership(pending_owner);
+    return ();
+}
+```
+
+This function can only be called by either the current owner or the proposed owner. Events will be emitted the same way as the traditional ownable library (`previousOwner` and `newOwner` will be the arguments).
+Note that the pending owner storage variable will be reset.
+
+### Cancel a transfer proposal
+
+Both the current owner and the proposed owner can cancel the proposal by calling the `cancel_ownership_proposal` function:
+
+```javascript
+func cancel_proposal{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    alloc_locals;
+
+    let (pending_owner) = OwnableTwoSteps.pending_owner();
+
+    // Confirm that a proposal is in motion 
+    with_attr error_message("OwnableTwoSteps: a proposal is not in motion") {
+        assert_not_zero(pending_owner);
+    }
+
+    let (current_owner) = OwnableTwoSteps.owner();
+    let (caller) = get_caller_address();
+
+    with_attr error_message("OwnableTwoSteps: caller is neither the current owner nor the pending owner") {
+        if (caller != pending_owner) {
+            assert caller = current_owner;
+        }
+    }
+
+    _reset_pending_owner();
+
+    // Emit cancellation event
+    OwnershipProposalCancelled.emit(caller, pending_owner);
+    return ();
+}
+```
+
+This will emit an event with the caller address and the `proposedOwner`.
+
+### Renounce ownership
+
+This library allows the owner to renounce ownership of the contract, by calling the `renounce_ownership` function. This works as the standard `ownable` version, however it also resets the pending owner.
+
+```javascript
+func renounce_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    assert_only_owner();
+    _transfer_ownership(0);
+    return ();
+}
+```

--- a/src/openzeppelin/access/ownableTwoSteps/library.cairo
+++ b/src/openzeppelin/access/ownableTwoSteps/library.cairo
@@ -55,12 +55,15 @@ namespace OwnableTwoSteps {
     func assert_only_owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
         let (owner) = OwnableTwoSteps.owner();
         let (caller) = get_caller_address();
+
         with_attr error_message("OwnableTwoSteps: caller is the zero address") {
             assert_not_zero(caller);
         }
+
         with_attr error_message("OwnableTwoSteps: caller is not the owner") {
             assert owner = caller;
         }
+
         return ();
     }
 
@@ -88,17 +91,18 @@ namespace OwnableTwoSteps {
 
         assert_only_owner();
         _propose_owner(pending_owner);
+
         return ();
     }
 
-    func accept_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
-        let (pending_owner) = OwnableTwoSteps.pending_owner();
-        let (caller) = get_caller_address();
-        
+    func accept_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {       
         // Caller cannot be the address zero to avoid overwriting the owner when the pending_owner is not set
         with_attr error_message("OwnableTwoSteps: caller is the zero address") {
+            let (caller) = get_caller_address();
             assert_not_zero(caller);
         }
+
+        let (pending_owner) = OwnableTwoSteps.pending_owner();
 
         // Confirm that a proposal is in motion 
         with_attr error_message("OwnableTwoSteps: a proposal is not in motion") {
@@ -111,6 +115,7 @@ namespace OwnableTwoSteps {
         }
 
         _transfer_ownership(pending_owner);
+
         return ();
     }
 
@@ -137,12 +142,14 @@ namespace OwnableTwoSteps {
 
         // Emit cancellation event
         OwnershipProposalCancelled.emit(caller, pending_owner);
+
         return ();
     }
 
     func renounce_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
         assert_only_owner();
         _transfer_ownership(0);
+
         return ();
     }
 
@@ -155,16 +162,21 @@ namespace OwnableTwoSteps {
 
         let (previous_owner: felt) = OwnableTwoSteps.owner();
         OwnableTwoSteps_owner.write(new_owner);
+
         // Reset pending owner
         _reset_pending_owner();
+
         OwnershipTransferred.emit(previous_owner, new_owner);
+
         return ();
     }
 
     func _propose_owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(pending_owner) {
         let (current_owner) = OwnableTwoSteps.owner();
         OwnableTwoSteps_pending_owner.write(pending_owner);
+
         OwnershipProposed.emit(current_owner, pending_owner);
+
         return ();
     }
 

--- a/src/openzeppelin/access/ownableTwoSteps/library.cairo
+++ b/src/openzeppelin/access/ownableTwoSteps/library.cairo
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.5.0 (access/ownableTwoSteps/library.cairo)
+
+%lang starknet 
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.math import assert_not_zero
+
+
+//
+// Events
+//
+
+@event
+func OwnershipTransferred(previousOwner: felt, newOwner: felt) {
+}
+
+@event 
+func OwnershipProposed(currentOwner: felt, newOwner: felt) {
+}
+
+@event 
+func OwnershipProposalCancelled(caller: felt, pending_owner: felt) {
+}
+
+//
+// Storage
+//
+
+@storage_var
+func OwnableTwoSteps_owner() -> (owner: felt) {
+}
+
+@storage_var
+func OwnableTwoSteps_pending_owner() -> (pending_owner: felt) {
+}
+
+
+namespace OwnableTwoSteps {
+
+    //
+    // Initializer
+    //
+
+    func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(owner: felt) {
+        _transfer_ownership(owner);
+        return ();
+    }
+
+    //
+    // Guards
+    //
+
+    func assert_only_owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let (owner) = OwnableTwoSteps.owner();
+        let (caller) = get_caller_address();
+        with_attr error_message("OwnableTwoSteps: caller is the zero address") {
+            assert_not_zero(caller);
+        }
+        with_attr error_message("OwnableTwoSteps: caller is not the owner") {
+            assert owner = caller;
+        }
+        return ();
+    }
+
+    //
+    // Public
+    //
+
+    func owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (owner: felt) {
+        return OwnableTwoSteps_owner.read();
+    }
+
+    func pending_owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (pending_owner: felt) {
+        return OwnableTwoSteps_pending_owner.read();
+    }
+
+    func transfer_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(pending_owner: felt) {
+        with_attr error_message("OwnableTwoSteps: pending owner cannot be the zero address") {
+            assert_not_zero(pending_owner);
+        }
+
+        with_attr error_message("OwnableTwoSteps: a proposal is already in motion") {
+            let (current_pending_owner) = OwnableTwoSteps.pending_owner();
+            assert current_pending_owner = 0;
+        }
+
+        assert_only_owner();
+        _propose_owner(pending_owner);
+        return ();
+    }
+
+    func accept_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let (pending_owner) = OwnableTwoSteps.pending_owner();
+        let (caller) = get_caller_address();
+        
+        // Caller cannot be the address zero to avoid overwriting the owner when the pending_owner is not set
+        with_attr error_message("OwnableTwoSteps: caller is the zero address") {
+            assert_not_zero(caller);
+        }
+
+        // Confirm that a proposal is in motion 
+        with_attr error_message("OwnableTwoSteps: a proposal is not in motion") {
+            assert_not_zero(pending_owner);
+        }
+
+        // Caller must be the proposed owner
+        with_attr error_message("OwnableTwoSteps: caller is not the pending owner") {
+            assert caller = pending_owner;
+        }
+
+        _transfer_ownership(pending_owner);
+        return ();
+    }
+
+    func cancel_proposal{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        alloc_locals;
+
+        let (pending_owner) = OwnableTwoSteps.pending_owner();
+
+        // Confirm that a proposal is in motion 
+        with_attr error_message("OwnableTwoSteps: a proposal is not in motion") {
+            assert_not_zero(pending_owner);
+        }
+
+        let (current_owner) = OwnableTwoSteps.owner();
+        let (caller) = get_caller_address();
+
+        with_attr error_message("OwnableTwoSteps: caller is neither the current owner nor the pending owner") {
+            if (caller != pending_owner) {
+                assert caller = current_owner;
+            }
+        }
+
+        _reset_pending_owner();
+
+        // Emit cancellation event
+        OwnershipProposalCancelled.emit(caller, pending_owner);
+        return ();
+    }
+
+    func renounce_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        assert_only_owner();
+        _transfer_ownership(0);
+        return ();
+    }
+
+    //
+    // Internal
+    //
+
+    func _transfer_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(new_owner: felt) {
+        alloc_locals;
+
+        let (previous_owner: felt) = OwnableTwoSteps.owner();
+        OwnableTwoSteps_owner.write(new_owner);
+        // Reset pending owner
+        _reset_pending_owner();
+        OwnershipTransferred.emit(previous_owner, new_owner);
+        return ();
+    }
+
+    func _propose_owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(pending_owner) {
+        let (current_owner) = OwnableTwoSteps.owner();
+        OwnableTwoSteps_pending_owner.write(pending_owner);
+        OwnershipProposed.emit(current_owner, pending_owner);
+        return ();
+    }
+
+    func _reset_pending_owner{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() {
+        OwnableTwoSteps_pending_owner.write(0);
+        return ();
+    }
+}

--- a/tests/access/test_OwnableTwoSteps.py
+++ b/tests/access/test_OwnableTwoSteps.py
@@ -1,0 +1,384 @@
+from copyreg import constructor
+import pytest
+from signers import MockSigner
+from nile.utils import ZERO_ADDRESS, assert_revert
+from utils import assert_event_emitted, State, Account, get_contract_class, cached_contract
+
+
+signer = MockSigner(123456789987654321)
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    return (
+        Account.get_class,
+        get_contract_class('OwnableTwoSteps')
+    )
+
+
+@pytest.fixture(scope='module')
+async def ownable_two_steps_init(contract_classes):
+    account_cls, ownable_two_steps_cls = contract_classes
+    starknet = await State.init()
+    owner = await Account.deploy(signer.public_key)
+    ownable_two_steps = await starknet.deploy(
+        contract_class=ownable_two_steps_cls,
+        constructor_calldata=[owner.contract_address]
+    )
+    pending_owner = await Account.deploy(signer.public_key)
+    third_account = await Account.deploy(signer.public_key)
+    return starknet.state, ownable_two_steps, owner, pending_owner, third_account 
+
+
+@pytest.fixture 
+def contract_factory(contract_classes, ownable_two_steps_init):
+    account_cls, ownable_two_steps_cls = contract_classes
+    state, ownable_two_steps, owner, pending_owner, third_account = ownable_two_steps_init 
+    _state = state.copy()
+    owner = cached_contract(_state, account_cls, owner)
+    ownable_two_steps = cached_contract(_state, ownable_two_steps_cls, ownable_two_steps)
+    pending_owner = cached_contract(_state, account_cls, pending_owner)
+    third_account = cached_contract(_state, account_cls, third_account)
+    return ownable_two_steps, owner, pending_owner, third_account
+
+
+# fixture to avoid repeating proposing a new owner
+@pytest.fixture 
+async def after_proposed(contract_factory):
+    ownable_two_steps, owner, pending_owner, third_account = contract_factory
+    await signer.send_transaction(
+        owner,
+        ownable_two_steps.contract_address,
+        'transferOwnership',
+        [pending_owner.contract_address]
+    )
+
+    return ownable_two_steps, owner, pending_owner, third_account
+
+
+@pytest.mark.asyncio 
+async def test_constructor(contract_factory):
+    ownable_two_steps, owner, _, _ = contract_factory
+    expected = await ownable_two_steps.owner().call()
+    assert expected.result.owner == owner.contract_address
+
+
+@pytest.mark.asyncio 
+async def test_transfer_ownership(contract_factory):
+    ownable_two_steps, owner, pending_owner, _ = contract_factory
+
+    await signer.send_transaction(owner, ownable_two_steps.contract_address, 'transferOwnership', [pending_owner.contract_address])
+    executed_info = await ownable_two_steps.pendingOwner().call()
+    assert executed_info.result == (pending_owner.contract_address, )
+
+
+@pytest.mark.asyncio 
+async def test_transfer_ownership_from_zero_address(contract_factory):
+    ownable_two_steps, _, pending_owner, _ = contract_factory
+
+    await assert_revert(
+        ownable_two_steps.transferOwnership(pending_owner.contract_address).execute(),
+        reverted_with="OwnableTwoSteps: caller is the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transfer_ownership_to_zero_address(contract_factory):
+    ownable_two_steps, owner, _, _ = contract_factory
+
+    await assert_revert(
+        signer.send_transaction(
+            owner,
+            ownable_two_steps.contract_address,
+            'transferOwnership',
+            [ZERO_ADDRESS]
+        ),
+        reverted_with="OwnableTwoSteps: pending owner cannot be the zero address"
+    )
+
+
+@pytest.mark.asyncio 
+async def test_transfer_ownership_from_not_owner(contract_factory):
+    ownable_two_steps, _, pending_owner, third_account = contract_factory 
+
+    await assert_revert(
+        signer.send_transaction(
+            third_account,
+            ownable_two_steps.contract_address,
+            'transferOwnership',
+            [pending_owner.contract_address]
+        ),
+        reverted_with="OwnableTwoSteps: caller is not the owner"
+    )
+
+
+@pytest.mark.asyncio 
+async def test_transfer_ownership_when_already_proposed(after_proposed):
+    ownable_two_steps, owner, pending_owner, _ = after_proposed
+
+    await assert_revert(
+        signer.send_transaction(
+            owner, 
+            ownable_two_steps.contract_address,
+            'transferOwnership',
+            [pending_owner.contract_address]
+        ),
+        reverted_with="OwnableTwoSteps: a proposal is already in motion"
+    )
+
+
+@pytest.mark.asyncio 
+async def test_transfer_ownership_emits_event(contract_factory):
+    ownable_two_steps, owner, pending_owner, _ = contract_factory
+
+    tx_execution_info = await signer.send_transaction(
+        owner,
+        ownable_two_steps.contract_address,
+        'transferOwnership',
+        [pending_owner.contract_address]
+    )
+
+    assert_event_emitted(
+        tx_exec_info=tx_execution_info,
+        from_address=ownable_two_steps.contract_address,
+        name='OwnershipProposed',
+        data=[
+            owner.contract_address,
+            pending_owner.contract_address
+        ]
+    )
+
+
+@pytest.mark.asyncio 
+async def test_cancel_transfer_proposal_from_owner(after_proposed):
+    ownable_two_steps, owner, pending_owner, _ = after_proposed
+
+    await signer.send_transaction(
+        owner,
+        ownable_two_steps.contract_address,
+        'cancelOwnershipProposal',
+        []
+    )
+
+    executed_info = await ownable_two_steps.pendingOwner().call()
+    assert executed_info.result == (ZERO_ADDRESS, )
+
+
+@pytest.mark.asyncio
+async def test_cancel_transfer_proposal_from_pending_owner(after_proposed):
+    ownable_two_steps, _, pending_owner, _ = after_proposed
+
+    await signer.send_transaction(
+        pending_owner,
+        ownable_two_steps.contract_address,
+        'cancelOwnershipProposal',
+        []
+    )
+
+    executed_info = await ownable_two_steps.pendingOwner().call()
+    assert executed_info.result == (ZERO_ADDRESS, )
+
+
+@pytest.mark.asyncio 
+async def test_cancel_transfer_proposal_from_zero_address(after_proposed):
+    ownable_two_steps, _, _, _ = after_proposed
+
+    await assert_revert(
+        ownable_two_steps.cancelOwnershipProposal().execute(),
+        reverted_with="OwnableTwoSteps: caller is neither the current owner nor the pending owner"
+    )
+
+
+@pytest.mark.asyncio 
+async def test_cancel_transfer_proposal_from_another_account(after_proposed):
+    ownable_two_steps, _, _, third_account = after_proposed
+
+    await assert_revert(
+        signer.send_transaction(
+            third_account,
+            ownable_two_steps.contract_address,
+            'cancelOwnershipProposal',
+            []
+        ),
+        reverted_with="OwnableTwoSteps: caller is neither the current owner nor the pending owner"
+    )
+
+
+@pytest.mark.asyncio 
+async def test_cancel_transfer_proposal_when_not_in_motion(contract_factory):
+    ownable_two_steps, owner, _, _ = contract_factory
+
+    await assert_revert(
+        signer.send_transaction(
+            owner,
+            ownable_two_steps.contract_address,
+            'cancelOwnershipProposal',
+            []
+        ),
+        reverted_with="OwnableTwoSteps: a proposal is not in motion"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_proposal_emits_event(after_proposed):
+    ownable_two_steps, owner, pending_owner, _ = after_proposed
+
+    tx_execution_info = await signer.send_transaction(
+        owner,
+        ownable_two_steps.contract_address,
+        'cancelOwnershipProposal',
+        []
+    )
+
+    assert_event_emitted(
+        tx_exec_info=tx_execution_info,
+        from_address=ownable_two_steps.contract_address,
+        name='OwnershipProposalCancelled',
+        data=[
+            owner.contract_address,
+            pending_owner.contract_address
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_accept_ownership(after_proposed):
+    ownable_two_steps, _, pending_owner, _ = after_proposed
+
+    await signer.send_transaction(
+        pending_owner,
+        ownable_two_steps.contract_address,
+        'acceptOwnership',
+        []
+    )
+    executed_info = await ownable_two_steps.pendingOwner().call()
+    assert executed_info.result == (ZERO_ADDRESS, )
+    executed_info = await ownable_two_steps.owner().call()
+    assert executed_info.result == (pending_owner.contract_address, )
+
+
+@pytest.mark.asyncio
+async def test_accept_ownership_from_zero_address(after_proposed):
+    ownable_two_steps, _, _, _ = after_proposed
+
+    await assert_revert(
+        ownable_two_steps.acceptOwnership().execute(),
+        reverted_with="OwnableTwoSteps: caller is the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_accept_ownership_from_owner(after_proposed):
+    ownable_two_steps, owner, _, _ = after_proposed
+
+    await assert_revert(
+        signer.send_transaction(
+            owner,
+            ownable_two_steps.contract_address,
+            'acceptOwnership',
+            []
+        ),
+        reverted_with="OwnableTwoSteps: caller is not the pending owner"
+    )
+
+
+@pytest.mark.asyncio
+async def test_accept_ownership_when_not_in_motion(contract_factory):
+    ownable_two_steps, owner, _, _ = contract_factory
+
+    await assert_revert(
+        signer.send_transaction(
+            owner,
+            ownable_two_steps.contract_address,
+            'acceptOwnership',
+            []
+        ),
+        reverted_with="OwnableTwoSteps: a proposal is not in motion"
+    )
+
+
+@pytest.mark.asyncio
+async def test_accept_ownership_emits_event(after_proposed):
+    ownable_two_steps, owner, pending_owner, _ = after_proposed
+
+    tx_execution_info = await signer.send_transaction(
+        pending_owner,
+        ownable_two_steps.contract_address,
+        'acceptOwnership',
+        []
+    )
+
+    assert_event_emitted(
+        tx_exec_info=tx_execution_info,
+        from_address=ownable_two_steps.contract_address,
+        name='OwnershipTransferred',
+        data=[
+            owner.contract_address, 
+            pending_owner.contract_address
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_renounce_ownership(contract_factory):
+    ownable_two_steps, owner, _, _ = contract_factory
+
+    await signer.send_transaction(
+        owner,
+        ownable_two_steps.contract_address,
+        'renounceOwnership',
+        []
+    )
+
+    executed_info = await ownable_two_steps.owner().call()
+    assert executed_info.result == (ZERO_ADDRESS, )
+
+    executed_info = await ownable_two_steps.pendingOwner().call()
+    assert executed_info.result == (ZERO_ADDRESS, )
+
+
+@pytest.mark.asyncio
+async def test_renounce_ownership_from_not_owner(contract_factory):
+    ownable_two_steps, _, pending_owner, _ = contract_factory
+
+    await assert_revert(
+        signer.send_transaction(
+            pending_owner,
+            ownable_two_steps.contract_address,
+            'renounceOwnership',
+            []
+        ),
+        reverted_with="OwnableTwoSteps: caller is not the owner"
+    )
+
+
+@pytest.mark.asyncio
+async def test_renounce_ownership_from_zero_address(contract_factory):
+    ownable_two_steps, _, _, _ = contract_factory
+
+    await assert_revert(
+        ownable_two_steps.renounceOwnership().execute(),
+        reverted_with="OwnableTwoSteps: caller is the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_renounce_ownership_emits_event(contract_factory):
+    ownable_two_steps, owner, _, _ = contract_factory
+
+    tx_execution_info = await signer.send_transaction(
+        owner,
+        ownable_two_steps.contract_address,
+        'renounceOwnership',
+        []
+    )
+
+    assert_event_emitted(
+        tx_exec_info=tx_execution_info,
+        from_address=ownable_two_steps.contract_address,
+        name='OwnershipTransferred',
+        data=[
+            owner.contract_address,
+            ZERO_ADDRESS
+        ]
+    )
+

--- a/tests/access/test_OwnableTwoSteps.py
+++ b/tests/access/test_OwnableTwoSteps.py
@@ -1,4 +1,3 @@
-from copyreg import constructor
 import pytest
 from signers import MockSigner
 from nile.utils import ZERO_ADDRESS, assert_revert

--- a/tests/mocks/OwnableTwoSteps.cairo
+++ b/tests/mocks/OwnableTwoSteps.cairo
@@ -1,0 +1,55 @@
+%lang starknet 
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+from openzeppelin.access.ownableTwoSteps.library import OwnableTwoSteps
+
+@constructor 
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr} (owner: felt) {
+    OwnableTwoSteps.initializer(owner);
+    return ();
+}
+
+@view
+func owner{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (owner: felt) {
+    return OwnableTwoSteps.owner();
+}
+
+@view
+func pendingOwner{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (pending_owner: felt) {
+    return OwnableTwoSteps.pending_owner();
+}
+
+@external
+func transferOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    pending_owner: felt
+) {
+    OwnableTwoSteps.transfer_ownership(pending_owner);
+    return ();
+}
+
+@external
+func acceptOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    OwnableTwoSteps.accept_ownership();
+    return ();
+}
+
+@external
+func cancelOwnershipProposal{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    OwnableTwoSteps.cancel_proposal();
+    return ();
+}
+
+@external
+func renounceOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    OwnableTwoSteps.renounce_ownership();
+    return ();
+}


### PR DESCRIPTION
Resubmitting the `ownableTwoSteps` library for more secure contract ownership transfers. Mock, tests and documentation are included.
