### PR TITLE
Update edition to 2023_10

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/OpenZeppelin/cairo-contracts"
 license-file = "LICENSE"
 keywords = ["openzeppelin", "starknet", "cairo", "contracts", "security", "standards"]
+edition = "2023_10"
 
 [dependencies]
 starknet = "2.3.1"

--- a/src/access/ownable/ownable.cairo
+++ b/src/access/ownable/ownable.cairo
@@ -14,6 +14,7 @@ mod OwnableComponent {
     use openzeppelin::access::ownable::interface;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
+    use core::zeroable::Zeroable;
 
     #[storage]
     struct Storage {

--- a/src/account/account.cairo
+++ b/src/account/account.cairo
@@ -6,7 +6,7 @@
 /// The Account component enables contracts to behave as accounts.
 #[starknet::component]
 mod AccountComponent {
-    use ecdsa::check_ecdsa_signature;
+    use core::{ecdsa::check_ecdsa_signature, zeroable::Zeroable};
     use openzeppelin::account::interface;
     use openzeppelin::introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin::introspection::src5::SRC5Component;

--- a/src/tests/access/test_dual_ownable.cairo
+++ b/src/tests/access/test_dual_ownable.cairo
@@ -1,3 +1,4 @@
+use core::zeroable::Zeroable;
 use openzeppelin::access::ownable::dual_ownable::DualCaseOwnable;
 use openzeppelin::access::ownable::dual_ownable::DualCaseOwnableTrait;
 use openzeppelin::access::ownable::interface::IOwnableCamelOnlyDispatcher;

--- a/src/tests/access/test_ownable.cairo
+++ b/src/tests/access/test_ownable.cairo
@@ -1,3 +1,4 @@
+use core::zeroable::Zeroable;
 use openzeppelin::access::ownable::OwnableComponent::InternalTrait;
 use openzeppelin::access::ownable::OwnableComponent::OwnershipTransferred;
 use openzeppelin::access::ownable::OwnableComponent;

--- a/src/tests/mocks/accesscontrol_mocks.cairo
+++ b/src/tests/mocks/accesscontrol_mocks.cairo
@@ -134,6 +134,7 @@ mod CamelAccessControlMock {
 
 #[starknet::contract]
 mod SnakeAccessControlPanicMock {
+    use core::panic_with_felt252;
     use starknet::ContractAddress;
 
     #[storage]
@@ -175,6 +176,7 @@ mod SnakeAccessControlPanicMock {
 
 #[starknet::contract]
 mod CamelAccessControlPanicMock {
+    use core::panic_with_felt252;
     use starknet::ContractAddress;
 
     #[storage]

--- a/src/tests/mocks/account_mocks.cairo
+++ b/src/tests/mocks/account_mocks.cairo
@@ -144,6 +144,8 @@ mod CamelAccountMock {
 
 #[starknet::contract]
 mod SnakeAccountPanicMock {
+    use core::panic_with_felt252;
+
     #[storage]
     struct Storage {}
 
@@ -175,6 +177,8 @@ mod SnakeAccountPanicMock {
 
 #[starknet::contract]
 mod CamelAccountPanicMock {
+    use core::panic_with_felt252;
+
     #[storage]
     struct Storage {}
 

--- a/src/tests/mocks/erc20_mocks.cairo
+++ b/src/tests/mocks/erc20_mocks.cairo
@@ -153,6 +153,7 @@ mod CamelERC20Mock {
 /// false for bool
 #[starknet::contract]
 mod SnakeERC20Panic {
+    use core::panic_with_felt252;
     use starknet::ContractAddress;
 
     #[storage]
@@ -217,6 +218,7 @@ mod SnakeERC20Panic {
 
 #[starknet::contract]
 mod CamelERC20Panic {
+    use core::panic_with_felt252;
     use starknet::ContractAddress;
 
     #[storage]

--- a/src/tests/mocks/erc721_mocks.cairo
+++ b/src/tests/mocks/erc721_mocks.cairo
@@ -187,8 +187,8 @@ mod CamelERC721Mock {
 /// u256 { 3, 3 } for u256
 #[starknet::contract]
 mod SnakeERC721PanicMock {
+    use core::{panic_with_felt252, zeroable::Zeroable};
     use starknet::ContractAddress;
-    use zeroable::Zeroable;
 
     #[storage]
     struct Storage {}
@@ -268,8 +268,8 @@ mod SnakeERC721PanicMock {
 
 #[starknet::contract]
 mod CamelERC721PanicMock {
+    use core::{panic_with_felt252, zeroable::Zeroable};
     use starknet::ContractAddress;
-    use zeroable::Zeroable;
 
     #[storage]
     struct Storage {}

--- a/src/tests/mocks/erc721_receiver_mocks.cairo
+++ b/src/tests/mocks/erc721_receiver_mocks.cairo
@@ -178,6 +178,7 @@ mod CamelERC721ReceiverMock {
 
 #[starknet::contract]
 mod SnakeERC721ReceiverPanicMock {
+    use core::panic_with_felt252;
     use starknet::ContractAddress;
 
     #[storage]
@@ -198,6 +199,7 @@ mod SnakeERC721ReceiverPanicMock {
 
 #[starknet::contract]
 mod CamelERC721ReceiverPanicMock {
+    use core::panic_with_felt252;
     use starknet::ContractAddress;
 
     #[storage]

--- a/src/tests/mocks/ownable_mocks.cairo
+++ b/src/tests/mocks/ownable_mocks.cairo
@@ -99,8 +99,8 @@ mod CamelOwnableMock {
 
 #[starknet::contract]
 mod SnakeOwnablePanicMock {
+    use core::{panic_with_felt252, zeroable::Zeroable};
     use starknet::ContractAddress;
-    use zeroable::Zeroable;
 
     #[storage]
     struct Storage {}
@@ -124,6 +124,7 @@ mod SnakeOwnablePanicMock {
 
 #[starknet::contract]
 mod CamelOwnablePanicMock {
+    use core::{panic_with_felt252, zeroable::Zeroable};
     use starknet::ContractAddress;
 
     #[storage]

--- a/src/tests/mocks/src5_mocks.cairo
+++ b/src/tests/mocks/src5_mocks.cairo
@@ -72,6 +72,8 @@ mod CamelSRC5Mock {
 
 #[starknet::contract]
 mod SnakeSRC5PanicMock {
+    use core::panic_with_felt252;
+
     #[storage]
     struct Storage {}
 
@@ -84,6 +86,8 @@ mod SnakeSRC5PanicMock {
 
 #[starknet::contract]
 mod CamelSRC5PanicMock {
+    use core::panic_with_felt252;
+
     #[storage]
     struct Storage {}
 

--- a/src/tests/presets/test_erc20.cairo
+++ b/src/tests/presets/test_erc20.cairo
@@ -1,4 +1,4 @@
-use integer::BoundedInt;
+use core::{integer::BoundedInt, zeroable::Zeroable};
 use openzeppelin::presets::ERC20;
 use openzeppelin::tests::utils::constants::{
     ZERO, OWNER, SPENDER, RECIPIENT, NAME, SYMBOL, DECIMALS, SUPPLY, VALUE

--- a/src/tests/token/test_erc20.cairo
+++ b/src/tests/token/test_erc20.cairo
@@ -1,4 +1,4 @@
-use integer::BoundedInt;
+use core::integer::BoundedInt;
 use openzeppelin::tests::mocks::erc20_mocks::DualCaseERC20Mock;
 use openzeppelin::tests::utils::constants::{
     ZERO, OWNER, SPENDER, RECIPIENT, NAME, SYMBOL, DECIMALS, SUPPLY, VALUE

--- a/src/tests/token/test_erc721.cairo
+++ b/src/tests/token/test_erc721.cairo
@@ -1,4 +1,4 @@
-use integer::u256_from_felt252;
+use core::integer::u256_from_felt252;
 use openzeppelin::account::AccountComponent;
 use openzeppelin::introspection::src5::SRC5Component::SRC5Impl;
 use openzeppelin::introspection::src5;

--- a/src/token/erc20/erc20.cairo
+++ b/src/token/erc20/erc20.cairo
@@ -11,7 +11,7 @@
 /// for examples.
 #[starknet::component]
 mod ERC20Component {
-    use integer::BoundedInt;
+    use core::{integer::BoundedInt, zeroable::Zeroable};
     use openzeppelin::token::erc20::interface;
     use starknet::ContractAddress;
     use starknet::get_caller_address;

--- a/src/token/erc721/erc721.cairo
+++ b/src/token/erc721/erc721.cairo
@@ -7,6 +7,7 @@
 /// and the IERC721Metadata interface.
 #[starknet::component]
 mod ERC721Component {
+    use core::{zeroable::Zeroable, panic_with_felt252};
     use openzeppelin::account;
     use openzeppelin::introspection::dual_src5::{DualCaseSRC5, DualCaseSRC5Trait};
     use openzeppelin::introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;

--- a/src/upgrades/upgradeable.cairo
+++ b/src/upgrades/upgradeable.cairo
@@ -6,6 +6,7 @@
 /// The Upgradeable component provides a mechanism to make a contract upgradeable.
 #[starknet::component]
 mod UpgradeableComponent {
+    use core::zeroable::Zeroable;
     use starknet::ClassHash;
 
     #[storage]


### PR DESCRIPTION
Cairo v2.4.0 introduced the notion of editions. New editions add new features but may include breaking changes. Editions are linearly increasing, i.e. if we have edition x<y<z, then we cannot upgrade to z without taking y's changes as well.

This PR adds edition to the project's Scarb.toml and makes the necessary changes so that the package compiles successfully. Edition 2023_10 narrows the part of the corelib which is available by default. To compile with this edition, this PR adds a bunch of use statements (mostly for `zeroable` and `panic_with_felt252`) for functionality that is no longer part of the prelude.

#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
