### PR TITLE
Verify signer control on `setPublicKey`

### DIFF
--- a/src/account/account.cairo
+++ b/src/account/account.cairo
@@ -7,6 +7,7 @@
 #[starknet::component]
 mod AccountComponent {
     use openzeppelin::account::interface;
+    use openzeppelin::account::utils::add_owner::AddOwner;
     use openzeppelin::account::utils::{MIN_TRANSACTION_VERSION, QUERY_VERSION, QUERY_OFFSET};
     use openzeppelin::account::utils::{execute_calls, is_valid_stark_signature};
     use openzeppelin::introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
@@ -156,8 +157,12 @@ mod AccountComponent {
         /// - The caller must be the contract itself.
         ///
         /// Emits an `OwnerRemoved` event.
-        fn set_public_key(ref self: ComponentState<TContractState>, new_public_key: felt252) {
+        fn set_public_key(ref self: ComponentState<TContractState>, new_public_key: felt252, signature: Span<felt252>) {
             self.assert_only_self();
+
+            let hash = AddOwner::build_hash(new_public_key);
+            assert(self._is_valid_signature(hash, signature), Errors::INVALID_SIGNATURE);
+
             self.emit(OwnerRemoved { removed_owner_guid: self.Account_public_key.read() });
             self._set_public_key(new_public_key);
         }
@@ -190,8 +195,8 @@ mod AccountComponent {
             self.Account_public_key.read()
         }
 
-        fn setPublicKey(ref self: ComponentState<TContractState>, newPublicKey: felt252) {
-            self.set_public_key(newPublicKey);
+        fn setPublicKey(ref self: ComponentState<TContractState>, newPublicKey: felt252, signature: Span<felt252>) {
+            self.set_public_key(newPublicKey, signature);
         }
     }
 

--- a/src/account/interface.cairo
+++ b/src/account/interface.cairo
@@ -35,7 +35,7 @@ trait IDeployable<TState> {
 #[starknet::interface]
 trait IPublicKey<TState> {
     fn get_public_key(self: @TState) -> felt252;
-    fn set_public_key(ref self: TState, new_public_key: felt252);
+    fn set_public_key(ref self: TState, new_public_key: felt252, signature: Span<felt252>);
 }
 
 #[starknet::interface]
@@ -46,7 +46,7 @@ trait ISRC6CamelOnly<TState> {
 #[starknet::interface]
 trait IPublicKeyCamel<TState> {
     fn getPublicKey(self: @TState) -> felt252;
-    fn setPublicKey(ref self: TState, newPublicKey: felt252);
+    fn setPublicKey(ref self: TState, newPublicKey: felt252, signature: Span<felt252>);
 }
 
 //
@@ -73,7 +73,7 @@ trait AccountABI<TState> {
 
     // IPublicKey
     fn get_public_key(self: @TState) -> felt252;
-    fn set_public_key(ref self: TState, new_public_key: felt252);
+    fn set_public_key(ref self: TState, new_public_key: felt252, signature: Span<felt252>);
 
     // ISRC6CamelOnly
     fn isValidSignature(self: @TState, hash: felt252, signature: Array<felt252>) -> felt252;
@@ -83,7 +83,7 @@ trait AccountABI<TState> {
 
     // IPublicKeyCamel
     fn getPublicKey(self: @TState) -> felt252;
-    fn setPublicKey(ref self: TState, newPublicKey: felt252);
+    fn setPublicKey(ref self: TState, newPublicKey: felt252, signature: Span<felt252>);
 }
 
 //

--- a/src/account/utils.cairo
+++ b/src/account/utils.cairo
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts for Cairo v0.9.0 (account/utils.cairo)
 
+mod add_owner;
 mod secp256k1;
 mod signature;
 

--- a/src/account/utils/add_owner.cairo
+++ b/src/account/utils/add_owner.cairo
@@ -1,0 +1,52 @@
+
+mod AddOwner {
+    use hash::{HashStateTrait, HashStateExTrait};
+    use pedersen::PedersenTrait;
+    use starknet::ContractAddress;
+    use starknet::get_contract_address;
+    use starknet::get_tx_info;
+
+    #[derive(Copy, Drop, Hash)]
+    struct StarkNetDomain {
+        name: felt252,
+        version: felt252,
+        chain_id: felt252
+    }
+
+    #[derive(Copy, Drop, Serde)]
+    struct AddOwner {
+        account: ContractAddress,
+        owner: felt252
+    }
+
+    fn build_hash(new_owner: felt252) -> felt252 {
+        let domain = StarkNetDomain {
+            name: 'Account.add_owner', version: 1, chain_id: get_tx_info().unbox().chain_id,
+        };
+
+        PedersenTrait::new(0)
+            .update('StarkNet Message')
+            .update(hash_domain(@domain))
+            .update(get_contract_address().into())
+            .update(hash_add_owner_message(new_owner))
+            .update(4)
+            .finalize()
+    }
+
+    fn hash_domain(domain: @StarkNetDomain) -> felt252 {
+        PedersenTrait::new(0)
+            .update(selector!("StarkNetDomain(name:felt,version:felt,chainId:felt)"))
+            .update_with(*domain)
+            .update(4)
+            .finalize()
+    }
+
+    fn hash_add_owner_message(new_owner: felt252) -> felt252 {
+        PedersenTrait::new(0)
+            .update(selector!("AddOwner(account:felt,owner:felt)"))
+            .update(get_contract_address().into())
+            .update(new_owner)
+            .update(3)
+            .finalize()
+    }
+}


### PR DESCRIPTION
Fixes #469, #818.

I propose not adding a 2step flow, but to add a `signature: Span<felt252>` param to `setPublicKey` (*) used to validate that we control the new owner, and that it "accepts" this ownership -- all in a single step.

To make this more user-friendly, i'm using [SNIP-12](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md) (aka Starknet's EIP712) and defining the `AddOwner` operation for the `Account.add_owner` application.

```
#[derive(Copy, Drop, Serde)]
struct AddOwner {
    account: ContractAddress,
    owner: felt252
}
```

Even though the `account` is already present in the hash as required by SNIP-12 and that `owner` is already known by the owner, I decided to make the struct overly explicit so users know what they're signing, even if it adds a bit of cost/redundancy/complexity.

If we move forward with this proposal, we should probably tackle #409 first.

*: i'd probably go even further an rename it `set_owner`, since that's the term we're using in the `OwnerAdded` and that I'm using here too.