### PR TITLE
Refactor Eth Account tests

### DIFF
--- a/src/tests/account/ethereum/common.cairo
+++ b/src/tests/account/ethereum/common.cairo
@@ -19,8 +19,8 @@ use starknet::{ContractAddress, SyscallResultTrait};
 
 #[derive(Drop)]
 pub(crate) struct SignedTransactionData {
-    pub(crate) private_key: u256,
-    pub(crate) public_key: EthPublicKey,
+    // pub(crate) private_key: u256,
+    // pub(crate) public_key: EthPublicKey,
     pub(crate) tx_hash: felt252,
     pub(crate) signature: EthSignature
 }
@@ -28,11 +28,9 @@ pub(crate) struct SignedTransactionData {
 pub(crate) fn SIGNED_TX_DATA(key_pair: Secp256k1KeyPair) -> SignedTransactionData {
     let tx_hash = TRANSACTION_HASH;
     let (r, s) = key_pair.sign(tx_hash.into()).unwrap();
-    SignedTransactionData {
-        private_key: key_pair.secret_key,
-        public_key: key_pair.public_key,
-        tx_hash,
-        signature: EthSignature { r, s }
+    SignedTransactionData { // private_key: key_pair.secret_key,
+        // public_key: key_pair.public_key,
+        tx_hash, signature: EthSignature { r, s }
     }
 }
 

--- a/src/tests/account/ethereum/test_dual_eth_account.cairo
+++ b/src/tests/account/ethereum/test_dual_eth_account.cairo
@@ -5,9 +5,9 @@ use openzeppelin::account::utils::secp256k1::{
 };
 use openzeppelin::account::utils::signature::EthSignature;
 use openzeppelin::introspection::interface::ISRC5_ID;
-use openzeppelin::tests::utils::constants::secp256k1::KEY_PAIR;
-use openzeppelin::tests::utils::constants::{ETH_PUBKEY, NEW_ETH_PUBKEY, TRANSACTION_HASH};
-use openzeppelin::tests::utils::signing::Secp256k1KeyPairExt;
+use openzeppelin::tests::utils::constants::secp256k1::{KEY_PAIR, KEY_PAIR_2};
+use openzeppelin::tests::utils::constants::{TRANSACTION_HASH};
+use openzeppelin::tests::utils::signing::{Secp256k1KeyPair, Secp256k1KeyPairExt};
 use openzeppelin::tests::utils;
 use openzeppelin::utils::serde::SerializedAppend;
 use snforge_std::start_cheat_caller_address;
@@ -18,32 +18,26 @@ use super::common::get_accept_ownership_signature;
 // Setup
 //
 
-fn setup_snake() -> (DualCaseEthAccount, EthAccountABIDispatcher) {
+fn setup_snake(key_pair: Secp256k1KeyPair) -> (DualCaseEthAccount, EthAccountABIDispatcher) {
     let mut calldata = array![];
-    calldata.append_serde(ETH_PUBKEY());
+    calldata.append_serde(key_pair.public_key);
 
-    let target = utils::declare_and_deploy("SnakeEthAccountMock", calldata);
-    (
-        DualCaseEthAccount { contract_address: target },
-        EthAccountABIDispatcher { contract_address: target }
-    )
+    let contract_address = utils::declare_and_deploy("SnakeEthAccountMock", calldata);
+    (DualCaseEthAccount { contract_address }, EthAccountABIDispatcher { contract_address })
 }
 
-fn setup_camel() -> (DualCaseEthAccount, EthAccountABIDispatcher) {
+fn setup_camel(key_pair: Secp256k1KeyPair) -> (DualCaseEthAccount, EthAccountABIDispatcher) {
     let mut calldata = array![];
-    calldata.append_serde(ETH_PUBKEY());
+    calldata.append_serde(key_pair.public_key);
 
-    let target = utils::declare_and_deploy("CamelEthAccountMock", calldata);
-    (
-        DualCaseEthAccount { contract_address: target },
-        EthAccountABIDispatcher { contract_address: target }
-    )
+    let contract_address = utils::declare_and_deploy("CamelEthAccountMock", calldata);
+    (DualCaseEthAccount { contract_address }, EthAccountABIDispatcher { contract_address })
 }
 
 fn setup_non_account() -> DualCaseEthAccount {
     let calldata = array![];
-    let target = utils::declare_and_deploy("NonImplementingMock", calldata);
-    DualCaseEthAccount { contract_address: target }
+    let contract_address = utils::declare_and_deploy("NonImplementingMock", calldata);
+    DualCaseEthAccount { contract_address }
 }
 
 fn setup_account_panic() -> (DualCaseEthAccount, DualCaseEthAccount) {
@@ -61,13 +55,14 @@ fn setup_account_panic() -> (DualCaseEthAccount, DualCaseEthAccount) {
 
 #[test]
 fn test_dual_set_public_key() {
-    let (snake_dispatcher, target) = setup_snake();
+    let key_pair = KEY_PAIR();
+    let (snake_dispatcher, target) = setup_snake(key_pair);
     let contract_address = snake_dispatcher.contract_address;
 
     start_cheat_caller_address(contract_address, contract_address);
 
     let key_pair = KEY_PAIR();
-    let signature = get_accept_ownership_signature(contract_address, ETH_PUBKEY(), key_pair);
+    let signature = get_accept_ownership_signature(contract_address, key_pair.public_key, key_pair);
 
     snake_dispatcher.set_public_key(key_pair.public_key, signature);
     assert_eq!(target.get_public_key(), key_pair.public_key);
@@ -78,20 +73,21 @@ fn test_dual_set_public_key() {
 #[should_panic(expected: ('ENTRYPOINT_NOT_FOUND',))]
 fn test_dual_no_set_public_key() {
     let dispatcher = setup_non_account();
-    dispatcher.set_public_key(NEW_ETH_PUBKEY(), array![].span());
+    dispatcher.set_public_key(KEY_PAIR().public_key, array![].span());
 }
 
 #[test]
 #[should_panic(expected: ("Some error",))]
 fn test_dual_set_public_key_exists_and_panics() {
     let (dispatcher, _) = setup_account_panic();
-    dispatcher.set_public_key(NEW_ETH_PUBKEY(), array![].span());
+    dispatcher.set_public_key(KEY_PAIR().public_key, array![].span());
 }
 
 #[test]
 fn test_dual_get_public_key() {
-    let (snake_dispatcher, _) = setup_snake();
-    assert_eq!(snake_dispatcher.get_public_key(), ETH_PUBKEY());
+    let key_pair = KEY_PAIR();
+    let (snake_dispatcher, _) = setup_snake(key_pair);
+    assert_eq!(snake_dispatcher.get_public_key(), key_pair.public_key);
 }
 
 #[test]
@@ -111,15 +107,18 @@ fn test_dual_get_public_key_exists_and_panics() {
 
 #[test]
 fn test_dual_is_valid_signature() {
-    let (snake_dispatcher, target) = setup_snake();
+    let key_pair = KEY_PAIR();
+    let (snake_dispatcher, target) = setup_snake(key_pair);
     let contract_address = snake_dispatcher.contract_address;
 
     start_cheat_caller_address(contract_address, contract_address);
-    let key_pair = KEY_PAIR();
-    let signature = get_accept_ownership_signature(contract_address, ETH_PUBKEY(), key_pair);
+    let new_key_pair = KEY_PAIR_2();
+    let signature = get_accept_ownership_signature(
+        contract_address, key_pair.public_key, new_key_pair
+    );
 
-    target.set_public_key(key_pair.public_key, signature);
-    let serialized_signature = key_pair.serialized_sign(TRANSACTION_HASH.into());
+    target.set_public_key(new_key_pair.public_key, signature);
+    let serialized_signature = new_key_pair.serialized_sign(TRANSACTION_HASH.into());
 
     let is_valid = snake_dispatcher.is_valid_signature(TRANSACTION_HASH, serialized_signature);
     assert_eq!(is_valid, starknet::VALIDATED);
@@ -148,7 +147,7 @@ fn test_dual_is_valid_signature_exists_and_panics() {
 
 #[test]
 fn test_dual_supports_interface() {
-    let (snake_dispatcher, _) = setup_snake();
+    let (snake_dispatcher, _) = setup_snake(KEY_PAIR());
     assert!(snake_dispatcher.supports_interface(ISRC5_ID), "Should implement ISRC5");
 }
 
@@ -174,13 +173,16 @@ fn test_dual_supports_interface_exists_and_panics() {
 #[test]
 #[ignore] // REASON: foundry entrypoint_not_found error message inconsistent with mainnet.
 fn test_dual_setPublicKey() {
-    let (camel_dispatcher, target) = setup_camel();
+    let key_pair = KEY_PAIR();
+    let (camel_dispatcher, target) = setup_camel(key_pair);
     let contract_address = camel_dispatcher.contract_address;
 
     start_cheat_caller_address(contract_address, contract_address);
 
-    let key_pair = KEY_PAIR();
-    let signature = get_accept_ownership_signature(contract_address, ETH_PUBKEY(), key_pair);
+    let new_key_pair = KEY_PAIR_2();
+    let signature = get_accept_ownership_signature(
+        contract_address, key_pair.public_key, new_key_pair
+    );
 
     camel_dispatcher.set_public_key(key_pair.public_key, signature);
     assert_eq!(target.getPublicKey(), key_pair.public_key);
@@ -191,14 +193,15 @@ fn test_dual_setPublicKey() {
 #[should_panic(expected: ("Some error",))]
 fn test_dual_setPublicKey_exists_and_panics() {
     let (_, dispatcher) = setup_account_panic();
-    dispatcher.set_public_key(NEW_ETH_PUBKEY(), array![].span());
+    dispatcher.set_public_key(KEY_PAIR().public_key, array![].span());
 }
 
 #[test]
 #[ignore] // REASON: foundry entrypoint_not_found error message inconsistent with mainnet.
 fn test_dual_getPublicKey() {
-    let (camel_dispatcher, _) = setup_camel();
-    assert_eq!(camel_dispatcher.get_public_key(), ETH_PUBKEY());
+    let key_pair = KEY_PAIR();
+    let (camel_dispatcher, _) = setup_camel(key_pair);
+    assert_eq!(camel_dispatcher.get_public_key(), key_pair.public_key);
 }
 
 #[test]
@@ -212,16 +215,19 @@ fn test_dual_getPublicKey_exists_and_panics() {
 #[test]
 #[ignore] // REASON: foundry entrypoint_not_found error message inconsistent with mainnet.
 fn test_dual_isValidSignature() {
-    let (camel_dispatcher, target) = setup_camel();
+    let key_pair = KEY_PAIR();
+    let (camel_dispatcher, target) = setup_camel(key_pair);
     let contract_address = camel_dispatcher.contract_address;
 
     start_cheat_caller_address(contract_address, contract_address);
 
-    let key_pair = KEY_PAIR();
-    let signature = get_accept_ownership_signature(contract_address, ETH_PUBKEY(), key_pair);
+    let new_key_pair = KEY_PAIR();
+    let signature = get_accept_ownership_signature(
+        contract_address, key_pair.public_key, new_key_pair
+    );
 
-    target.setPublicKey(key_pair.public_key, signature);
-    let serialized_signature = key_pair.serialized_sign(TRANSACTION_HASH.into());
+    target.setPublicKey(new_key_pair.public_key, signature);
+    let serialized_signature = new_key_pair.serialized_sign(TRANSACTION_HASH.into());
 
     let is_valid = camel_dispatcher.is_valid_signature(TRANSACTION_HASH, serialized_signature);
     assert_eq!(is_valid, starknet::VALIDATED);

--- a/src/tests/account/starknet/test_account.cairo
+++ b/src/tests/account/starknet/test_account.cairo
@@ -290,7 +290,7 @@ fn test_multicall() {
     let recipient1 = RECIPIENT();
     let recipient2 = OTHER();
 
-    // Craft call1
+    // Craft 1st call
     let mut calldata1 = array![];
     let amount1: u256 = 300;
     calldata1.append_serde(recipient1);
@@ -299,7 +299,7 @@ fn test_multicall() {
         to: erc20.contract_address, selector: selectors::transfer, calldata: calldata1.span()
     };
 
-    // Craft call2
+    // Craft 2nd call1_serialized_retval
     let mut calldata2 = array![];
     let amount2: u256 = 500;
     calldata2.append_serde(recipient2);

--- a/src/tests/account/test_signature.cairo
+++ b/src/tests/account/test_signature.cairo
@@ -46,20 +46,22 @@ fn test_is_valid_stark_signature_invalid_len_sig() {
 
 #[test]
 fn test_is_valid_eth_signature_good_sig() {
-    let data = eth_signature_data(secp256k1::KEY_PAIR());
+    let key_pair = secp256k1::KEY_PAIR();
+    let data = eth_signature_data(key_pair);
 
     let mut serialized_good_signature = array![];
     data.signature.serialize(ref serialized_good_signature);
 
     let is_valid = is_valid_eth_signature(
-        data.tx_hash, data.public_key, serialized_good_signature.span()
+        data.tx_hash, key_pair.public_key, serialized_good_signature.span()
     );
     assert!(is_valid);
 }
 
 #[test]
 fn test_is_valid_eth_signature_bad_sig() {
-    let data = eth_signature_data(secp256k1::KEY_PAIR());
+    let key_pair = secp256k1::KEY_PAIR();
+    let data = eth_signature_data(key_pair);
     let mut bad_signature = data.signature;
 
     bad_signature.r += 1;
@@ -69,7 +71,7 @@ fn test_is_valid_eth_signature_bad_sig() {
     bad_signature.serialize(ref serialized_bad_signature);
 
     let is_invalid = !is_valid_eth_signature(
-        data.tx_hash, data.public_key, serialized_bad_signature.span()
+        data.tx_hash, key_pair.public_key, serialized_bad_signature.span()
     );
     assert!(is_invalid);
 }
@@ -77,15 +79,17 @@ fn test_is_valid_eth_signature_bad_sig() {
 #[test]
 #[should_panic(expected: ('Signature: Invalid format.',))]
 fn test_is_valid_eth_signature_invalid_format_sig() {
-    let data = eth_signature_data(secp256k1::KEY_PAIR());
+    let key_pair = secp256k1::KEY_PAIR();
+    let data = eth_signature_data(key_pair);
     let mut serialized_bad_signature = array![0x1];
 
-    is_valid_eth_signature(data.tx_hash, data.public_key, serialized_bad_signature.span());
+    is_valid_eth_signature(data.tx_hash, key_pair.public_key, serialized_bad_signature.span());
 }
 
 #[test]
 fn test_signature_r_out_of_range() {
-    let data = eth_signature_data(secp256k1::KEY_PAIR());
+    let key_pair = secp256k1::KEY_PAIR();
+    let data = eth_signature_data(key_pair);
     let mut bad_signature = data.signature;
 
     let curve_size = Secp256Trait::<Secp256k1Point>::get_curve_size();
@@ -97,14 +101,15 @@ fn test_signature_r_out_of_range() {
     bad_signature.serialize(ref serialized_bad_signature);
 
     let is_invalid = !is_valid_eth_signature(
-        data.tx_hash, data.public_key, serialized_bad_signature.span()
+        data.tx_hash, key_pair.public_key, serialized_bad_signature.span()
     );
     assert!(is_invalid);
 }
 
 #[test]
 fn test_signature_s_out_of_range() {
-    let data = eth_signature_data(secp256k1::KEY_PAIR());
+    let key_pair = secp256k1::KEY_PAIR();
+    let data = eth_signature_data(key_pair);
     let mut bad_signature = data.signature;
 
     let curve_size = Secp256Trait::<Secp256k1Point>::get_curve_size();
@@ -116,7 +121,7 @@ fn test_signature_s_out_of_range() {
     bad_signature.serialize(ref serialized_bad_signature);
 
     let is_invalid = !is_valid_eth_signature(
-        data.tx_hash, data.public_key, serialized_bad_signature.span()
+        data.tx_hash, key_pair.public_key, serialized_bad_signature.span()
     );
     assert!(is_invalid);
 }

--- a/src/tests/presets/test_account.cairo
+++ b/src/tests/presets/test_account.cairo
@@ -434,9 +434,8 @@ fn test_multicall() {
     let erc20 = deploy_erc20(account.contract_address, 1000);
     let recipient1 = RECIPIENT();
     let recipient2 = OTHER();
-    let mut calls = array![];
 
-    // Craft call1
+    // Craft 1st call
     let mut calldata1 = array![];
     let amount1: u256 = 300;
     calldata1.append_serde(recipient1);
@@ -445,7 +444,7 @@ fn test_multicall() {
         to: erc20.contract_address, selector: selectors::transfer, calldata: calldata1.span()
     };
 
-    // Craft call2
+    // Craft 2nd call
     let mut calldata2 = array![];
     let amount2: u256 = 500;
     calldata2.append_serde(recipient2);
@@ -455,8 +454,7 @@ fn test_multicall() {
     };
 
     // Bundle calls and execute
-    calls.append(call1);
-    calls.append(call2);
+    let calls = array![call1, call2];
     let ret = account.__execute__(calls);
 
     // Assert that the transfers were successful

--- a/src/tests/utils/constants.cairo
+++ b/src/tests/utils/constants.cairo
@@ -17,8 +17,6 @@ pub(crate) const TOKEN_ID_2: u256 = 121;
 pub(crate) const TOKEN_VALUE: u256 = 42;
 pub(crate) const TOKEN_VALUE_2: u256 = 142;
 pub(crate) const PUBKEY: felt252 = 'PUBKEY';
-pub(crate) const NEW_PUBKEY: felt252 =
-    0x26da8d11938b76025862be14fdb8b28438827f73e75e86f7bfa38b196951fa7;
 pub(crate) const DAPP_NAME: felt252 = 'DAPP_NAME';
 pub(crate) const DAPP_VERSION: felt252 = 'DAPP_VERSION';
 pub(crate) const SALT: felt252 = 'SALT';
@@ -45,14 +43,6 @@ pub(crate) fn BASE_URI() -> ByteArray {
 
 pub(crate) fn BASE_URI_2() -> ByteArray {
     "https://api.example.com/v2/"
-}
-
-pub(crate) fn ETH_PUBKEY() -> EthPublicKey {
-    Secp256Trait::secp256_ec_get_point_from_x_syscall(3, false).unwrap_syscall().unwrap()
-}
-
-pub(crate) fn NEW_ETH_PUBKEY() -> EthPublicKey {
-    Secp256Trait::secp256_ec_get_point_from_x_syscall(4, false).unwrap_syscall().unwrap()
 }
 
 pub(crate) fn ADMIN() -> ContractAddress {


### PR DESCRIPTION
- Refactor Eth Account tests to use Key Pairs as setup parameters
- Removed usage of ETH_PUB_KEY and NEW_ETH_PUB_KEY constants

Resolves #1075 