### PR TITLE
Remove underscore from `name_` and `symbol_` params

### DIFF
--- a/src/token/erc20/erc20.cairo
+++ b/src/token/erc20/erc20.cairo
@@ -172,9 +172,9 @@ mod ERC20 {
 
     #[generate_trait]
     impl InternalImpl of InternalTrait {
-        fn initializer(ref self: ContractState, name_: felt252, symbol_: felt252) {
-            self._name.write(name_);
-            self._symbol.write(symbol_);
+        fn initializer(ref self: ContractState, name: felt252, symbol: felt252) {
+            self._name.write(name);
+            self._symbol.write(symbol);
         }
 
         fn _increase_allowance(

--- a/src/token/erc721/erc721.cairo
+++ b/src/token/erc721/erc721.cairo
@@ -238,9 +238,9 @@ mod ERC721 {
 
     #[generate_trait]
     impl InternalImpl of InternalTrait {
-        fn initializer(ref self: ContractState, name_: felt252, symbol_: felt252) {
-            self._name.write(name_);
-            self._symbol.write(symbol_);
+        fn initializer(ref self: ContractState, name: felt252, symbol: felt252) {
+            self._name.write(name);
+            self._symbol.write(symbol);
 
             let mut unsafe_state = src5::SRC5::unsafe_new_contract_state();
             src5::SRC5::InternalImpl::register_interface(ref unsafe_state, interface::IERC721_ID);


### PR DESCRIPTION
Because the initializers reside within `InternalImpl`, the `name` and `symbol` parameters no longer clash with the functions. Part of #736 