### PR TITLE
Remove Wizard from 0.5.0 docs

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,5 +1,4 @@
 * xref:index.adoc[Overview]
-* xref:wizard.adoc[Wizard]
 * xref:extensibility.adoc[Extensibility]
 * xref:proxies.adoc[Proxies and Upgrades]
 


### PR DESCRIPTION
The Wizard embed only supports the latest release. Remove from older versions of the docs.