### PR TITLE
Bump to 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ mod MyToken {
 
 ### Unsupported
 
-[`DualCase` dispatchers](https://docs.openzeppelin.com/contracts-cairo/0.8.0-beta.0/interfaces#dualcase_dispatchers) rely on Sierra's ability to catch a revert to resume execution. Currently, Starknet live chains (testnets and mainnet) don't implement that behavior. Starknet's testing framework does support it.
+[`DualCase` dispatchers](https://docs.openzeppelin.com/contracts-cairo/0.8.0/interfaces#dualcase_dispatchers) rely on Sierra's ability to catch a revert to resume execution. Currently, Starknet live chains (testnets and mainnet) don't implement that behavior. Starknet's testing framework does support it.
 
 ## Learn
 

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -3,4 +3,4 @@ version = 1
 
 [[package]]
 name = "openzeppelin"
-version = "0.8.0-beta.0"
+version = "0.8.0"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openzeppelin"
-version = "0.8.0-beta.0"
+version = "0.8.0"
 cairo-version = "2.3.1"
 authors = ["OpenZeppelin Community <maintainers@openzeppelin.org>"]
 description = "OpenZeppelin Contracts written in Cairo for StarkNet, a decentralized ZK Rollup"

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: contracts-cairo
 title: Contracts for Cairo
-version: 0.8.0-beta.0
+version: 0.8.0
 nav:
   - modules/ROOT/nav.adoc
 asciidoc:

--- a/src/token/erc20/erc20.cairo
+++ b/src/token/erc20/erc20.cairo
@@ -7,7 +7,7 @@
 /// non-standard implementations that can be used to create an ERC20 contract. This
 /// component is agnostic regarding how tokens are created, which means that developers
 /// must create their own token distribution mechanism.
-/// See [the documentation](https://docs.openzeppelin.com/contracts-cairo/0.8.0-beta.0/guides/erc20-supply)
+/// See [the documentation](https://docs.openzeppelin.com/contracts-cairo/0.8.0/guides/erc20-supply)
 /// for examples.
 #[starknet::component]
 mod ERC20Component {


### PR DESCRIPTION
The other bump only changed `v0.8.0` and missed instances of `0.8.0` 😅