### PR TITLE
Remove Wizard from 0.4.0b docs

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -14,4 +14,3 @@
 * xref:utilities.adoc[Utilities]
 
 * xref:contracts::index.adoc[Contracts for Solidity]
-* https://wizard.openzeppelin.com/cairo[Wizard]


### PR DESCRIPTION
The Wizard link only supports the latest release. Remove from older versions of the docs.