### PR TITLE
fix: Call corrections and removal of ABI annotations in SRC6Impl

### DIFF
--- a/src/account/utils.cairo
+++ b/src/account/utils.cairo
@@ -28,5 +28,5 @@ fn execute_calls(mut calls: Array<Call>) -> Array<Span<felt252>> {
 
 fn execute_single_call(call: Call) -> Span<felt252> {
     let Call{to, selector, calldata } = call;
-    starknet::call_contract_syscall(to, selector, calldata.span()).unwrap()
+    starknet::call_contract_syscall(to, selector, calldata).unwrap()
 }

--- a/src/presets/account.cairo
+++ b/src/presets/account.cairo
@@ -13,7 +13,6 @@ mod Account {
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 
     // Account
-    #[abi(embed_v0)]
     impl SRC6Impl = AccountComponent::SRC6Impl<ContractState>;
     #[abi(embed_v0)]
     impl SRC6CamelOnlyImpl = AccountComponent::SRC6CamelOnlyImpl<ContractState>;

--- a/src/presets/eth_account.cairo
+++ b/src/presets/eth_account.cairo
@@ -20,7 +20,6 @@ mod EthAccountUpgradeable {
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
 
     // EthAccount
-    #[abi(embed_v0)]
     impl SRC6Impl = EthAccountComponent::SRC6Impl<ContractState>;
     #[abi(embed_v0)]
     impl SRC6CamelOnlyImpl = EthAccountComponent::SRC6CamelOnlyImpl<ContractState>;
@@ -68,7 +67,7 @@ mod EthAccountUpgradeable {
         self.eth_account.initializer(public_key);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl UpgradeableImpl of IUpgradeable<ContractState> {
         fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
             self.eth_account.assert_only_self();


### PR DESCRIPTION
Fixes #887 

Just went on and fixed the the few things that were causing the problem to initilize the project:
1. Deleted unnecesary `.span()`
2. Deleted wrong `[abi(embed_v0)]`etiquettes because the  `SRC6Impl` shouldn't be exposed in the abi.

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
