### PR TITLE
fix: ensure option is used to remove warning

### DIFF
--- a/src/tests/utils.cairo
+++ b/src/tests/utils.cairo
@@ -49,7 +49,7 @@ fn assert_no_events_left(address: ContractAddress) {
 }
 
 fn drop_event(address: ContractAddress) {
-    testing::pop_log_raw(address).unwrap();
+    let _ = testing::pop_log_raw(address);
 }
 
 fn drop_events(address: ContractAddress, count: felt252) {

--- a/src/tests/utils.cairo
+++ b/src/tests/utils.cairo
@@ -24,7 +24,7 @@ fn pop_log<T, +Drop<T>, +starknet::Event<T>>(address: ContractAddress) -> Option
     let (mut keys, mut data) = testing::pop_log_raw(address)?;
 
     // Remove the event ID from the keys
-    keys.pop_front();
+    keys.pop_front()?;
 
     let ret = starknet::Event::deserialize(ref keys, ref data);
     assert!(data.is_empty(), "Event has extra data");
@@ -49,7 +49,7 @@ fn assert_no_events_left(address: ContractAddress) {
 }
 
 fn drop_event(address: ContractAddress) {
-    testing::pop_log_raw(address);
+    testing::pop_log_raw(address).unwrap();
 }
 
 fn drop_events(address: ContractAddress, count: felt252) {

--- a/src/tests/utils.cairo
+++ b/src/tests/utils.cairo
@@ -24,7 +24,7 @@ fn pop_log<T, +Drop<T>, +starknet::Event<T>>(address: ContractAddress) -> Option
     let (mut keys, mut data) = testing::pop_log_raw(address)?;
 
     // Remove the event ID from the keys
-    keys.pop_front()?;
+    let _ = keys.pop_front();
 
     let ret = starknet::Event::deserialize(ref keys, ref data);
     assert!(data.is_empty(), "Event has extra data");


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Describe the changes introduced in this pull request. -->
When testing with the new `0.9.0` version, we had some warning when compiling a project:
```
warning: Unhandled `#[must_use]` type `core::option::Option::<@core::felt252>`
 --> /home/.cache/scarb/registry/git/checkouts/cairo-contracts-9cboa8jg3jldq/861fc41/src/tests/utils.cairo:26:5
    keys.pop_front();
    ^**************^

warning: Unhandled `#[must_use]` type `core::option::Option::<(core::array::Span::<core::felt252>, core::array::Span::<core::felt252>)>`
 --> /home/.cache/scarb/registry/git/checkouts/cairo-contracts-9cboa8jg3jldq/861fc41/src/tests/utils.cairo:51:5
    testing::pop_log_raw(address);
    ^***************************^

warning: Unhandled `#[must_use]` type `core::option::Option::<@core::felt252>`
 --> /home/.cache/scarb/registry/git/checkouts/cairo-contracts-9cboa8jg3jldq/861fc41/src/tests/utils.cairo:26:5
    keys.pop_front();
    ^**************^

warning: Unhandled `#[must_use]` type `core::option::Option::<(core::array::Span::<core::felt252>, core::array::Span::<core::felt252>)>`
 --> /home/.cache/scarb/registry/git/checkouts/cairo-contracts-9cboa8jg3jldq/861fc41/src/tests/utils.cairo:51:5
    testing::pop_log_raw(address);
    ^***************************^

```
Checking on main, this issue is still present.
This PR aims at using the `Option` to avoid warnings.

<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

It's a very small fix for warnings, the test suite passes but I've not deployed a contract on public network as the issue is related to testing only. Not sure if the `CHANGELOG` applies in this occasion, but will be happy to complete any missing item. :+1: 

- [ ] Tests
- [ ] Documentation
- [ ] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
