### PR TITLE
Bump scarb and fix examples

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -2,7 +2,7 @@
 name = "openzeppelin"
 version = "0.13.0"
 edition = "2023_11"
-cairo-version = "2.6.3"
+cairo-version = "2.6.4"
 authors = ["OpenZeppelin Community <maintainers@openzeppelin.org>"]
 description = "OpenZeppelin Contracts written in Cairo for StarkNet, a decentralized ZK Rollup"
 documentation = "https://docs.openzeppelin.com/contracts-cairo"
@@ -12,7 +12,7 @@ license-file = "LICENSE"
 keywords = ["openzeppelin", "starknet", "cairo", "contracts", "security", "standards"]
 
 [dependencies]
-starknet = "2.6.3"
+starknet = "2.6.4"
 
 [lib]
 

--- a/docs/modules/ROOT/pages/access.adoc
+++ b/docs/modules/ROOT/pages/access.adoc
@@ -83,7 +83,8 @@ This is the full interface of the `OwnableMixinImpl` implementation:
 
 [,cairo]
 ----
-trait OwnableABI {
+#[starknet::interface]
+pub trait OwnableABI {
     // IOwnable
     fn owner() -> ContractAddress;
     fn transfer_ownership(new_owner: ContractAddress);
@@ -124,7 +125,8 @@ This is the full interface of the two step `OwnableTwoStepMixinImpl` implementat
 
 [,cairo]
 ----
-trait OwnableTwoStepABI {
+#[starknet::interface]
+pub trait OwnableTwoStepABI {
     // IOwnableTwoStep
     fn owner() -> ContractAddress;
     fn pending_owner() -> ContractAddress;
@@ -491,7 +493,8 @@ This is the full interface of the `AccessControlMixinImpl` implementation:
 
 [,cairo]
 ----
-trait AccessControlABI {
+#[starknet::interface]
+pub trait AccessControlABI {
     // IAccessControl
     fn has_role(role: felt252, account: ContractAddress) -> bool;
     fn get_role_admin(role: felt252) -> felt252;

--- a/docs/modules/ROOT/pages/accounts.adoc
+++ b/docs/modules/ROOT/pages/accounts.adoc
@@ -36,7 +36,8 @@ struct Call {
 }
 
 /// Standard Account Interface
-trait ISRC6 {
+#[starknet::interface]
+pub trait ISRC6 {
     /// Executes a transaction through the account.
     fn __execute__(calls: Array<Call>) -> Array<Span<felt252>>;
 
@@ -47,6 +48,9 @@ trait ISRC6 {
     fn is_valid_signature(hash: felt252, signature: Array<felt252>) -> felt252;
 }
 ----
+
+WARNING: The `calldata` member of the `Call` struct in the accounts has been updated to `Span<felt252>` for optimization
+purposes, but the interface Id remains the same for backwards compatiblity. This inconsistency will be fixed in future releases.
 
 {snip-6}[SNIP-6] adds the `is_valid_signature` method. This method is not used by the protocol, but it's useful for
 DApps to verify the validity of signatures, supporting features like Sign In with Starknet.
@@ -59,7 +63,8 @@ a mechanism for detecting whether a contract is an account or not through intros
 [,cairo]
 ----
 /// Standard Interface Detection
-trait ISRC5 {
+#[starknet::interface]
+pub trait ISRC5 {
     /// Queries if a contract implements a given interface.
     fn supports_interface(interface_id: felt252) -> bool;
 }
@@ -148,7 +153,8 @@ This is the full interface of the `AccountMixinImpl` implementation:
 
 [,cairo]
 ----
-trait AccountABI {
+#[starknet::interface]
+pub trait AccountABI {
     // ISRC6
     fn __execute__(calls: Array<Call>) -> Array<Span<felt252>>;
     fn __validate__(calls: Array<Call>) -> felt252;
@@ -241,7 +247,8 @@ This is the full interface of the `EthAccountMixinImpl` implementation:
 
 [,cairo]
 ----
-trait EthAccountABI {
+#[starknet::interface]
+pub trait EthAccountABI {
     // ISRC6
     fn __execute__(calls: Array<Call>) -> Array<Span<felt252>>;
     fn __validate__(calls: Array<Call>) -> felt252;

--- a/docs/modules/ROOT/pages/components.adoc
+++ b/docs/modules/ROOT/pages/components.adoc
@@ -400,7 +400,7 @@ mod ERC20Pausable {
     (...)
 
     // Custom ERC20 implementation
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl CustomERC20Impl of IERC20<ContractState> {
         fn transfer(
             ref self: ContractState, recipient: ContractAddress, amount: u256
@@ -422,7 +422,7 @@ mod ERC20Pausable {
     }
 
     // Custom ERC20CamelOnly implementation
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl CustomERC20CamelOnlyImpl of IERC20CamelOnly<ContractState> {
         fn totalSupply(self: @ContractState) -> u256 {
             self.erc20.total_supply()

--- a/docs/modules/ROOT/pages/erc1155.adoc
+++ b/docs/modules/ROOT/pages/erc1155.adoc
@@ -95,7 +95,8 @@ To support older token deployments, as mentioned in {dual-interfaces}, the compo
 
 [,cairo]
 ----
-trait ERC1155ABI {
+#[starknet::interface]
+pub trait ERC1155ABI {
     // IERC1155
     fn balance_of(account: ContractAddress, token_id: u256) -> u256;
     fn balance_of_batch(
@@ -189,7 +190,8 @@ The recipient contract must also implement the {src5} interface which supports i
 
 [,cairo]
 ----
-trait IERC1155Receiver {
+#[starknet::interface]
+pub trait IERC1155Receiver {
     fn on_erc1155_received(
         operator: ContractAddress,
         from: ContractAddress,

--- a/docs/modules/ROOT/pages/erc20.adoc
+++ b/docs/modules/ROOT/pages/erc20.adoc
@@ -83,7 +83,8 @@ To support older token deployments, as mentioned in {dual-interfaces}, the compo
 
 [,cairo]
 ----
-trait ERC20ABI {
+#[starknet::interface]
+pub trait ERC20ABI {
     // IERC20
     fn total_supply() -> u256;
     fn balance_of(account: ContractAddress) -> u256;
@@ -147,7 +148,7 @@ For example:
 
 [,cairo]
 ----
-#[external(v0)]
+#[abi(embed_v0)]
 impl ERC20MetadataImpl of interface::IERC20Metadata<ContractState> {
     fn decimals(self: @ContractState) -> u8 {
         // Change the `3` below to the desired number of decimals
@@ -213,7 +214,7 @@ mod MyToken {
         self.erc20.mint(recipient, initial_supply);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ERC20MetadataImpl of interface::IERC20Metadata<ContractState> {
         fn name(self: @ContractState) -> ByteArray {
             self.erc20.name()

--- a/docs/modules/ROOT/pages/erc721.adoc
+++ b/docs/modules/ROOT/pages/erc721.adoc
@@ -78,7 +78,8 @@ To support older token deployments, as mentioned in {dual-interfaces}, the compo
 
 [,cairo]
 ----
-trait ERC721ABI {
+#[starknet::interface]
+pub trait ERC721ABI {
     // IERC721
     fn balance_of(account: ContractAddress) -> u256;
     fn owner_of(token_id: u256) -> ContractAddress;
@@ -167,7 +168,8 @@ The recipient contract must also implement the {src5} interface which, as descri
 
 [,cairo]
 ----
-trait IERC721Receiver {
+#[starknet::interface]
+pub trait IERC721Receiver {
     fn on_erc721_received(
         operator: ContractAddress,
         from: ContractAddress,

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -20,8 +20,8 @@ before proceeding, and run the following command to check that the installation 
 ----
 $ scarb --version
 
-scarb 2.6.3 (e6f921dfd 2024-03-13)
-cairo: 2.6.3 (https://crates.io/crates/cairo-lang-compiler/2.6.3)
+scarb 2.6.5 (d49f54394 2024-06-11)
+cairo: 2.6.4 (https://crates.io/crates/cairo-lang-compiler/2.6.4)
 sierra: 1.5.0
 ----
 

--- a/docs/modules/ROOT/pages/interfaces.adoc
+++ b/docs/modules/ROOT/pages/interfaces.adoc
@@ -28,7 +28,7 @@ This includes only the functions defined in the interface, and is the standard w
 
 ```cairo
 #[starknet::interface]
-trait IERC20<TState> {
+pub trait IERC20<TState> {
     fn total_supply(self: @TState) -> u256;
     fn balance_of(self: @TState, account: ContractAddress) -> u256;
     fn allowance(self: @TState, owner: ContractAddress, spender: ContractAddress) -> u256;
@@ -46,7 +46,7 @@ They describe a contract's complete interface. This is useful to interface with 
 
 ```cairo
 #[starknet::interface]
-trait ERC20ABI<TState> {
+pub trait ERC20ABI<TState> {
     // IERC20
     fn total_supply(self: @TState) -> u256;
     fn balance_of(self: @TState, account: ContractAddress) -> u256;
@@ -76,11 +76,11 @@ This is a utility trait to interface with contracts whose interface is unknown. 
 
 ```cairo
 #[derive(Copy, Drop)]
-struct DualCaseERC20 {
+pub struct DualCaseERC20 {
     contract_address: ContractAddress
 }
 
-trait DualCaseERC20Trait {
+pub trait DualCaseERC20Trait {
     fn name(self: @DualCaseERC20) -> ByteArray;
     fn symbol(self: @DualCaseERC20) -> ByteArray;
     fn decimals(self: @DualCaseERC20) -> u8;
@@ -114,7 +114,7 @@ The default version of the ERC20 interface trait exposes `snake_case` functions:
 
 ```cairo
 #[starknet::interface]
-trait IERC20<TState> {
+pub trait IERC20<TState> {
     fn name(self: @TState) -> ByteArray;
     fn symbol(self: @TState) -> ByteArray;
     fn decimals(self: @TState) -> u8;
@@ -135,7 +135,7 @@ On top of that, we also offer a `camelCase` version of the same interface:
 
 ```cairo
 #[starknet::interface]
-trait IERC20Camel<TState> {
+pub trait IERC20Camel<TState> {
     fn name(self: @TState) -> ByteArray;
     fn symbol(self: @TState) -> ByteArray;
     fn decimals(self: @TState) -> u8;

--- a/docs/modules/ROOT/pages/introspection.adoc
+++ b/docs/modules/ROOT/pages/introspection.adoc
@@ -58,7 +58,8 @@ mod MyContract {
 
 [,cairo]
 ----
-trait ISRC5 {
+#[starknet::interface]
+pub trait ISRC5 {
     /// Query if a contract implements an interface.
     /// Receives the interface identifier as specified in SRC-5.
     /// Returns `true` if the contract implements `interface_id`, `false` otherwise.

--- a/docs/modules/ROOT/pages/security.adoc
+++ b/docs/modules/ROOT/pages/security.adoc
@@ -56,7 +56,8 @@ The component provides the following external functions as part of the `Initiali
 
 [,cairo]
 ----
-trait InitializableABI {
+#[starknet::interface]
+pub trait InitializableABI {
     fn is_initialized() -> bool;
 }
 ----
@@ -152,7 +153,8 @@ The component provides the following external functions as part of the `Pausable
 
 [,cairo]
 ----
-trait PausableABI {
+#[starknet::interface]
+pub trait PausableABI {
     fn is_paused() -> bool;
 }
 ----

--- a/docs/modules/ROOT/pages/udc.adoc
+++ b/docs/modules/ROOT/pages/udc.adoc
@@ -20,7 +20,8 @@ The UDC address is deployed at address `0x04a64cd09a853868621d94cae9952b106f2c36
 
 [,cairo]
 ----
-trait IUniversalDeployer {
+#[starknet::interface]
+pub trait IUniversalDeployer {
     fn deploy_contract(
         class_hash: ClassHash,
         salt: felt252,

--- a/docs/modules/ROOT/pages/upgrades.adoc
+++ b/docs/modules/ROOT/pages/upgrades.adoc
@@ -90,7 +90,7 @@ mod UpgradeableContract {
         self.ownable.initializer(owner);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl UpgradeableImpl of IUpgradeable<ContractState> {
         fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
             // This function can only be called by the owner

--- a/src/account.cairo
+++ b/src/account.cairo
@@ -7,3 +7,71 @@ pub mod utils;
 
 pub use account::AccountComponent;
 pub use eth_account::EthAccountComponent;
+#[starknet::contract]
+mod ERC20Upgradeable {
+    use openzeppelin::access::ownable::OwnableComponent;
+    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin::upgrades::UpgradeableComponent;
+    use openzeppelin::upgrades::interface::IUpgradeable;
+    use starknet::{ContractAddress, ClassHash};
+
+    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: ERC20Component, storage: erc20, event: ERC20Event);
+    component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
+
+    // Ownable Mixin
+    #[abi(embed_v0)]
+    impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
+    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+
+    // ERC20 Mixin
+    #[abi(embed_v0)]
+    impl ERC20MixinImpl = ERC20Component::ERC20MixinImpl<ContractState>;
+    impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
+
+    // Upgradeable
+    impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        ownable: OwnableComponent::Storage,
+        #[substorage(v0)]
+        erc20: ERC20Component::Storage,
+        #[substorage(v0)]
+        upgradeable: UpgradeableComponent::Storage
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
+        #[flat]
+        ERC20Event: ERC20Component::Event,
+        #[flat]
+        UpgradeableEvent: UpgradeableComponent::Event
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        name: ByteArray,
+        symbol: ByteArray,
+        fixed_supply: u256,
+        recipient: ContractAddress,
+        owner: ContractAddress
+    ) {
+        self.ownable.initializer(owner);
+        self.erc20.initializer(name, symbol);
+        self.erc20.mint(recipient, fixed_supply);
+    }
+
+    #[abi(embed_v0)]
+    impl UpgradeableImpl of IUpgradeable<ContractState> {
+        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            self.ownable.assert_only_owner();
+            self.upgradeable.upgrade(new_class_hash);
+        }
+    }
+}


### PR DESCRIPTION
This PR bumps scarb to 2.6.5 (Cairo 2.6.4) with the Option serialization bugfix, and is also fixing some code examples in the docsite.