### PR TITLE
Fix test state in `signer.declare_class`

### DIFF
--- a/tests/signers.py
+++ b/tests/signers.py
@@ -94,7 +94,12 @@ class BaseSigner():
         )
 
         execution_info = await state.execute_tx(tx=tx)
-        return execution_info
+
+        await state.state.set_contract_class(
+            class_hash=tx.class_hash,
+            contract_class=contract_class
+        )
+        return class_hash, execution_info
 
     async def deploy_account(
         self,

--- a/tests/signers.py
+++ b/tests/signers.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 from starkware.starknet.core.os.transaction_hash.transaction_hash import TransactionHashPrefix
 from starkware.starknet.core.os.contract_address.contract_address import (
     calculate_contract_address_from_hash,
@@ -62,7 +63,7 @@ class BaseSigner():
         contract_name,
         nonce=None,
         max_fee=0,
-    ) -> tuple[int, TransactionExecutionInfo]:
+    ) -> Tuple[int, TransactionExecutionInfo]:
         state = account.state
 
         if nonce is None:

--- a/tests/signers.py
+++ b/tests/signers.py
@@ -62,7 +62,7 @@ class BaseSigner():
         contract_name,
         nonce=None,
         max_fee=0,
-    ) -> TransactionExecutionInfo:
+    ) -> tuple[int, TransactionExecutionInfo]:
         state = account.state
 
         if nonce is None:

--- a/tests/signers.py
+++ b/tests/signers.py
@@ -6,8 +6,8 @@ from starkware.starknet.definitions.general_config import StarknetChainId
 from starkware.starknet.services.api.gateway.transaction import InvokeFunction, DeployAccount
 from starkware.starknet.business_logic.transaction.objects import InternalTransaction, InternalDeclare, TransactionExecutionInfo
 from nile.signer import Signer, from_call_to_call_array, get_transaction_hash, TRANSACTION_VERSION
-from nile.common import get_contract_class, get_class_hash
 from nile.utils import to_uint
+from utils import get_contract_class, get_class_hash
 import eth_keys
 
 

--- a/tests/signers.py
+++ b/tests/signers.py
@@ -7,7 +7,8 @@ from starkware.starknet.services.api.gateway.transaction import InvokeFunction, 
 from starkware.starknet.business_logic.transaction.objects import InternalTransaction, InternalDeclare, TransactionExecutionInfo
 from nile.signer import Signer, from_call_to_call_array, get_transaction_hash, TRANSACTION_VERSION
 from nile.utils import to_uint
-from utils import get_contract_class, get_class_hash
+from nile.common import get_class_hash
+from utils import get_contract_class
 import eth_keys
 
 

--- a/tests/signers.py
+++ b/tests/signers.py
@@ -7,8 +7,7 @@ from starkware.starknet.services.api.gateway.transaction import InvokeFunction, 
 from starkware.starknet.business_logic.transaction.objects import InternalTransaction, InternalDeclare, TransactionExecutionInfo
 from nile.signer import Signer, from_call_to_call_array, get_transaction_hash, TRANSACTION_VERSION
 from nile.utils import to_uint
-from nile.common import get_class_hash
-from utils import get_contract_class
+from utils import get_class_hash, get_contract_class
 import eth_keys
 
 

