### PR TITLE
fix: bug in account.cairo

### DIFF
--- a/src/account/account.cairo
+++ b/src/account/account.cairo
@@ -269,6 +269,6 @@ mod AccountComponent {
 
     fn _execute_single_call(call: Call) -> Span<felt252> {
         let Call{to, selector, calldata } = call;
-        starknet::call_contract_syscall(to, selector, calldata.span()).unwrap()
+        starknet::call_contract_syscall(to, selector, calldata.into()).unwrap()
     }
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes bug in `src/account/account.cairo` <!-- Fill in with issue number -->

Scarb version: scarb 2.5.0 (c531a6e50 2024-01-22)
I'm trying to build a NFT, so I use [Wizzard for Cairo](https://docs.openzeppelin.com/contracts-cairo/0.8.1/wizard) to get start.
When I tried to compile the contract with `scarb build`. I got a error below:
```sh
error: Method `span` could not be called on type `core::array::Span::<core::felt252>`.
Candidate `ArrayTrait::span` inference failed with: Type mismatch: `core::array::Span::<core::felt252>` and `@core::array::Array::<?0>`
 --> C:\Users\username\AppData\Local\swmansion\scarb\cache\registry\git\checkouts\cairo-contracts-9cboa8jg3jldq\5c7a022\src\account\account.cairo:272:64
        starknet::call_contract_syscall(to, selector, calldata.span()).unwrap()
                                                               ^**^
```
After I change `calldata.span()` into `calldata.into()`, the error was gone.
The NFT's class hash is https://testnet.starkscan.co/class/0x07a029bdd6727af993c9d2432a5c353ffa8a08a2ef33249bd6dd33bf12ffe7ed

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [ ] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
