### PR TITLE
Fix formatting for CI

### DIFF
--- a/src/openzeppelin/introspection/erc165.cairo
+++ b/src/openzeppelin/introspection/erc165.cairo
@@ -2,7 +2,7 @@ const IERC165_ID: u32 = 0x01ffc9a7_u32;
 const INVALID_ID: u32 = 0xffffffff_u32;
 
 trait IERC165 {
-  fn supports_interface(interface_id: u32) -> bool;
+    fn supports_interface(interface_id: u32) -> bool;
 }
 
 #[contract]
@@ -10,7 +10,7 @@ mod ERC165 {
     use openzeppelin::introspection::erc165;
 
     struct Storage {
-        supported_interfaces: LegacyMap<u32, bool>,
+        supported_interfaces: LegacyMap<u32, bool>
     }
 
     impl ERC165 of erc165::IERC165 {
@@ -26,7 +26,7 @@ mod ERC165 {
     fn supports_interface(interface_id: u32) -> bool {
         ERC165::supports_interface(interface_id)
     }
- 
+
     #[internal]
     fn register_interface(interface_id: u32) {
         assert(interface_id != erc165::INVALID_ID, 'Invalid id');

--- a/src/openzeppelin/tests/test_erc165.cairo
+++ b/src/openzeppelin/tests/test_erc165.cairo
@@ -15,14 +15,14 @@ fn test_default_behavior() {
 #[available_gas(2000000)]
 fn test_not_registered_interface() {
     let supports_unregistered_interface: bool = ERC165::supports_interface(OTHER_ID);
-    assert(! supports_unregistered_interface, 'Should not support unregistered');
+    assert(!supports_unregistered_interface, 'Should not support unregistered');
 }
 
 #[test]
 #[available_gas(2000000)]
 fn test_supports_invalid_interface() {
     let supports_invalid_interface: bool = ERC165::supports_interface(INVALID_ID);
-    assert(! supports_invalid_interface, 'Should not support invalid id');
+    assert(!supports_invalid_interface, 'Should not support invalid id');
 }
 
 #[test]
@@ -46,7 +46,7 @@ fn test_deregister_interface() {
     ERC165::register_interface(OTHER_ID);
     ERC165::deregister_interface(OTHER_ID);
     let supports_old_interface: bool = ERC165::supports_interface(OTHER_ID);
-    assert(! supports_old_interface, 'Should not support interface');
+    assert(!supports_old_interface, 'Should not support interface');
 }
 
 #[test]


### PR DESCRIPTION
The workflow failed [here](https://github.com/OpenZeppelin/cairo-contracts/actions/runs/4824320026/jobs/8593952580) because the CI branch didn't include the latest cairo-1 branch updates 