### PR TITLE
Fix test implementation in ERC721BaseSuite.py

### DIFF
--- a/tests/token/erc721/ERC721BaseSuite.py
+++ b/tests/token/erc721/ERC721BaseSuite.py
@@ -913,12 +913,12 @@ class ERC721Base:
 
     @pytest.mark.asyncio
     async def test_setTokenURI_for_nonexistent_token(self, erc721_minted):
-        erc721, _, not_owner, *_ = erc721_minted
+        erc721, account, *_ = erc721_minted
 
         await assert_revert(signer.send_transaction(
-            not_owner, erc721.contract_address, 'setTokenURI', [
+            account, erc721.contract_address, 'setTokenURI', [
                 *NONEXISTENT_TOKEN,
                 SAMPLE_URI_1
             ]),
-            reverted_with="Ownable: caller is not the owner"
+            reverted_with="ERC721_Metadata: set token URI for nonexistent token"
         )


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #511 <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

As stated in the issue, the `test_setTokenURI_for_nonexistent_token` test case in the suite **ERC721BaseSuite** doesn't have the correct implementation.

The test case uses the `not_owner` account to set the token URI for a nonexistent token instead of `account`. Furthermore, the reverted_with message is incorrect, it should be : `ERC721_Metadata: set token URI for nonexistent token`.
These two points have been fixed in this PR.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Tried the feature on a public network
- [ ] Documentation