--- a/tests/test_signers.py
+++ b/tests/test_signers.py
@@ -1,0 +1,72 @@
+import pytest
+
+from signers import MockSigner
+from utils import (
+    State,
+    Account,
+    get_contract_class,
+    cached_contract,
+    FALSE,
+    TRUE,
+)
+
+signer = MockSigner(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    account_cls = Account.get_class
+    deployer_cls = get_contract_class('UniversalDeployer')
+
+    return account_cls, deployer_cls
+
+
+@pytest.fixture(scope='module')
+async def deployer_init(contract_classes):
+    _, deployer_cls = contract_classes
+    starknet = await State.init()
+    account = await Account.deploy(signer.public_key)
+    deployer = await starknet.deploy(contract_class=deployer_cls)
+    return (
+        starknet.state,
+        account,
+        deployer
+    )
+
+
+@pytest.fixture
+def deployer_factory(contract_classes, deployer_init):
+    account_cls, deployer_cls = contract_classes
+    state, account, deployer = deployer_init
+    _state = state.copy()
+    _account = cached_contract(_state, account_cls, account)
+    deployer = cached_contract(_state, deployer_cls, deployer)
+
+    return _account, deployer
+
+
+@pytest.mark.asyncio
+async def test_signer_declare_class(deployer_factory):
+    account, deployer = deployer_factory
+    salt = 1234567875432  # random value
+    unique = 0
+    calldata = []
+
+    # declare contract class
+    class_hash, _ = await signer.declare_class(account, "Initializable")
+
+    # deploy contract
+    params = [class_hash, salt, unique, len(calldata), *calldata]
+    deploy_exec_info = await signer.send_transaction(account, deployer.contract_address, 'deployContract', params)
+    deployed_address = deploy_exec_info.call_info.retdata[1]
+
+    # test deployment
+    tx_exec_info = await signer.send_transaction(account, deployed_address, 'initialized', [])
+    is_initialized = tx_exec_info.call_info.retdata[1]
+    assert is_initialized == FALSE
+
+    await signer.send_transaction(account, deployed_address, 'initialize', [])
+
+    tx_exec_info = await signer.send_transaction(account, deployed_address, 'initialized', [])
+    is_initialized = tx_exec_info.call_info.retdata[1]
+    assert is_initialized == TRUE

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -94,12 +94,6 @@ def get_contract_class(contract, is_path=False):
     return contract_class
 
 
-def get_class_hash(contract, is_path=False):
-    """Return the class_hash for a given contract."""
-    contract_class = get_contract_class(contract, is_path)
-    return compute_class_hash(contract_class=contract_class, hash_func=pedersen_hash)
-
-
 def cached_contract(state, _class, deployed):
     """Return the cached contract"""
     contract = StarknetContract(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -94,6 +94,12 @@ def get_contract_class(contract, is_path=False):
     return contract_class
 
 
+def get_class_hash(contract_name, is_path=False):
+    """Return the class_hash for a given contract."""
+    contract_class = get_contract_class(contract_name, is_path)
+    return compute_class_hash(contract_class=contract_class, hash_func=pedersen_hash)
+
+
 def cached_contract(state, _class, deployed):
     """Return the cached contract"""
     contract = StarknetContract(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,8 @@
 
 import os
 from pathlib import Path
+from starkware.crypto.signature.fast_pedersen_hash import pedersen_hash
+from starkware.starknet.core.os.class_hash import compute_class_hash
 from starkware.starknet.public.abi import get_selector_from_name
 from starkware.starknet.business_logic.execution.objects import OrderedEvent
 from starkware.starknet.compiler.compile import compile_starknet_files
@@ -90,6 +92,12 @@ def get_contract_class(contract, is_path=False):
         cairo_path=get_cairo_path()
     )
     return contract_class
+
+
+def get_class_hash(contract, is_path=False):
+    """Return the class_hash for a given contract."""
+    contract_class = get_contract_class(contract, is_path)
+    return compute_class_hash(contract_class=contract_class, hash_func=pedersen_hash)
 
 
 def cached_contract(state, _class, deployed):

--- a/tests/utils/test_UniversalDeployer.py
+++ b/tests/utils/test_UniversalDeployer.py
@@ -109,7 +109,7 @@ async def test_declare_and_deploy(deployer_factory, unique):
     salt = 1234567875432  # random value
     calldata = []
 
-    # declare contract
+    # declare contract class
     class_hash, _ = await signer.declare_class(account, "Initializable")
 
     # deploy contract

--- a/tests/utils/test_UniversalDeployer.py
+++ b/tests/utils/test_UniversalDeployer.py
@@ -100,30 +100,3 @@ async def test_deployment(deployer_factory, unique):
             salt,                     # salt
         ]
     )
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize('unique', [TRUE, FALSE])
-async def test_declare_and_deploy(deployer_factory, unique):
-    account, deployer = deployer_factory
-    salt = 1234567875432  # random value
-    calldata = []
-
-    # declare contract class
-    class_hash, _ = await signer.declare_class(account, "Initializable")
-
-    # deploy contract
-    params = [class_hash, salt, unique, len(calldata), *calldata]
-    deploy_exec_info = await signer.send_transaction(account, deployer.contract_address, 'deployContract', params)
-    deployed_address = deploy_exec_info.call_info.retdata[1]
-
-    # test deployment
-    tx_exec_info = await signer.send_transaction(account, deployed_address, 'initialized', [])
-    is_initialized = tx_exec_info.call_info.retdata[1]
-    assert is_initialized == FALSE
-
-    await signer.send_transaction(account, deployed_address, 'initialize', [])
-
-    tx_exec_info = await signer.send_transaction(account, deployed_address, 'initialized', [])
-    is_initialized = tx_exec_info.call_info.retdata[1]
-    assert is_initialized == TRUE

--- a/tests/utils/test_UniversalDeployer.py
+++ b/tests/utils/test_UniversalDeployer.py
@@ -117,7 +117,7 @@ async def test_declare_and_deploy(deployer_factory, unique):
     deploy_exec_info = await signer.send_transaction(account, deployer.contract_address, 'deployContract', params)
     deployed_address = deploy_exec_info.call_info.retdata[1]
 
-#    # test deployment
+    # test deployment
     tx_exec_info = await signer.send_transaction(account, deployed_address, 'initialized', [])
     is_initialized = tx_exec_info.call_info.retdata[1]
     assert is_initialized == FALSE

--- a/tests/utils/test_UniversalDeployer.py
+++ b/tests/utils/test_UniversalDeployer.py
@@ -100,3 +100,30 @@ async def test_deployment(deployer_factory, unique):
             salt,                     # salt
         ]
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('unique', [TRUE, FALSE])
+async def test_declare_and_deploy(deployer_factory, unique):
+    account, deployer = deployer_factory
+    salt = 1234567875432  # random value
+    calldata = []
+
+    # declare contract
+    class_hash, _ = await signer.declare_class(account, "Initializable")
+
+    # deploy contract
+    params = [class_hash, salt, unique, len(calldata), *calldata]
+    deploy_exec_info = await signer.send_transaction(account, deployer.contract_address, 'deployContract', params)
+    deployed_address = deploy_exec_info.call_info.retdata[1]
+
+#    # test deployment
+    tx_exec_info = await signer.send_transaction(account, deployed_address, 'initialized', [])
+    is_initialized = tx_exec_info.call_info.retdata[1]
+    assert is_initialized == FALSE
+
+    await signer.send_transaction(account, deployed_address, 'initialize', [])
+
+    tx_exec_info = await signer.send_transaction(account, deployed_address, 'initialized', [])
+    is_initialized = tx_exec_info.call_info.retdata[1]
+    assert is_initialized == TRUE


### PR DESCRIPTION
Resolves #531.

This PR also proposes to use `get_contract_class` from Contracts's utils.py instead of importing it from Nile. Contracts's `get_contract_class` also compiles the contract; whereas, Nile's `get_contract_class` expects the contract to be already compiled. This is an issue with running tests from tox (and consequently, the CI) because it only compiles from the `src/` directory (and not the mock contracts) https://github.com/OpenZeppelin/cairo-contracts/blob/main/tox.ini#L30

An alternative solution would be to also compile `tests/mocks/` in tox. 