### PR TITLE
Bump scarb to 2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump snforge to v0.27.0 (#1107)
+- Bump scarb to v2.7.1 (#1025)
+- Bump scarb to v2.8.0 (#1120)
 
 ### Changed (Breaking)
 
 - Changed ABI suffix to Trait in dual case account and eth account modules (#1096).
   - `DualCaseAccountABI` renamed to `DualCaseAccountTrait`
   - `DualCaseEthAccountABI` renamed to `DualCaseEthAccountTrait`
-- Bump scarb to v2.7.1 (#1025)
+
 
 ## 0.15.1 (2024-08-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `DualCaseAccountABI` renamed to `DualCaseAccountTrait`
   - `DualCaseEthAccountABI` renamed to `DualCaseEthAccountTrait`
 
-
 ## 0.15.1 (2024-08-13)
 
 ### Changed

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -21,8 +21,8 @@ version.workspace = true
 [workspace.package]
 version = "0.15.1"
 edition = "2023_11"
-cairo-version = "2.7.1"
-scarb-version = "2.7.1"
+cairo-version = "2.8.0"
+scarb-version = "2.8.0"
 authors = ["OpenZeppelin Community <maintainers@openzeppelin.org>"]
 description = "OpenZeppelin Contracts written in Cairo for Starknet, a decentralized ZK Rollup"
 documentation = "https://docs.openzeppelin.com/contracts-cairo"
@@ -39,7 +39,7 @@ keywords = [
 ]
 
 [workspace.dependencies]
-starknet = "2.7.1"
+starknet = "2.8.0"
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.27.0" }
 
 [dependencies]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -21,8 +21,8 @@ before proceeding, and run the following command to check that the installation 
 ----
 $ scarb --version
 
-scarb 2.7.1 (e288874ba 2024-08-13)
-cairo: 2.7.1 (https://crates.io/crates/cairo-lang-compiler/2.7.1)
+scarb 2.8.0 (09590f5fc 2024-08-27)
+cairo: 2.8.0 (https://crates.io/crates/cairo-lang-compiler/2.8.0)
 sierra: 1.6.0
 ----
 

--- a/packages/access/src/accesscontrol/accesscontrol.cairo
+++ b/packages/access/src/accesscontrol/accesscontrol.cairo
@@ -7,7 +7,7 @@
 /// Roles are referred to by their `felt252` identifier.
 #[starknet::component]
 pub mod AccessControlComponent {
-    use openzeppelin_access::accesscontrol::interface;
+    use crate::accesscontrol::interface;
     use openzeppelin_introspection::src5::SRC5Component::InternalImpl as SRC5InternalImpl;
     use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
     use openzeppelin_introspection::src5::SRC5Component;

--- a/packages/access/src/ownable/ownable.cairo
+++ b/packages/access/src/ownable/ownable.cairo
@@ -16,8 +16,8 @@
 #[starknet::component]
 pub mod OwnableComponent {
     use core::num::traits::Zero;
-    use openzeppelin_access::ownable::interface::IOwnableTwoStep;
-    use openzeppelin_access::ownable::interface;
+    use crate::ownable::interface::IOwnableTwoStep;
+    use crate::ownable::interface;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
 

--- a/packages/access/src/tests/mocks/accesscontrol_mocks.cairo
+++ b/packages/access/src/tests/mocks/accesscontrol_mocks.cairo
@@ -1,7 +1,7 @@
 #[starknet::contract]
 pub(crate) mod DualCaseAccessControlMock {
-    use openzeppelin_access::accesscontrol::AccessControlComponent;
-    use openzeppelin_access::accesscontrol::DEFAULT_ADMIN_ROLE;
+    use crate::accesscontrol::AccessControlComponent;
+    use crate::accesscontrol::DEFAULT_ADMIN_ROLE;
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
 
@@ -40,8 +40,8 @@ pub(crate) mod DualCaseAccessControlMock {
 
 #[starknet::contract]
 pub(crate) mod SnakeAccessControlMock {
-    use openzeppelin_access::accesscontrol::AccessControlComponent;
-    use openzeppelin_access::accesscontrol::DEFAULT_ADMIN_ROLE;
+    use crate::accesscontrol::AccessControlComponent;
+    use crate::accesscontrol::DEFAULT_ADMIN_ROLE;
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
 
@@ -84,8 +84,8 @@ pub(crate) mod SnakeAccessControlMock {
 
 #[starknet::contract]
 pub(crate) mod CamelAccessControlMock {
-    use openzeppelin_access::accesscontrol::AccessControlComponent;
-    use openzeppelin_access::accesscontrol::DEFAULT_ADMIN_ROLE;
+    use crate::accesscontrol::AccessControlComponent;
+    use crate::accesscontrol::DEFAULT_ADMIN_ROLE;
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
 

--- a/packages/access/src/tests/mocks/ownable_mocks.cairo
+++ b/packages/access/src/tests/mocks/ownable_mocks.cairo
@@ -1,6 +1,6 @@
 #[starknet::contract]
 pub(crate) mod DualCaseOwnableMock {
-    use openzeppelin_access::ownable::OwnableComponent;
+    use crate::ownable::OwnableComponent;
     use starknet::ContractAddress;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
@@ -30,7 +30,7 @@ pub(crate) mod DualCaseOwnableMock {
 
 #[starknet::contract]
 pub(crate) mod SnakeOwnableMock {
-    use openzeppelin_access::ownable::OwnableComponent;
+    use crate::ownable::OwnableComponent;
     use starknet::ContractAddress;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
@@ -60,7 +60,7 @@ pub(crate) mod SnakeOwnableMock {
 
 #[starknet::contract]
 pub(crate) mod CamelOwnableMock {
-    use openzeppelin_access::ownable::OwnableComponent;
+    use crate::ownable::OwnableComponent;
     use starknet::ContractAddress;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
@@ -158,7 +158,7 @@ pub(crate) mod CamelOwnablePanicMock {
 
 #[starknet::contract]
 pub(crate) mod DualCaseTwoStepOwnableMock {
-    use openzeppelin_access::ownable::OwnableComponent;
+    use crate::ownable::OwnableComponent;
     use starknet::ContractAddress;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);

--- a/packages/access/src/tests/test_accesscontrol.cairo
+++ b/packages/access/src/tests/test_accesscontrol.cairo
@@ -1,11 +1,9 @@
-use openzeppelin_access::accesscontrol::AccessControlComponent::{
+use crate::accesscontrol::AccessControlComponent::{
     InternalImpl, RoleAdminChanged, RoleGranted, RoleRevoked
 };
-use openzeppelin_access::accesscontrol::interface::{
-    IAccessControl, IAccessControlCamel, IACCESSCONTROL_ID
-};
-use openzeppelin_access::accesscontrol::{AccessControlComponent, DEFAULT_ADMIN_ROLE};
-use openzeppelin_access::tests::mocks::accesscontrol_mocks::DualCaseAccessControlMock;
+use crate::accesscontrol::interface::{IAccessControl, IAccessControlCamel, IACCESSCONTROL_ID};
+use crate::accesscontrol::{AccessControlComponent, DEFAULT_ADMIN_ROLE};
+use crate::tests::mocks::accesscontrol_mocks::DualCaseAccessControlMock;
 use openzeppelin_introspection::interface::ISRC5;
 use openzeppelin_testing::constants::{
     ADMIN, AUTHORIZED, OTHER, OTHER_ADMIN, ROLE, OTHER_ROLE, ZERO

--- a/packages/access/src/tests/test_dual_accesscontrol.cairo
+++ b/packages/access/src/tests/test_dual_accesscontrol.cairo
@@ -1,12 +1,10 @@
-use openzeppelin_access::accesscontrol::DEFAULT_ADMIN_ROLE;
-use openzeppelin_access::accesscontrol::dual_accesscontrol::DualCaseAccessControl;
-use openzeppelin_access::accesscontrol::dual_accesscontrol::DualCaseAccessControlTrait;
-use openzeppelin_access::accesscontrol::interface::{
+use crate::accesscontrol::DEFAULT_ADMIN_ROLE;
+use crate::accesscontrol::dual_accesscontrol::DualCaseAccessControl;
+use crate::accesscontrol::dual_accesscontrol::DualCaseAccessControlTrait;
+use crate::accesscontrol::interface::{
     IACCESSCONTROL_ID, IAccessControlCamelDispatcher, IAccessControlCamelDispatcherTrait
 };
-use openzeppelin_access::accesscontrol::interface::{
-    IAccessControlDispatcher, IAccessControlDispatcherTrait
-};
+use crate::accesscontrol::interface::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::{ADMIN, AUTHORIZED, ROLE};
 use openzeppelin_utils::serde::SerializedAppend;

--- a/packages/access/src/tests/test_dual_ownable.cairo
+++ b/packages/access/src/tests/test_dual_ownable.cairo
@@ -1,6 +1,6 @@
 use core::num::traits::Zero;
-use openzeppelin_access::ownable::dual_ownable::{DualCaseOwnable, DualCaseOwnableTrait};
-use openzeppelin_access::ownable::interface::{
+use crate::ownable::dual_ownable::{DualCaseOwnable, DualCaseOwnableTrait};
+use crate::ownable::interface::{
     IOwnableDispatcher, IOwnableCamelOnlyDispatcher, IOwnableDispatcherTrait
 };
 use openzeppelin_testing as utils;

--- a/packages/access/src/tests/test_ownable.cairo
+++ b/packages/access/src/tests/test_ownable.cairo
@@ -1,8 +1,8 @@
 use core::num::traits::Zero;
-use openzeppelin_access::ownable::OwnableComponent::InternalTrait;
-use openzeppelin_access::ownable::OwnableComponent;
-use openzeppelin_access::ownable::interface::{IOwnable, IOwnableCamelOnly};
-use openzeppelin_access::tests::mocks::ownable_mocks::DualCaseOwnableMock;
+use crate::ownable::OwnableComponent::InternalTrait;
+use crate::ownable::OwnableComponent;
+use crate::ownable::interface::{IOwnable, IOwnableCamelOnly};
+use crate::tests::mocks::ownable_mocks::DualCaseOwnableMock;
 
 use openzeppelin_test_common::ownable::OwnableSpyHelpers;
 use openzeppelin_testing::constants::{ZERO, OTHER, OWNER};

--- a/packages/access/src/tests/test_ownable_twostep.cairo
+++ b/packages/access/src/tests/test_ownable_twostep.cairo
@@ -1,8 +1,8 @@
 use core::num::traits::Zero;
-use openzeppelin_access::ownable::OwnableComponent::{InternalTrait, OwnershipTransferStarted};
-use openzeppelin_access::ownable::OwnableComponent;
-use openzeppelin_access::ownable::interface::{IOwnableTwoStep, IOwnableTwoStepCamelOnly};
-use openzeppelin_access::tests::mocks::ownable_mocks::DualCaseTwoStepOwnableMock;
+use crate::ownable::OwnableComponent::{InternalTrait, OwnershipTransferStarted};
+use crate::ownable::OwnableComponent;
+use crate::ownable::interface::{IOwnableTwoStep, IOwnableTwoStepCamelOnly};
+use crate::tests::mocks::ownable_mocks::DualCaseTwoStepOwnableMock;
 use openzeppelin_test_common::ownable::OwnableSpyHelpers;
 use openzeppelin_testing::constants::{ZERO, OWNER, OTHER, NEW_OWNER};
 use openzeppelin_testing::events::EventSpyExt;

--- a/packages/account/src/account.cairo
+++ b/packages/account/src/account.cairo
@@ -9,9 +9,9 @@ pub mod AccountComponent {
     use core::hash::{HashStateExTrait, HashStateTrait};
     use core::num::traits::Zero;
     use core::poseidon::PoseidonTrait;
-    use openzeppelin_account::interface;
-    use openzeppelin_account::utils::{MIN_TRANSACTION_VERSION, QUERY_OFFSET};
-    use openzeppelin_account::utils::{execute_calls, is_valid_stark_signature};
+    use crate::interface;
+    use crate::utils::{MIN_TRANSACTION_VERSION, QUERY_OFFSET};
+    use crate::utils::{execute_calls, is_valid_stark_signature};
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
     use openzeppelin_introspection::src5::SRC5Component;

--- a/packages/account/src/dual_eth_account.cairo
+++ b/packages/account/src/dual_eth_account.cairo
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts for Cairo v0.15.1 (account/dual_eth_account.cairo)
 
-use openzeppelin_account::interface::EthPublicKey;
+use crate::interface::EthPublicKey;
 use openzeppelin_utils::UnwrapAndCast;
 use openzeppelin_utils::selectors;
 use openzeppelin_utils::serde::SerializedAppend;

--- a/packages/account/src/eth_account.cairo
+++ b/packages/account/src/eth_account.cairo
@@ -10,11 +10,11 @@ pub mod EthAccountComponent {
     use core::num::traits::Zero;
     use core::poseidon::{PoseidonTrait, poseidon_hash_span};
     use core::starknet::secp256_trait::Secp256PointTrait;
-    use openzeppelin_account::interface::EthPublicKey;
-    use openzeppelin_account::interface;
-    use openzeppelin_account::utils::secp256k1::Secp256k1PointStorePacking;
-    use openzeppelin_account::utils::{MIN_TRANSACTION_VERSION, QUERY_OFFSET};
-    use openzeppelin_account::utils::{execute_calls, is_valid_eth_signature};
+    use crate::interface::EthPublicKey;
+    use crate::interface;
+    use crate::utils::secp256k1::Secp256k1PointStorePacking;
+    use crate::utils::{MIN_TRANSACTION_VERSION, QUERY_OFFSET};
+    use crate::utils::{execute_calls, is_valid_eth_signature};
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
     use openzeppelin_introspection::src5::SRC5Component;

--- a/packages/account/src/tests/mocks/account_mocks.cairo
+++ b/packages/account/src/tests/mocks/account_mocks.cairo
@@ -1,6 +1,6 @@
 #[starknet::contract(account)]
 pub(crate) mod DualCaseAccountMock {
-    use openzeppelin_account::AccountComponent;
+    use crate::AccountComponent;
     use openzeppelin_introspection::src5::SRC5Component;
 
     component!(path: AccountComponent, storage: account, event: AccountEvent);
@@ -46,7 +46,7 @@ pub(crate) mod DualCaseAccountMock {
 
 #[starknet::contract(account)]
 pub(crate) mod SnakeAccountMock {
-    use openzeppelin_account::AccountComponent;
+    use crate::AccountComponent;
     use openzeppelin_introspection::src5::SRC5Component;
 
     component!(path: AccountComponent, storage: account, event: AccountEvent);
@@ -88,7 +88,7 @@ pub(crate) mod SnakeAccountMock {
 
 #[starknet::contract(account)]
 pub(crate) mod CamelAccountMock {
-    use openzeppelin_account::AccountComponent;
+    use crate::AccountComponent;
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::account::Call;
 

--- a/packages/account/src/tests/mocks/eth_account_mocks.cairo
+++ b/packages/account/src/tests/mocks/eth_account_mocks.cairo
@@ -1,7 +1,7 @@
 #[starknet::contract(account)]
 pub(crate) mod DualCaseEthAccountMock {
-    use openzeppelin_account::EthAccountComponent;
-    use openzeppelin_account::interface::EthPublicKey;
+    use crate::EthAccountComponent;
+    use crate::interface::EthPublicKey;
     use openzeppelin_introspection::src5::SRC5Component;
 
     component!(path: EthAccountComponent, storage: eth_account, event: EthAccountEvent);
@@ -44,8 +44,8 @@ pub(crate) mod DualCaseEthAccountMock {
 
 #[starknet::contract(account)]
 pub(crate) mod SnakeEthAccountMock {
-    use openzeppelin_account::EthAccountComponent;
-    use openzeppelin_account::interface::EthPublicKey;
+    use crate::EthAccountComponent;
+    use crate::interface::EthPublicKey;
     use openzeppelin_introspection::src5::SRC5Component;
 
     component!(path: EthAccountComponent, storage: eth_account, event: EthAccountEvent);
@@ -84,8 +84,8 @@ pub(crate) mod SnakeEthAccountMock {
 
 #[starknet::contract(account)]
 pub(crate) mod CamelEthAccountMock {
-    use openzeppelin_account::EthAccountComponent;
-    use openzeppelin_account::interface::EthPublicKey;
+    use crate::EthAccountComponent;
+    use crate::interface::EthPublicKey;
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::account::Call;
 
@@ -147,7 +147,7 @@ pub(crate) mod CamelEthAccountMock {
 
 #[starknet::contract]
 pub(crate) mod SnakeEthAccountPanicMock {
-    use openzeppelin_account::interface::EthPublicKey;
+    use crate::interface::EthPublicKey;
     use starknet::SyscallResultTrait;
     use starknet::secp256_trait::Secp256Trait;
 
@@ -188,7 +188,7 @@ pub(crate) mod SnakeEthAccountPanicMock {
 
 #[starknet::contract]
 pub(crate) mod CamelEthAccountPanicMock {
-    use openzeppelin_account::interface::EthPublicKey;
+    use crate::interface::EthPublicKey;
     use starknet::SyscallResultTrait;
     use starknet::secp256_trait::Secp256Trait;
 

--- a/packages/account/src/tests/test_account.cairo
+++ b/packages/account/src/tests/test_account.cairo
@@ -1,25 +1,21 @@
 use core::num::traits::Zero;
 use core::starknet::SyscallResultTrait;
-use openzeppelin_account::AccountComponent::{InternalTrait, SRC6CamelOnlyImpl};
-use openzeppelin_account::AccountComponent::{PublicKeyCamelImpl, PublicKeyImpl};
-use openzeppelin_account::AccountComponent;
-use openzeppelin_account::interface::{AccountABIDispatcherTrait, AccountABIDispatcher};
-use openzeppelin_account::interface::{ISRC6, ISRC6_ID};
-use openzeppelin_account::tests::mocks::account_mocks::DualCaseAccountMock;
-use openzeppelin_account::tests::mocks::simple_mock::SimpleMock;
-use openzeppelin_account::tests::mocks::simple_mock::{
-    ISimpleMockDispatcher, ISimpleMockDispatcherTrait
-};
+use crate::AccountComponent::{InternalTrait, SRC6CamelOnlyImpl};
+use crate::AccountComponent::{PublicKeyCamelImpl, PublicKeyImpl};
+use crate::AccountComponent;
+use crate::interface::{AccountABIDispatcherTrait, AccountABIDispatcher};
+use crate::interface::{ISRC6, ISRC6_ID};
+use crate::tests::mocks::account_mocks::DualCaseAccountMock;
+use crate::tests::mocks::simple_mock::{ISimpleMockDispatcher, ISimpleMockDispatcherTrait};
 use openzeppelin_introspection::interface::{ISRC5, ISRC5_ID};
 use openzeppelin_test_common::account::{AccountSpyHelpers, SignedTransactionData};
 use openzeppelin_test_common::account::{SIGNED_TX_DATA, get_accept_ownership_signature};
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::stark::{KEY_PAIR, KEY_PAIR_2};
 use openzeppelin_testing::constants::{
-    SALT, ZERO, OTHER, CALLER, RECIPIENT, QUERY_OFFSET, QUERY_VERSION, MIN_TRANSACTION_VERSION
+    SALT, ZERO, OTHER, CALLER, QUERY_OFFSET, QUERY_VERSION, MIN_TRANSACTION_VERSION
 };
 use openzeppelin_testing::signing::StarkKeyPair;
-use openzeppelin_utils::selectors;
 use snforge_std::{
     start_cheat_signature_global, start_cheat_transaction_version_global,
     start_cheat_transaction_hash_global

--- a/packages/account/src/tests/test_dual_account.cairo
+++ b/packages/account/src/tests/test_dual_account.cairo
@@ -1,5 +1,5 @@
-use openzeppelin_account::dual_account::{DualCaseAccountTrait, DualCaseAccount};
-use openzeppelin_account::interface::{AccountABIDispatcherTrait, AccountABIDispatcher};
+use crate::dual_account::{DualCaseAccountTrait, DualCaseAccount};
+use crate::interface::{AccountABIDispatcherTrait, AccountABIDispatcher};
 use openzeppelin_introspection::interface::ISRC5_ID;
 
 use openzeppelin_test_common::account::{get_accept_ownership_signature};

--- a/packages/account/src/tests/test_dual_eth_account.cairo
+++ b/packages/account/src/tests/test_dual_eth_account.cairo
@@ -1,6 +1,6 @@
-use openzeppelin_account::dual_eth_account::{DualCaseEthAccountTrait, DualCaseEthAccount};
-use openzeppelin_account::interface::{EthAccountABIDispatcherTrait, EthAccountABIDispatcher};
-use openzeppelin_account::utils::secp256k1::{DebugSecp256k1Point, Secp256k1PointPartialEq};
+use crate::dual_eth_account::{DualCaseEthAccountTrait, DualCaseEthAccount};
+use crate::interface::{EthAccountABIDispatcherTrait, EthAccountABIDispatcher};
+use crate::utils::secp256k1::{DebugSecp256k1Point, Secp256k1PointPartialEq};
 use openzeppelin_introspection::interface::ISRC5_ID;
 
 use openzeppelin_test_common::eth_account::get_accept_ownership_signature;

--- a/packages/account/src/tests/test_eth_account.cairo
+++ b/packages/account/src/tests/test_eth_account.cairo
@@ -1,15 +1,12 @@
-use openzeppelin_account::EthAccountComponent::{InternalTrait, SRC6CamelOnlyImpl};
-use openzeppelin_account::EthAccountComponent::{PublicKeyCamelImpl, PublicKeyImpl};
-use openzeppelin_account::EthAccountComponent;
-use openzeppelin_account::interface::{EthAccountABIDispatcherTrait, EthAccountABIDispatcher};
-use openzeppelin_account::interface::{ISRC6, ISRC6_ID};
-use openzeppelin_account::tests::mocks::eth_account_mocks::DualCaseEthAccountMock;
-use openzeppelin_account::tests::mocks::simple_mock::SimpleMock;
-use openzeppelin_account::tests::mocks::simple_mock::{
-    ISimpleMockDispatcher, ISimpleMockDispatcherTrait
-};
-use openzeppelin_account::utils::secp256k1::{DebugSecp256k1Point, Secp256k1PointPartialEq};
-use openzeppelin_account::utils::signature::EthSignature;
+use crate::EthAccountComponent::{InternalTrait, SRC6CamelOnlyImpl};
+use crate::EthAccountComponent::{PublicKeyCamelImpl, PublicKeyImpl};
+use crate::EthAccountComponent;
+use crate::interface::{EthAccountABIDispatcherTrait, EthAccountABIDispatcher};
+use crate::interface::{ISRC6, ISRC6_ID};
+use crate::tests::mocks::eth_account_mocks::DualCaseEthAccountMock;
+use crate::tests::mocks::simple_mock::{ISimpleMockDispatcher, ISimpleMockDispatcherTrait};
+use crate::utils::secp256k1::{DebugSecp256k1Point, Secp256k1PointPartialEq};
+use crate::utils::signature::EthSignature;
 use openzeppelin_introspection::interface::{ISRC5, ISRC5_ID};
 use openzeppelin_test_common::eth_account::EthAccountSpyHelpers;
 use openzeppelin_test_common::eth_account::{
@@ -18,10 +15,9 @@ use openzeppelin_test_common::eth_account::{
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::secp256k1::{KEY_PAIR, KEY_PAIR_2};
 use openzeppelin_testing::constants::{
-    SALT, ZERO, OTHER, RECIPIENT, CALLER, QUERY_VERSION, MIN_TRANSACTION_VERSION
+    SALT, ZERO, OTHER, CALLER, QUERY_VERSION, MIN_TRANSACTION_VERSION
 };
 use openzeppelin_testing::signing::Secp256k1KeyPair;
-use openzeppelin_utils::selectors;
 use openzeppelin_utils::serde::SerializedAppend;
 use snforge_std::{
     start_cheat_signature_global, start_cheat_transaction_version_global,

--- a/packages/account/src/tests/test_secp256k1.cairo
+++ b/packages/account/src/tests/test_secp256k1.cairo
@@ -1,4 +1,4 @@
-use openzeppelin_account::utils::secp256k1::{
+use crate::utils::secp256k1::{
     DebugSecp256k1Point, Secp256k1PointPartialEq, Secp256k1PointStorePacking as StorePacking
 };
 use starknet::SyscallResultTrait;

--- a/packages/account/src/tests/test_signature.cairo
+++ b/packages/account/src/tests/test_signature.cairo
@@ -1,4 +1,4 @@
-use openzeppelin_account::utils::signature::{is_valid_stark_signature, is_valid_eth_signature};
+use crate::utils::signature::{is_valid_stark_signature, is_valid_eth_signature};
 use openzeppelin_test_common::account::SIGNED_TX_DATA as stark_signature_data;
 use openzeppelin_test_common::eth_account::SIGNED_TX_DATA as eth_signature_data;
 use openzeppelin_testing::constants::{stark, secp256k1};

--- a/packages/account/src/utils/signature.cairo
+++ b/packages/account/src/utils/signature.cairo
@@ -2,7 +2,7 @@
 // OpenZeppelin Contracts for Cairo v0.15.1 (account/utils/signature.cairo)
 
 use core::ecdsa::check_ecdsa_signature;
-use openzeppelin_account::interface::EthPublicKey;
+use crate::interface::EthPublicKey;
 use starknet::secp256_trait;
 
 #[derive(Copy, Drop, Serde)]

--- a/packages/governance/src/tests/mocks/timelock_mocks.cairo
+++ b/packages/governance/src/tests/mocks/timelock_mocks.cairo
@@ -1,7 +1,7 @@
 #[starknet::contract]
 pub(crate) mod TimelockControllerMock {
+    use crate::timelock::TimelockControllerComponent;
     use openzeppelin_access::accesscontrol::AccessControlComponent;
-    use openzeppelin_governance::timelock::TimelockControllerComponent;
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
 
@@ -88,9 +88,7 @@ pub(crate) trait ITimelockAttacker<TState> {
 
 #[starknet::contract]
 pub(crate) mod TimelockAttackerMock {
-    use openzeppelin_governance::timelock::interface::{
-        ITimelockDispatcher, ITimelockDispatcherTrait
-    };
+    use crate::timelock::interface::{ITimelockDispatcher, ITimelockDispatcherTrait};
     use starknet::account::Call;
     use super::ITimelockAttacker;
 

--- a/packages/governance/src/tests/test_timelock.cairo
+++ b/packages/governance/src/tests/test_timelock.cairo
@@ -1,28 +1,24 @@
 use core::hash::{HashStateTrait, HashStateExTrait};
 use core::pedersen::PedersenTrait;
+use crate::tests::mocks::timelock_mocks::{IMockContractDispatcher, IMockContractDispatcherTrait};
+use crate::tests::mocks::timelock_mocks::{ITimelockAttackerDispatcher};
+use crate::tests::mocks::timelock_mocks::{TimelockControllerMock};
+use crate::timelock::OperationState;
+use crate::timelock::TimelockControllerComponent::{
+    CallScheduled, CallExecuted, CallSalt, CallCancelled, MinDelayChanged
+};
+use crate::timelock::TimelockControllerComponent::{
+    TimelockImpl, InternalImpl as TimelockInternalImpl
+};
+use crate::timelock::TimelockControllerComponent;
+use crate::timelock::interface::{TimelockABIDispatcher, TimelockABIDispatcherTrait};
+use crate::timelock::{PROPOSER_ROLE, EXECUTOR_ROLE, CANCELLER_ROLE};
 use openzeppelin_access::accesscontrol::AccessControlComponent::{
     AccessControlImpl, InternalImpl as AccessControlInternalImpl
 };
 use openzeppelin_access::accesscontrol::DEFAULT_ADMIN_ROLE;
 use openzeppelin_access::accesscontrol::interface::IACCESSCONTROL_ID;
 use openzeppelin_access::accesscontrol::interface::IAccessControl;
-use openzeppelin_governance::tests::mocks::timelock_mocks::{
-    IMockContractDispatcher, IMockContractDispatcherTrait
-};
-use openzeppelin_governance::tests::mocks::timelock_mocks::{ITimelockAttackerDispatcher};
-use openzeppelin_governance::tests::mocks::timelock_mocks::{TimelockControllerMock};
-use openzeppelin_governance::timelock::OperationState;
-use openzeppelin_governance::timelock::TimelockControllerComponent::{
-    CallScheduled, CallExecuted, CallSalt, CallCancelled, MinDelayChanged
-};
-use openzeppelin_governance::timelock::TimelockControllerComponent::{
-    TimelockImpl, InternalImpl as TimelockInternalImpl
-};
-use openzeppelin_governance::timelock::TimelockControllerComponent;
-use openzeppelin_governance::timelock::interface::{
-    TimelockABIDispatcher, TimelockABIDispatcherTrait
-};
-use openzeppelin_governance::timelock::{PROPOSER_ROLE, EXECUTOR_ROLE, CANCELLER_ROLE};
 use openzeppelin_introspection::interface::ISRC5_ID;
 use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
 use openzeppelin_testing as utils;

--- a/packages/governance/src/tests/test_utils.cairo
+++ b/packages/governance/src/tests/test_utils.cairo
@@ -1,4 +1,4 @@
-use openzeppelin_governance::timelock::utils::call_impls::CallPartialEq;
+use crate::timelock::utils::call_impls::CallPartialEq;
 use starknet::account::Call;
 use starknet::contract_address_const;
 

--- a/packages/governance/src/timelock/interface.cairo
+++ b/packages/governance/src/timelock/interface.cairo
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts for Cairo v0.15.1 (governance/timelock/interface.cairo)
 
-use openzeppelin_governance::timelock::OperationState;
+use crate::timelock::OperationState;
 use starknet::ContractAddress;
 use starknet::account::Call;
 

--- a/packages/governance/src/timelock/timelock_controller.cairo
+++ b/packages/governance/src/timelock/timelock_controller.cairo
@@ -17,16 +17,14 @@ pub mod TimelockControllerComponent {
     use core::hash::{HashStateTrait, HashStateExTrait};
     use core::num::traits::Zero;
     use core::pedersen::PedersenTrait;
+    use crate::timelock::interface::{ITimelock, TimelockABI};
+    use crate::timelock::utils::call_impls::{HashCallImpl, HashCallsImpl, CallPartialEq};
     use openzeppelin_access::accesscontrol::AccessControlComponent::InternalTrait as AccessControlInternalTrait;
     use openzeppelin_access::accesscontrol::AccessControlComponent::{
         AccessControlImpl, AccessControlCamelImpl
     };
     use openzeppelin_access::accesscontrol::AccessControlComponent;
     use openzeppelin_access::accesscontrol::DEFAULT_ADMIN_ROLE;
-    use openzeppelin_governance::timelock::interface::{ITimelock, TimelockABI};
-    use openzeppelin_governance::timelock::utils::call_impls::{
-        HashCallImpl, HashCallsImpl, CallPartialEq
-    };
     use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;

--- a/packages/introspection/src/src5.cairo
+++ b/packages/introspection/src/src5.cairo
@@ -6,7 +6,7 @@
 /// The SRC5 component allows contracts to expose the interfaces they implement.
 #[starknet::component]
 pub mod SRC5Component {
-    use openzeppelin_introspection::interface;
+    use crate::interface;
     use starknet::storage::Map;
 
     #[storage]

--- a/packages/introspection/src/tests/mocks/src5_mocks.cairo
+++ b/packages/introspection/src/tests/mocks/src5_mocks.cairo
@@ -1,6 +1,6 @@
 #[starknet::contract]
 pub(crate) mod SRC5Mock {
-    use openzeppelin_introspection::src5::SRC5Component;
+    use crate::src5::SRC5Component;
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 

--- a/packages/introspection/src/tests/test_src5.cairo
+++ b/packages/introspection/src/tests/test_src5.cairo
@@ -1,7 +1,7 @@
-use openzeppelin_introspection::interface::{ISRC5_ID, ISRC5};
-use openzeppelin_introspection::src5::SRC5Component::InternalTrait;
-use openzeppelin_introspection::src5::SRC5Component;
-use openzeppelin_introspection::tests::mocks::src5_mocks::SRC5Mock;
+use crate::interface::{ISRC5_ID, ISRC5};
+use crate::src5::SRC5Component::InternalTrait;
+use crate::src5::SRC5Component;
+use crate::tests::mocks::src5_mocks::SRC5Mock;
 
 const OTHER_ID: felt252 = 0x12345678;
 

--- a/packages/merkle_tree/src/hashes.cairo
+++ b/packages/merkle_tree/src/hashes.cairo
@@ -46,23 +46,8 @@ pub impl PoseidonCHasher of CommutativeHasher {
 
 impl Felt252AsIntPartialOrd of PartialOrd<felt252> {
     #[inline(always)]
-    fn le(lhs: felt252, rhs: felt252) -> bool {
-        let lhs: u256 = lhs.into();
-        lhs <= rhs.into()
-    }
-    #[inline(always)]
-    fn ge(lhs: felt252, rhs: felt252) -> bool {
-        let lhs: u256 = lhs.into();
-        lhs >= rhs.into()
-    }
-    #[inline(always)]
     fn lt(lhs: felt252, rhs: felt252) -> bool {
         let lhs: u256 = lhs.into();
         lhs < rhs.into()
-    }
-    #[inline(always)]
-    fn gt(lhs: felt252, rhs: felt252) -> bool {
-        let lhs: u256 = lhs.into();
-        lhs > rhs.into()
     }
 }

--- a/packages/merkle_tree/src/merkle_proof.cairo
+++ b/packages/merkle_tree/src/merkle_proof.cairo
@@ -13,7 +13,7 @@
 /// leaf inclusion in trees built using non-commutative hashing functions requires
 /// additional logic that is not supported by this library.
 
-use openzeppelin_merkle_tree::hashes::{CommutativeHasher, PedersenCHasher, PoseidonCHasher};
+use crate::hashes::{CommutativeHasher, PedersenCHasher, PoseidonCHasher};
 
 /// Returns true if a `leaf` can be proved to be a part of a Merkle tree
 /// defined by `root`. For this, a `proof` must be provided, containing
@@ -98,38 +98,37 @@ pub fn process_multi_proof<impl Hasher: CommutativeHasher>(
     let mut leaf_pos = 0;
     let mut hash_pos = 0;
     let mut proof_pos = 0;
-    let mut i = 0;
 
     // At each step, we compute the next hash using two values:
     // - a value from the "main queue". If not all leaves have been consumed, we get the next leaf,
     // otherwise we get the next hash.
     // - depending on the flag, either another value from the "main queue" (merging branches) or an
     // element from the `proof` array.
-    while i < proof_flags_len {
-        let a = if leaf_pos < leaves_len {
-            leaf_pos += 1;
-            leaves.at(leaf_pos - 1)
-        } else {
-            hash_pos += 1;
-            hashes.at(hash_pos - 1)
-        };
-
-        let b = if *proof_flags.at(i) {
-            if leaf_pos < leaves_len {
+    for i in 0
+        ..proof_flags_len {
+            let a = if leaf_pos < leaves_len {
                 leaf_pos += 1;
                 leaves.at(leaf_pos - 1)
             } else {
                 hash_pos += 1;
                 hashes.at(hash_pos - 1)
-            }
-        } else {
-            proof_pos += 1;
-            proof.at(proof_pos - 1)
-        };
+            };
 
-        hashes.append(Hasher::commutative_hash(*a, *b));
-        i += 1;
-    };
+            let b = if *proof_flags.at(i) {
+                if leaf_pos < leaves_len {
+                    leaf_pos += 1;
+                    leaves.at(leaf_pos - 1)
+                } else {
+                    hash_pos += 1;
+                    hashes.at(hash_pos - 1)
+                }
+            } else {
+                proof_pos += 1;
+                proof.at(proof_pos - 1)
+            };
+
+            hashes.append(Hasher::commutative_hash(*a, *b));
+        };
 
     let root = if proof_flags_len > 0 {
         hashes.at(proof_flags_len - 1)

--- a/packages/merkle_tree/src/tests/merkle_proof/test_with_pedersen.cairo
+++ b/packages/merkle_tree/src/tests/merkle_proof/test_with_pedersen.cairo
@@ -1,10 +1,9 @@
 use core::hash::{HashStateTrait, HashStateExTrait};
 use core::pedersen::{PedersenTrait, pedersen};
-use openzeppelin_merkle_tree::hashes::PedersenCHasher;
-use openzeppelin_merkle_tree::merkle_proof::{
+use crate::hashes::PedersenCHasher;
+use crate::merkle_proof::{
     process_proof, process_multi_proof, verify, verify_multi_proof, verify_pedersen
 };
-use starknet::{ContractAddress, contract_address_const};
 use super::common::{Leaf, LEAVES};
 
 // `ROOT`, `PROOF`, and `MULTI_PROOF` were computed using @ericnordelo/strk-merkle-tree

--- a/packages/merkle_tree/src/tests/merkle_proof/test_with_poseidon.cairo
+++ b/packages/merkle_tree/src/tests/merkle_proof/test_with_poseidon.cairo
@@ -1,6 +1,6 @@
 use core::poseidon::poseidon_hash_span;
-use openzeppelin_merkle_tree::hashes::PoseidonCHasher;
-use openzeppelin_merkle_tree::merkle_proof::{
+use crate::hashes::PoseidonCHasher;
+use crate::merkle_proof::{
     process_proof, process_multi_proof, verify, verify_multi_proof, verify_poseidon
 };
 use super::common::{Leaf, LEAVES};

--- a/packages/merkle_tree/src/tests/merkle_proof/test_with_poseidon.cairo
+++ b/packages/merkle_tree/src/tests/merkle_proof/test_with_poseidon.cairo
@@ -3,7 +3,6 @@ use openzeppelin_merkle_tree::hashes::PoseidonCHasher;
 use openzeppelin_merkle_tree::merkle_proof::{
     process_proof, process_multi_proof, verify, verify_multi_proof, verify_poseidon
 };
-use starknet::{ContractAddress, contract_address_const};
 use super::common::{Leaf, LEAVES};
 
 // `ROOT`, `PROOF`, and `MULTI_PROOF` were computed using @ericnordelo/strk-merkle-tree

--- a/packages/merkle_tree/src/tests/test_hashes.cairo
+++ b/packages/merkle_tree/src/tests/test_hashes.cairo
@@ -1,7 +1,7 @@
 use core::hash::HashStateTrait;
 use core::pedersen::PedersenTrait;
 use core::poseidon::poseidon_hash_span;
-use openzeppelin_merkle_tree::hashes::{PedersenCHasher, PoseidonCHasher};
+use crate::hashes::{PedersenCHasher, PoseidonCHasher};
 
 #[test]
 fn test_pedersen_commutative_hash_is_commutative() {

--- a/packages/presets/src/interfaces/account.cairo
+++ b/packages/presets/src/interfaces/account.cairo
@@ -1,5 +1,5 @@
+use starknet::ClassHash;
 use starknet::account::Call;
-use starknet::{ClassHash};
 
 #[starknet::interface]
 pub trait AccountUpgradeableABI<TState> {

--- a/packages/presets/src/interfaces/eth_account.cairo
+++ b/packages/presets/src/interfaces/eth_account.cairo
@@ -1,6 +1,6 @@
 use openzeppelin_account::interface::EthPublicKey;
+use starknet::ClassHash;
 use starknet::account::Call;
-use starknet::{ClassHash};
 
 #[starknet::interface]
 pub trait EthAccountUpgradeableABI<TState> {

--- a/packages/presets/src/tests/test_account.cairo
+++ b/packages/presets/src/tests/test_account.cairo
@@ -1,13 +1,11 @@
 use core::num::traits::Zero;
-use openzeppelin_account::interface::ISRC6_ID;
-use openzeppelin_introspection::interface::ISRC5_ID;
-use openzeppelin_presets::AccountUpgradeable;
-use openzeppelin_presets::interfaces::account::{
+use crate::AccountUpgradeable;
+use crate::interfaces::account::{
     AccountUpgradeableABISafeDispatcher, AccountUpgradeableABISafeDispatcherTrait
 };
-use openzeppelin_presets::interfaces::{
-    AccountUpgradeableABIDispatcher, AccountUpgradeableABIDispatcherTrait
-};
+use crate::interfaces::{AccountUpgradeableABIDispatcher, AccountUpgradeableABIDispatcherTrait};
+use openzeppelin_account::interface::ISRC6_ID;
+use openzeppelin_introspection::interface::ISRC5_ID;
 use openzeppelin_test_common::account::{
     SIGNED_TX_DATA, get_accept_ownership_signature, SignedTransactionData, AccountSpyHelpers
 };

--- a/packages/presets/src/tests/test_erc1155.cairo
+++ b/packages/presets/src/tests/test_erc1155.cairo
@@ -1,7 +1,5 @@
 use core::num::traits::Zero;
-use openzeppelin_presets::interfaces::{
-    ERC1155UpgradeableABIDispatcher, ERC1155UpgradeableABIDispatcherTrait
-};
+use crate::interfaces::{ERC1155UpgradeableABIDispatcher, ERC1155UpgradeableABIDispatcherTrait};
 use openzeppelin_test_common::erc1155::ERC1155SpyHelpers;
 use openzeppelin_test_common::erc1155::{
     setup_account, setup_receiver, setup_camel_receiver, deploy_another_account_at, setup_src5

--- a/packages/presets/src/tests/test_erc20.cairo
+++ b/packages/presets/src/tests/test_erc20.cairo
@@ -1,11 +1,9 @@
 use core::num::traits::Bounded;
 use core::num::traits::Zero;
-use openzeppelin_presets::interfaces::erc20::{
+use crate::interfaces::erc20::{
     ERC20UpgradeableABISafeDispatcher, ERC20UpgradeableABISafeDispatcherTrait
 };
-use openzeppelin_presets::interfaces::{
-    ERC20UpgradeableABIDispatcher, ERC20UpgradeableABIDispatcherTrait
-};
+use crate::interfaces::{ERC20UpgradeableABIDispatcher, ERC20UpgradeableABIDispatcherTrait};
 use openzeppelin_test_common::erc20::ERC20SpyHelpers;
 use openzeppelin_test_common::ownable::OwnableSpyHelpers;
 use openzeppelin_test_common::upgrades::UpgradeableSpyHelpers;

--- a/packages/presets/src/tests/test_erc721.cairo
+++ b/packages/presets/src/tests/test_erc721.cairo
@@ -1,10 +1,8 @@
 use core::num::traits::Zero;
+use crate::ERC721Upgradeable::InternalImpl;
+use crate::ERC721Upgradeable;
+use crate::interfaces::{ERC721UpgradeableABIDispatcher, ERC721UpgradeableABIDispatcherTrait};
 use openzeppelin_introspection::interface::ISRC5_ID;
-use openzeppelin_presets::ERC721Upgradeable::InternalImpl;
-use openzeppelin_presets::ERC721Upgradeable;
-use openzeppelin_presets::interfaces::{
-    ERC721UpgradeableABIDispatcher, ERC721UpgradeableABIDispatcherTrait
-};
 use openzeppelin_test_common::erc721::ERC721SpyHelpers;
 use openzeppelin_test_common::ownable::OwnableSpyHelpers;
 use openzeppelin_test_common::upgrades::UpgradeableSpyHelpers;

--- a/packages/presets/src/tests/test_eth_account.cairo
+++ b/packages/presets/src/tests/test_eth_account.cairo
@@ -1,14 +1,14 @@
 use core::num::traits::Zero;
+use crate::EthAccountUpgradeable;
+use crate::interfaces::eth_account::{
+    EthAccountUpgradeableABISafeDispatcher, EthAccountUpgradeableABISafeDispatcherTrait
+};
+use crate::interfaces::{
+    EthAccountUpgradeableABIDispatcher, EthAccountUpgradeableABIDispatcherTrait
+};
 use openzeppelin_account::interface::ISRC6_ID;
 use openzeppelin_account::utils::secp256k1::{DebugSecp256k1Point, Secp256k1PointPartialEq};
 use openzeppelin_introspection::interface::ISRC5_ID;
-use openzeppelin_presets::EthAccountUpgradeable;
-use openzeppelin_presets::interfaces::eth_account::{
-    EthAccountUpgradeableABISafeDispatcher, EthAccountUpgradeableABISafeDispatcherTrait
-};
-use openzeppelin_presets::interfaces::{
-    EthAccountUpgradeableABIDispatcher, EthAccountUpgradeableABIDispatcherTrait
-};
 use openzeppelin_test_common::erc20::deploy_erc20;
 use openzeppelin_test_common::eth_account::EthAccountSpyHelpers;
 use openzeppelin_test_common::eth_account::{
@@ -31,7 +31,6 @@ use snforge_std::{spy_events, test_address};
 use starknet::ClassHash;
 use starknet::SyscallResultTrait;
 use starknet::account::Call;
-use starknet::contract_address_const;
 use starknet::secp256_trait::Secp256Trait;
 use starknet::secp256k1::Secp256k1Point;
 

--- a/packages/presets/src/tests/test_universal_deployer.cairo
+++ b/packages/presets/src/tests/test_universal_deployer.cairo
@@ -1,5 +1,5 @@
-use openzeppelin_presets::universal_deployer::UniversalDeployer::ContractDeployed;
-use openzeppelin_presets::universal_deployer::UniversalDeployer;
+use crate::universal_deployer::UniversalDeployer::ContractDeployed;
+use crate::universal_deployer::UniversalDeployer;
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::{NAME, SYMBOL, SUPPLY, SALT, CALLER, RECIPIENT};
 use openzeppelin_testing::events::EventSpyExt;

--- a/packages/security/src/initializable.cairo
+++ b/packages/security/src/initializable.cairo
@@ -8,7 +8,7 @@
 /// initial state in scenarios where a constructor cannot be used.
 #[starknet::component]
 pub mod InitializableComponent {
-    use openzeppelin_security::interface::IInitializable;
+    use crate::interface::IInitializable;
 
     #[storage]
     struct Storage {

--- a/packages/security/src/pausable.cairo
+++ b/packages/security/src/pausable.cairo
@@ -8,7 +8,7 @@
 /// or `assert_not_paused` will be affected by this mechanism.
 #[starknet::component]
 pub mod PausableComponent {
-    use openzeppelin_security::interface::IPausable;
+    use crate::interface::IPausable;
 
     use starknet::ContractAddress;
     use starknet::get_caller_address;

--- a/packages/security/src/tests/mocks/initializable_mocks.cairo
+++ b/packages/security/src/tests/mocks/initializable_mocks.cairo
@@ -1,6 +1,6 @@
 #[starknet::contract]
 pub(crate) mod InitializableMock {
-    use openzeppelin_security::initializable::InitializableComponent;
+    use crate::initializable::InitializableComponent;
 
     component!(path: InitializableComponent, storage: initializable, event: InitializableEvent);
 

--- a/packages/security/src/tests/mocks/pausable_mocks.cairo
+++ b/packages/security/src/tests/mocks/pausable_mocks.cairo
@@ -1,6 +1,6 @@
 #[starknet::contract]
 pub(crate) mod PausableMock {
-    use openzeppelin_security::pausable::PausableComponent;
+    use crate::pausable::PausableComponent;
 
     component!(path: PausableComponent, storage: pausable, event: PausableEvent);
 

--- a/packages/security/src/tests/mocks/reentrancy_mocks.cairo
+++ b/packages/security/src/tests/mocks/reentrancy_mocks.cairo
@@ -17,7 +17,7 @@ pub(crate) trait IReentrancyMock<TState> {
 
 #[starknet::contract]
 pub(crate) mod ReentrancyMock {
-    use openzeppelin_security::reentrancyguard::ReentrancyGuardComponent;
+    use crate::reentrancyguard::ReentrancyGuardComponent;
     use starknet::ContractAddress;
     use starknet::get_contract_address;
     use super::IAttackerDispatcher;

--- a/packages/security/src/tests/test_initializable.cairo
+++ b/packages/security/src/tests/test_initializable.cairo
@@ -1,6 +1,6 @@
-use openzeppelin_security::InitializableComponent::{InitializableImpl, InternalImpl};
-use openzeppelin_security::InitializableComponent;
-use openzeppelin_security::tests::mocks::initializable_mocks::InitializableMock;
+use crate::InitializableComponent::{InitializableImpl, InternalImpl};
+use crate::InitializableComponent;
+use crate::tests::mocks::initializable_mocks::InitializableMock;
 
 type ComponentState = InitializableComponent::ComponentState<InitializableMock::ContractState>;
 

--- a/packages/security/src/tests/test_pausable.cairo
+++ b/packages/security/src/tests/test_pausable.cairo
@@ -1,7 +1,7 @@
-use openzeppelin_security::PausableComponent::{InternalImpl, PausableImpl};
-use openzeppelin_security::PausableComponent::{Paused, Unpaused};
-use openzeppelin_security::PausableComponent;
-use openzeppelin_security::tests::mocks::pausable_mocks::PausableMock;
+use crate::PausableComponent::{InternalImpl, PausableImpl};
+use crate::PausableComponent::{Paused, Unpaused};
+use crate::PausableComponent;
+use crate::tests::mocks::pausable_mocks::PausableMock;
 use openzeppelin_testing::constants::CALLER;
 use openzeppelin_testing::events::EventSpyExt;
 use snforge_std::EventSpy;

--- a/packages/security/src/tests/test_reentrancyguard.cairo
+++ b/packages/security/src/tests/test_reentrancyguard.cairo
@@ -1,6 +1,6 @@
-use openzeppelin_security::ReentrancyGuardComponent::InternalImpl;
-use openzeppelin_security::ReentrancyGuardComponent;
-use openzeppelin_security::tests::mocks::reentrancy_mocks::{
+use crate::ReentrancyGuardComponent::InternalImpl;
+use crate::ReentrancyGuardComponent;
+use crate::tests::mocks::reentrancy_mocks::{
     ReentrancyMock, IReentrancyMockDispatcher, IReentrancyMockDispatcherTrait
 };
 use openzeppelin_testing as utils;

--- a/packages/test_common/src/upgrades.cairo
+++ b/packages/test_common/src/upgrades.cairo
@@ -1,7 +1,7 @@
 use openzeppelin_testing::events::EventSpyExt;
 use openzeppelin_upgrades::UpgradeableComponent::Upgraded;
 use openzeppelin_upgrades::UpgradeableComponent;
-use snforge_std::{EventSpy};
+use snforge_std::EventSpy;
 use starknet::{ContractAddress, ClassHash};
 
 #[generate_trait]

--- a/packages/testing/src/constants.cairo
+++ b/packages/testing/src/constants.cairo
@@ -1,6 +1,5 @@
 use starknet::class_hash::class_hash_const;
-use starknet::secp256_trait::Secp256Trait;
-use starknet::{ClassHash, ContractAddress, SyscallResultTrait, contract_address_const};
+use starknet::{ClassHash, ContractAddress, contract_address_const};
 
 pub type EthPublicKey = starknet::secp256k1::Secp256k1Point;
 
@@ -110,7 +109,7 @@ pub fn EMPTY_DATA() -> Span<felt252> {
 //
 
 pub mod secp256k1 {
-    use openzeppelin_testing::signing::{Secp256k1KeyPair, get_secp256k1_keys_from};
+    use crate::signing::{Secp256k1KeyPair, get_secp256k1_keys_from};
 
     pub fn KEY_PAIR() -> Secp256k1KeyPair {
         let private_key = u256 { low: 'PRIVATE_LOW', high: 'PRIVATE_HIGH' };
@@ -124,7 +123,7 @@ pub mod secp256k1 {
 }
 
 pub mod stark {
-    use openzeppelin_testing::signing::{StarkKeyPair, get_stark_keys_from};
+    use crate::signing::{StarkKeyPair, get_stark_keys_from};
 
     pub fn KEY_PAIR() -> StarkKeyPair {
         get_stark_keys_from('PRIVATE_KEY')

--- a/packages/testing/src/deployment.cairo
+++ b/packages/testing/src/deployment.cairo
@@ -1,4 +1,4 @@
-use openzeppelin_testing::panic_data_to_byte_array;
+use crate::panic_data_to_byte_array;
 use snforge_std::{ContractClass, ContractClassTrait};
 use starknet::ContractAddress;
 

--- a/packages/token/src/common/erc2981/erc2981.cairo
+++ b/packages/token/src/common/erc2981/erc2981.cairo
@@ -20,10 +20,10 @@
 #[starknet::component]
 pub mod ERC2981Component {
     use core::num::traits::Zero;
+    use crate::common::erc2981::interface::{IERC2981, IERC2981_ID};
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
     use openzeppelin_introspection::src5::SRC5Component;
-    use crate::common::erc2981::interface::{IERC2981, IERC2981_ID};
     use starknet::ContractAddress;
     use starknet::storage::Map;
 

--- a/packages/token/src/common/erc2981/erc2981.cairo
+++ b/packages/token/src/common/erc2981/erc2981.cairo
@@ -23,7 +23,7 @@ pub mod ERC2981Component {
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::common::erc2981::interface::{IERC2981, IERC2981_ID};
+    use crate::common::erc2981::interface::{IERC2981, IERC2981_ID};
     use starknet::ContractAddress;
     use starknet::storage::Map;
 
@@ -244,7 +244,7 @@ pub impl DefaultConfig of ERC2981Component::ImmutableConfig {
 
 #[cfg(test)]
 mod tests {
-    use openzeppelin_token::tests::mocks::erc2981_mocks::ERC2981Mock;
+    use crate::tests::mocks::erc2981_mocks::ERC2981Mock;
     use starknet::contract_address_const;
     use super::ERC2981Component::InternalImpl;
     use super::ERC2981Component;

--- a/packages/token/src/erc1155/erc1155.cairo
+++ b/packages/token/src/erc1155/erc1155.cairo
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts for Cairo v0.15.1 (token/erc1155/erc1155.cairo)
 
-use starknet::ContractAddress;
-
 /// # ERC1155 Component
 ///
 /// The ERC1155 component provides an implementation of the basic standard multi-token.
@@ -10,15 +8,13 @@ use starknet::ContractAddress;
 #[starknet::component]
 pub mod ERC1155Component {
     use core::num::traits::Zero;
+    use crate::erc1155::dual1155_receiver::{DualCaseERC1155Receiver, DualCaseERC1155ReceiverTrait};
+    use crate::erc1155::interface;
     use openzeppelin_account::interface::ISRC6_ID;
     use openzeppelin_introspection::interface::{ISRC5Dispatcher, ISRC5DispatcherTrait};
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc1155::dual1155_receiver::{
-        DualCaseERC1155Receiver, DualCaseERC1155ReceiverTrait
-    };
-    use openzeppelin_token::erc1155::interface;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
     use starknet::storage::Map;

--- a/packages/token/src/erc1155/erc1155_receiver.cairo
+++ b/packages/token/src/erc1155/erc1155_receiver.cairo
@@ -8,13 +8,11 @@
 /// safe transfers.
 #[starknet::component]
 pub mod ERC1155ReceiverComponent {
+    use crate::erc1155::interface::IERC1155_RECEIVER_ID;
+    use crate::erc1155::interface::{IERC1155Receiver, IERC1155ReceiverCamel, ERC1155ReceiverABI};
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc1155::interface::IERC1155_RECEIVER_ID;
-    use openzeppelin_token::erc1155::interface::{
-        IERC1155Receiver, IERC1155ReceiverCamel, ERC1155ReceiverABI
-    };
     use starknet::ContractAddress;
 
     #[storage]

--- a/packages/token/src/erc20/erc20.cairo
+++ b/packages/token/src/erc20/erc20.cairo
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts for Cairo v0.15.1 (token/erc20/erc20.cairo)
 
-use starknet::ContractAddress;
-
 /// # ERC20 Component
 ///
 /// The ERC20 component provides an implementation of the IERC20 interface as well as
@@ -16,7 +14,7 @@ use starknet::ContractAddress;
 pub mod ERC20Component {
     use core::num::traits::Bounded;
     use core::num::traits::Zero;
-    use openzeppelin_token::erc20::interface;
+    use crate::erc20::interface;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
     use starknet::storage::Map;

--- a/packages/token/src/erc20/extensions/erc20_votes.cairo
+++ b/packages/token/src/erc20/extensions/erc20_votes.cairo
@@ -17,10 +17,10 @@ use starknet::ContractAddress;
 #[starknet::component]
 pub mod ERC20VotesComponent {
     use core::num::traits::Zero;
+    use crate::erc20::ERC20Component;
+    use crate::erc20::interface::IERC20;
     use openzeppelin_account::dual_account::{DualCaseAccount, DualCaseAccountTrait};
     use openzeppelin_governance::utils::interfaces::IVotes;
-    use openzeppelin_token::erc20::ERC20Component;
-    use openzeppelin_token::erc20::interface::IERC20;
     use openzeppelin_utils::nonces::NoncesComponent::InternalTrait as NoncesInternalTrait;
     use openzeppelin_utils::nonces::NoncesComponent;
     use openzeppelin_utils::structs::checkpoint::{Checkpoint, Trace, TraceTrait};

--- a/packages/token/src/erc721/erc721.cairo
+++ b/packages/token/src/erc721/erc721.cairo
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts for Cairo v0.15.1 (token/erc721/erc721.cairo)
 
-use starknet::ContractAddress;
-
 /// # ERC721 Component
 ///
 /// The ERC721 component provides implementations for both the IERC721 interface
@@ -10,14 +8,12 @@ use starknet::ContractAddress;
 #[starknet::component]
 pub mod ERC721Component {
     use core::num::traits::Zero;
+    use crate::erc721::dual721_receiver::{DualCaseERC721Receiver, DualCaseERC721ReceiverTrait};
+    use crate::erc721::interface;
     use openzeppelin_introspection::interface::{ISRC5Dispatcher, ISRC5DispatcherTrait};
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc721::dual721_receiver::{
-        DualCaseERC721Receiver, DualCaseERC721ReceiverTrait
-    };
-    use openzeppelin_token::erc721::interface;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
     use starknet::storage::Map;

--- a/packages/token/src/erc721/erc721_receiver.cairo
+++ b/packages/token/src/erc721/erc721_receiver.cairo
@@ -8,12 +8,12 @@
 /// safe transfers.
 #[starknet::component]
 pub mod ERC721ReceiverComponent {
+    use crate::erc721::interface::IERC721_RECEIVER_ID;
+    use crate::erc721::interface::{IERC721Receiver, IERC721ReceiverCamel};
+    use crate::erc721::interface;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc721::interface::IERC721_RECEIVER_ID;
-    use openzeppelin_token::erc721::interface::{IERC721Receiver, IERC721ReceiverCamel};
-    use openzeppelin_token::erc721::interface;
     use starknet::ContractAddress;
 
     #[storage]

--- a/packages/token/src/erc721/extensions/erc721_enumerable/erc721_enumerable.cairo
+++ b/packages/token/src/erc721/extensions/erc721_enumerable/erc721_enumerable.cairo
@@ -19,11 +19,11 @@ pub mod ERC721EnumerableComponent {
     use core::num::traits::Zero;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc721::ERC721Component::ERC721Impl;
-    use openzeppelin_token::erc721::ERC721Component::InternalImpl as ERC721InternalImpl;
-    use openzeppelin_token::erc721::ERC721Component;
-    use openzeppelin_token::erc721::extensions::erc721_enumerable::interface::IERC721Enumerable;
-    use openzeppelin_token::erc721::extensions::erc721_enumerable::interface;
+    use crate::erc721::ERC721Component::ERC721Impl;
+    use crate::erc721::ERC721Component::InternalImpl as ERC721InternalImpl;
+    use crate::erc721::ERC721Component;
+    use crate::erc721::extensions::erc721_enumerable::interface::IERC721Enumerable;
+    use crate::erc721::extensions::erc721_enumerable::interface;
     use starknet::ContractAddress;
     use starknet::storage::Map;
 

--- a/packages/token/src/erc721/extensions/erc721_enumerable/erc721_enumerable.cairo
+++ b/packages/token/src/erc721/extensions/erc721_enumerable/erc721_enumerable.cairo
@@ -17,13 +17,13 @@
 #[starknet::component]
 pub mod ERC721EnumerableComponent {
     use core::num::traits::Zero;
-    use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
-    use openzeppelin_introspection::src5::SRC5Component;
     use crate::erc721::ERC721Component::ERC721Impl;
     use crate::erc721::ERC721Component::InternalImpl as ERC721InternalImpl;
     use crate::erc721::ERC721Component;
     use crate::erc721::extensions::erc721_enumerable::interface::IERC721Enumerable;
     use crate::erc721::extensions::erc721_enumerable::interface;
+    use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
+    use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
     use starknet::storage::Map;
 

--- a/packages/token/src/tests/erc1155/test_dual1155.cairo
+++ b/packages/token/src/tests/erc1155/test_dual1155.cairo
@@ -1,13 +1,13 @@
 use core::num::traits::Zero;
+use crate::erc1155::dual1155::{DualCaseERC1155, DualCaseERC1155Trait};
+use crate::erc1155::interface::IERC1155_ID;
+use crate::erc1155::interface::{IERC1155CamelDispatcher, IERC1155CamelDispatcherTrait};
+use crate::erc1155::interface::{IERC1155Dispatcher, IERC1155DispatcherTrait};
 use openzeppelin_test_common::erc1155::{setup_account, setup_receiver};
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::{
     EMPTY_DATA, OWNER, RECIPIENT, OPERATOR, TOKEN_ID, TOKEN_ID_2, TOKEN_VALUE
 };
-use openzeppelin_token::erc1155::dual1155::{DualCaseERC1155, DualCaseERC1155Trait};
-use openzeppelin_token::erc1155::interface::IERC1155_ID;
-use openzeppelin_token::erc1155::interface::{IERC1155CamelDispatcher, IERC1155CamelDispatcherTrait};
-use openzeppelin_token::erc1155::interface::{IERC1155Dispatcher, IERC1155DispatcherTrait};
 use openzeppelin_utils::serde::SerializedAppend;
 use snforge_std::start_cheat_caller_address;
 use starknet::ContractAddress;

--- a/packages/token/src/tests/erc1155/test_dual1155_receiver.cairo
+++ b/packages/token/src/tests/erc1155/test_dual1155_receiver.cairo
@@ -1,11 +1,9 @@
+use crate::erc1155::dual1155_receiver::{DualCaseERC1155Receiver, DualCaseERC1155ReceiverTrait};
+use crate::erc1155::interface::IERC1155_RECEIVER_ID;
+use crate::erc1155::interface::{IERC1155ReceiverCamelDispatcher};
+use crate::erc1155::interface::{IERC1155ReceiverDispatcher};
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::{EMPTY_DATA, OPERATOR, OWNER, TOKEN_ID, TOKEN_VALUE};
-use openzeppelin_token::erc1155::dual1155_receiver::{
-    DualCaseERC1155Receiver, DualCaseERC1155ReceiverTrait
-};
-use openzeppelin_token::erc1155::interface::IERC1155_RECEIVER_ID;
-use openzeppelin_token::erc1155::interface::{IERC1155ReceiverCamelDispatcher};
-use openzeppelin_token::erc1155::interface::{IERC1155ReceiverDispatcher};
 
 //
 // Setup

--- a/packages/token/src/tests/erc1155/test_erc1155.cairo
+++ b/packages/token/src/tests/erc1155/test_erc1155.cairo
@@ -1,4 +1,9 @@
 use core::num::traits::Zero;
+use crate::erc1155::ERC1155Component::ERC1155CamelImpl;
+use crate::erc1155::ERC1155Component::{ERC1155Impl, ERC1155MetadataURIImpl, InternalImpl};
+use crate::erc1155::ERC1155Component;
+use crate::erc1155;
+use crate::tests::mocks::erc1155_mocks::DualCaseERC1155Mock;
 use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
 use openzeppelin_test_common::erc1155::{
     ERC1155SpyHelpers, get_ids_and_values, get_ids_and_split_values
@@ -10,13 +15,6 @@ use openzeppelin_testing::constants::{
     EMPTY_DATA, ZERO, OWNER, RECIPIENT, OPERATOR, OTHER, TOKEN_ID, TOKEN_ID_2, TOKEN_VALUE,
     TOKEN_VALUE_2
 };
-use openzeppelin_token::erc1155::ERC1155Component::ERC1155CamelImpl;
-use openzeppelin_token::erc1155::ERC1155Component::{
-    ERC1155Impl, ERC1155MetadataURIImpl, InternalImpl
-};
-use openzeppelin_token::erc1155::ERC1155Component;
-use openzeppelin_token::erc1155;
-use openzeppelin_token::tests::mocks::erc1155_mocks::DualCaseERC1155Mock;
 use snforge_std::{spy_events, test_address, start_cheat_caller_address};
 use starknet::ContractAddress;
 

--- a/packages/token/src/tests/erc1155/test_erc1155_receiver.cairo
+++ b/packages/token/src/tests/erc1155/test_erc1155_receiver.cairo
@@ -1,11 +1,11 @@
+use crate::erc1155::ERC1155ReceiverComponent::{
+    ERC1155ReceiverImpl, ERC1155ReceiverCamelImpl, InternalImpl
+};
+use crate::erc1155::interface::IERC1155_RECEIVER_ID;
+use crate::tests::mocks::erc1155_receiver_mocks::DualCaseERC1155ReceiverMock;
 use openzeppelin_introspection::interface::ISRC5_ID;
 use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
 use openzeppelin_testing::constants::{OWNER, OPERATOR, TOKEN_ID, TOKEN_VALUE, EMPTY_DATA};
-use openzeppelin_token::erc1155::ERC1155ReceiverComponent::{
-    ERC1155ReceiverImpl, ERC1155ReceiverCamelImpl, InternalImpl
-};
-use openzeppelin_token::erc1155::interface::IERC1155_RECEIVER_ID;
-use openzeppelin_token::tests::mocks::erc1155_receiver_mocks::DualCaseERC1155ReceiverMock;
 
 fn STATE() -> DualCaseERC1155ReceiverMock::ContractState {
     DualCaseERC1155ReceiverMock::contract_state_for_testing()

--- a/packages/token/src/tests/erc20/test_dual20.cairo
+++ b/packages/token/src/tests/erc20/test_dual20.cairo
@@ -1,10 +1,10 @@
+use crate::erc20::dual20::{DualCaseERC20, DualCaseERC20Trait};
+use crate::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
+use crate::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::{
     OWNER, RECIPIENT, SPENDER, OPERATOR, NAME, SYMBOL, DECIMALS, SUPPLY, VALUE
 };
-use openzeppelin_token::erc20::dual20::{DualCaseERC20, DualCaseERC20Trait};
-use openzeppelin_token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
-use openzeppelin_token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
 use openzeppelin_utils::serde::SerializedAppend;
 use snforge_std::{test_address, start_cheat_caller_address};
 

--- a/packages/token/src/tests/erc20/test_erc20.cairo
+++ b/packages/token/src/tests/erc20/test_erc20.cairo
@@ -1,12 +1,12 @@
 use core::num::traits::Bounded;
+use crate::erc20::ERC20Component::{ERC20CamelOnlyImpl, ERC20Impl};
+use crate::erc20::ERC20Component::{ERC20MetadataImpl, InternalImpl};
+use crate::erc20::ERC20Component;
+use crate::tests::mocks::erc20_mocks::DualCaseERC20Mock;
 use openzeppelin_test_common::erc20::ERC20SpyHelpers;
 use openzeppelin_testing::constants::{
     ZERO, OWNER, SPENDER, RECIPIENT, NAME, SYMBOL, DECIMALS, SUPPLY, VALUE
 };
-use openzeppelin_token::erc20::ERC20Component::{ERC20CamelOnlyImpl, ERC20Impl};
-use openzeppelin_token::erc20::ERC20Component::{ERC20MetadataImpl, InternalImpl};
-use openzeppelin_token::erc20::ERC20Component;
-use openzeppelin_token::tests::mocks::erc20_mocks::DualCaseERC20Mock;
 use snforge_std::{spy_events, test_address, start_cheat_caller_address};
 use starknet::ContractAddress;
 

--- a/packages/token/src/tests/erc20/test_erc20_votes.cairo
+++ b/packages/token/src/tests/erc20/test_erc20_votes.cairo
@@ -1,28 +1,25 @@
 use core::num::traits::Bounded;
 use core::num::traits::Zero;
+use crate::erc20::ERC20Component::InternalImpl as ERC20Impl;
+use crate::erc20::extensions::ERC20VotesComponent::{DelegateChanged, DelegateVotesChanged};
+use crate::erc20::extensions::ERC20VotesComponent::{ERC20VotesImpl, InternalImpl};
+use crate::erc20::extensions::ERC20VotesComponent;
+use crate::erc20::extensions::erc20_votes::Delegation;
+use crate::tests::mocks::erc20_votes_mocks::DualCaseERC20VotesMock::SNIP12MetadataImpl;
+use crate::tests::mocks::erc20_votes_mocks::DualCaseERC20VotesMock;
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::{SUPPLY, ZERO, OWNER, RECIPIENT};
 use openzeppelin_testing::events::EventSpyExt;
-use openzeppelin_token::erc20::ERC20Component::InternalImpl as ERC20Impl;
-use openzeppelin_token::erc20::extensions::ERC20VotesComponent::{
-    DelegateChanged, DelegateVotesChanged
-};
-use openzeppelin_token::erc20::extensions::ERC20VotesComponent::{ERC20VotesImpl, InternalImpl};
-use openzeppelin_token::erc20::extensions::ERC20VotesComponent;
-use openzeppelin_token::erc20::extensions::erc20_votes::Delegation;
-use openzeppelin_token::tests::mocks::erc20_votes_mocks::DualCaseERC20VotesMock::SNIP12MetadataImpl;
-use openzeppelin_token::tests::mocks::erc20_votes_mocks::DualCaseERC20VotesMock;
 use openzeppelin_utils::cryptography::snip12::OffchainMessageHash;
 use openzeppelin_utils::structs::checkpoint::{Checkpoint, TraceTrait};
+use snforge_std::EventSpy;
 use snforge_std::signature::KeyPairTrait;
 use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl};
 use snforge_std::{
     start_cheat_block_timestamp_global, start_cheat_caller_address, spy_events,
     start_cheat_chain_id_global, test_address
 };
-use snforge_std::{EventSpy};
-use starknet::ContractAddress;
-use starknet::contract_address_const;
+use starknet::{ContractAddress, contract_address_const};
 
 //
 // Setup

--- a/packages/token/src/tests/erc2981/test_erc2981.cairo
+++ b/packages/token/src/tests/erc2981/test_erc2981.cairo
@@ -1,10 +1,9 @@
-use openzeppelin_introspection::interface::ISRC5Dispatcher;
+use crate::common::erc2981::ERC2981Component::{ERC2981Impl, InternalImpl};
+use crate::common::erc2981::interface::IERC2981_ID;
+use crate::common::erc2981::{ERC2981Component, DefaultConfig};
+use crate::tests::mocks::erc2981_mocks::ERC2981Mock;
 use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
-use openzeppelin_testing::constants::{OTHER, ZERO, RECIPIENT};
-use openzeppelin_token::common::erc2981::ERC2981Component::{ERC2981Impl, InternalImpl};
-use openzeppelin_token::common::erc2981::interface::IERC2981_ID;
-use openzeppelin_token::common::erc2981::{ERC2981Component, DefaultConfig};
-use openzeppelin_token::tests::mocks::erc2981_mocks::ERC2981Mock;
+use openzeppelin_testing::constants::{ZERO, RECIPIENT};
 use starknet::{ContractAddress, contract_address_const};
 
 type ComponentState = ERC2981Component::ComponentState<ERC2981Mock::ContractState>;

--- a/packages/token/src/tests/erc721/test_dual721.cairo
+++ b/packages/token/src/tests/erc721/test_dual721.cairo
@@ -1,13 +1,11 @@
+use crate::erc721::dual721::{DualCaseERC721, DualCaseERC721Trait};
+use crate::erc721::interface::IERC721_ID;
+use crate::erc721::interface::{IERC721CamelOnlyDispatcher, IERC721CamelOnlyDispatcherTrait};
+use crate::erc721::interface::{IERC721Dispatcher, IERC721DispatcherTrait};
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::{
     DATA, OWNER, RECIPIENT, SPENDER, OPERATOR, NAME, SYMBOL, BASE_URI, TOKEN_ID
 };
-use openzeppelin_token::erc721::dual721::{DualCaseERC721, DualCaseERC721Trait};
-use openzeppelin_token::erc721::interface::IERC721_ID;
-use openzeppelin_token::erc721::interface::{
-    IERC721CamelOnlyDispatcher, IERC721CamelOnlyDispatcherTrait
-};
-use openzeppelin_token::erc721::interface::{IERC721Dispatcher, IERC721DispatcherTrait};
 use openzeppelin_utils::serde::SerializedAppend;
 use snforge_std::{start_cheat_caller_address};
 use starknet::ContractAddress;

--- a/packages/token/src/tests/erc721/test_dual721_receiver.cairo
+++ b/packages/token/src/tests/erc721/test_dual721_receiver.cairo
@@ -1,11 +1,9 @@
+use crate::erc721::dual721_receiver::{DualCaseERC721Receiver, DualCaseERC721ReceiverTrait};
+use crate::erc721::interface::IERC721_RECEIVER_ID;
+use crate::erc721::interface::{IERC721ReceiverCamelDispatcher};
+use crate::erc721::interface::{IERC721ReceiverDispatcher};
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::{DATA, OPERATOR, OWNER, TOKEN_ID};
-use openzeppelin_token::erc721::dual721_receiver::{
-    DualCaseERC721Receiver, DualCaseERC721ReceiverTrait
-};
-use openzeppelin_token::erc721::interface::IERC721_RECEIVER_ID;
-use openzeppelin_token::erc721::interface::{IERC721ReceiverCamelDispatcher};
-use openzeppelin_token::erc721::interface::{IERC721ReceiverDispatcher};
 
 //
 // Setup

--- a/packages/token/src/tests/erc721/test_dual721_receiver.cairo
+++ b/packages/token/src/tests/erc721/test_dual721_receiver.cairo
@@ -1,7 +1,7 @@
 use crate::erc721::dual721_receiver::{DualCaseERC721Receiver, DualCaseERC721ReceiverTrait};
 use crate::erc721::interface::IERC721_RECEIVER_ID;
-use crate::erc721::interface::{IERC721ReceiverCamelDispatcher};
-use crate::erc721::interface::{IERC721ReceiverDispatcher};
+use crate::erc721::interface::IERC721ReceiverCamelDispatcher;
+use crate::erc721::interface::IERC721ReceiverDispatcher;
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::{DATA, OPERATOR, OWNER, TOKEN_ID};
 

--- a/packages/token/src/tests/erc721/test_dual721_receiver.cairo
+++ b/packages/token/src/tests/erc721/test_dual721_receiver.cairo
@@ -1,7 +1,7 @@
 use crate::erc721::dual721_receiver::{DualCaseERC721Receiver, DualCaseERC721ReceiverTrait};
-use crate::erc721::interface::IERC721_RECEIVER_ID;
-use crate::erc721::interface::IERC721ReceiverCamelDispatcher;
-use crate::erc721::interface::IERC721ReceiverDispatcher;
+use crate::erc721::interface::{
+    IERC721ReceiverDispatcher, IERC721ReceiverCamelDispatcher, IERC721_RECEIVER_ID
+};
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::{DATA, OPERATOR, OWNER, TOKEN_ID};
 

--- a/packages/token/src/tests/erc721/test_erc721.cairo
+++ b/packages/token/src/tests/erc721/test_erc721.cairo
@@ -1,4 +1,9 @@
 use core::num::traits::Zero;
+use crate::erc721::ERC721Component::{ERC721Impl, ERC721CamelOnlyImpl};
+use crate::erc721::ERC721Component::{ERC721MetadataImpl, InternalImpl};
+use crate::erc721::ERC721Component;
+use crate::erc721;
+use crate::tests::mocks::erc721_mocks::DualCaseERC721Mock;
 use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
 use openzeppelin_test_common::erc721::ERC721SpyHelpers;
 use openzeppelin_testing as utils;
@@ -7,11 +12,6 @@ use openzeppelin_testing::constants::{
     TOKEN_ID_2, PUBKEY, BASE_URI, BASE_URI_2
 };
 use openzeppelin_testing::events::EventSpyExt;
-use openzeppelin_token::erc721::ERC721Component::{ERC721Impl, ERC721CamelOnlyImpl};
-use openzeppelin_token::erc721::ERC721Component::{ERC721MetadataImpl, InternalImpl};
-use openzeppelin_token::erc721::ERC721Component;
-use openzeppelin_token::erc721;
-use openzeppelin_token::tests::mocks::erc721_mocks::DualCaseERC721Mock;
 use snforge_std::{spy_events, test_address, start_cheat_caller_address};
 use starknet::ContractAddress;
 

--- a/packages/token/src/tests/erc721/test_erc721_enumerable.cairo
+++ b/packages/token/src/tests/erc721/test_erc721_enumerable.cairo
@@ -1,6 +1,3 @@
-use openzeppelin_introspection::interface::ISRC5_ID;
-use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
-use openzeppelin_testing::constants::{OWNER, RECIPIENT, OTHER, ZERO};
 use crate::erc721::ERC721Component::{ERC721Impl, InternalImpl as ERC721InternalImpl};
 use crate::erc721::extensions::erc721_enumerable::ERC721EnumerableComponent::{
     ERC721EnumerableImpl, InternalImpl
@@ -8,6 +5,9 @@ use crate::erc721::extensions::erc721_enumerable::ERC721EnumerableComponent::{
 use crate::erc721::extensions::erc721_enumerable::ERC721EnumerableComponent;
 use crate::erc721::extensions::erc721_enumerable::interface;
 use crate::tests::mocks::erc721_enumerable_mocks::ERC721EnumerableMock;
+use openzeppelin_introspection::interface::ISRC5_ID;
+use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
+use openzeppelin_testing::constants::{OWNER, RECIPIENT, OTHER, ZERO};
 use starknet::ContractAddress;
 
 // Token IDs

--- a/packages/token/src/tests/erc721/test_erc721_enumerable.cairo
+++ b/packages/token/src/tests/erc721/test_erc721_enumerable.cairo
@@ -1,13 +1,13 @@
 use openzeppelin_introspection::interface::ISRC5_ID;
 use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
 use openzeppelin_testing::constants::{OWNER, RECIPIENT, OTHER, ZERO};
-use openzeppelin_token::erc721::ERC721Component::{ERC721Impl, InternalImpl as ERC721InternalImpl};
-use openzeppelin_token::erc721::extensions::erc721_enumerable::ERC721EnumerableComponent::{
+use crate::erc721::ERC721Component::{ERC721Impl, InternalImpl as ERC721InternalImpl};
+use crate::erc721::extensions::erc721_enumerable::ERC721EnumerableComponent::{
     ERC721EnumerableImpl, InternalImpl
 };
-use openzeppelin_token::erc721::extensions::erc721_enumerable::ERC721EnumerableComponent;
-use openzeppelin_token::erc721::extensions::erc721_enumerable::interface;
-use openzeppelin_token::tests::mocks::erc721_enumerable_mocks::ERC721EnumerableMock;
+use crate::erc721::extensions::erc721_enumerable::ERC721EnumerableComponent;
+use crate::erc721::extensions::erc721_enumerable::interface;
+use crate::tests::mocks::erc721_enumerable_mocks::ERC721EnumerableMock;
 use starknet::ContractAddress;
 
 // Token IDs

--- a/packages/token/src/tests/erc721/test_erc721_receiver.cairo
+++ b/packages/token/src/tests/erc721/test_erc721_receiver.cairo
@@ -1,11 +1,11 @@
+use crate::erc721::ERC721ReceiverComponent::{
+    ERC721ReceiverImpl, ERC721ReceiverCamelImpl, InternalImpl
+};
+use crate::erc721::interface::IERC721_RECEIVER_ID;
+use crate::tests::mocks::erc721_receiver_mocks::DualCaseERC721ReceiverMock;
 use openzeppelin_introspection::interface::ISRC5_ID;
 use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
 use openzeppelin_testing::constants::{OWNER, OPERATOR, TOKEN_ID};
-use openzeppelin_token::erc721::ERC721ReceiverComponent::{
-    ERC721ReceiverImpl, ERC721ReceiverCamelImpl, InternalImpl
-};
-use openzeppelin_token::erc721::interface::IERC721_RECEIVER_ID;
-use openzeppelin_token::tests::mocks::erc721_receiver_mocks::DualCaseERC721ReceiverMock;
 
 fn STATE() -> DualCaseERC721ReceiverMock::ContractState {
     DualCaseERC721ReceiverMock::contract_state_for_testing()

--- a/packages/token/src/tests/mocks/erc1155_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc1155_mocks.cairo
@@ -1,7 +1,7 @@
 #[starknet::contract]
 pub(crate) mod DualCaseERC1155Mock {
+    use crate::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC1155Component, storage: erc1155, event: ERC1155Event);
@@ -53,8 +53,8 @@ pub(crate) mod DualCaseERC1155Mock {
 
 #[starknet::contract]
 pub(crate) mod SnakeERC1155Mock {
+    use crate::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC1155Component, storage: erc1155, event: ERC1155Event);
@@ -104,8 +104,8 @@ pub(crate) mod SnakeERC1155Mock {
 
 #[starknet::contract]
 pub(crate) mod CamelERC1155Mock {
+    use crate::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC1155Component, storage: erc1155, event: ERC1155Event);

--- a/packages/token/src/tests/mocks/erc1155_receiver_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc1155_receiver_mocks.cairo
@@ -2,8 +2,8 @@ const SUCCESS: felt252 = 'SUCCESS';
 
 #[starknet::contract]
 pub(crate) mod DualCaseERC1155ReceiverMock {
+    use crate::erc1155::ERC1155ReceiverComponent;
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc1155::ERC1155ReceiverComponent;
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
     component!(
@@ -41,8 +41,8 @@ pub(crate) mod DualCaseERC1155ReceiverMock {
 
 #[starknet::contract]
 pub(crate) mod SnakeERC1155ReceiverMock {
+    use crate::erc1155::ERC1155ReceiverComponent;
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc1155::ERC1155ReceiverComponent;
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
     component!(
@@ -84,8 +84,8 @@ pub(crate) mod SnakeERC1155ReceiverMock {
 
 #[starknet::contract]
 pub(crate) mod CamelERC1155ReceiverMock {
+    use crate::erc1155::ERC1155ReceiverComponent;
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc1155::ERC1155ReceiverComponent;
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
     component!(

--- a/packages/token/src/tests/mocks/erc20_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc20_mocks.cairo
@@ -1,6 +1,6 @@
 #[starknet::contract]
 pub(crate) mod DualCaseERC20Mock {
-    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use crate::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);
@@ -41,7 +41,7 @@ pub(crate) mod DualCaseERC20Mock {
 
 #[starknet::contract]
 pub(crate) mod SnakeERC20Mock {
-    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use crate::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);
@@ -80,7 +80,7 @@ pub(crate) mod SnakeERC20Mock {
 
 #[starknet::contract]
 pub(crate) mod CamelERC20Mock {
-    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use crate::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);

--- a/packages/token/src/tests/mocks/erc20_votes_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc20_votes_mocks.cairo
@@ -1,8 +1,8 @@
 #[starknet::contract]
 pub(crate) mod DualCaseERC20VotesMock {
-    use openzeppelin_token::erc20::ERC20Component;
-    use openzeppelin_token::erc20::extensions::ERC20VotesComponent::InternalTrait as ERC20VotesInternalTrait;
-    use openzeppelin_token::erc20::extensions::ERC20VotesComponent;
+    use crate::erc20::ERC20Component;
+    use crate::erc20::extensions::ERC20VotesComponent::InternalTrait as ERC20VotesInternalTrait;
+    use crate::erc20::extensions::ERC20VotesComponent;
     use openzeppelin_utils::cryptography::nonces::NoncesComponent;
     use openzeppelin_utils::cryptography::snip12::SNIP12Metadata;
     use starknet::ContractAddress;

--- a/packages/token/src/tests/mocks/erc2981_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc2981_mocks.cairo
@@ -1,7 +1,7 @@
 #[starknet::contract]
 pub(crate) mod ERC2981Mock {
+    use crate::common::erc2981::{ERC2981Component, DefaultConfig};
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::common::erc2981::{ERC2981Component, DefaultConfig};
     use starknet::ContractAddress;
 
     component!(path: ERC2981Component, storage: erc2981, event: ERC2981Event);

--- a/packages/token/src/tests/mocks/erc721_enumerable_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc721_enumerable_mocks.cairo
@@ -1,8 +1,8 @@
 #[starknet::contract]
 pub(crate) mod ERC721EnumerableMock {
-    use openzeppelin_introspection::src5::SRC5Component;
     use crate::erc721::ERC721Component;
     use crate::erc721::extensions::ERC721EnumerableComponent;
+    use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
 
     component!(path: ERC721Component, storage: erc721, event: ERC721Event);
@@ -76,9 +76,9 @@ pub(crate) mod ERC721EnumerableMock {
 
 #[starknet::contract]
 pub(crate) mod SnakeERC721EnumerableMock {
-    use openzeppelin_introspection::src5::SRC5Component;
     use crate::erc721::ERC721Component;
     use crate::erc721::extensions::ERC721EnumerableComponent;
+    use openzeppelin_introspection::src5::SRC5Component;
 
     use starknet::ContractAddress;
 

--- a/packages/token/src/tests/mocks/erc721_enumerable_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc721_enumerable_mocks.cairo
@@ -1,9 +1,8 @@
 #[starknet::contract]
 pub(crate) mod ERC721EnumerableMock {
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc721::ERC721Component::ERC721HooksTrait;
-    use openzeppelin_token::erc721::ERC721Component;
-    use openzeppelin_token::erc721::extensions::ERC721EnumerableComponent;
+    use crate::erc721::ERC721Component;
+    use crate::erc721::extensions::ERC721EnumerableComponent;
     use starknet::ContractAddress;
 
     component!(path: ERC721Component, storage: erc721, event: ERC721Event);
@@ -78,9 +77,8 @@ pub(crate) mod ERC721EnumerableMock {
 #[starknet::contract]
 pub(crate) mod SnakeERC721EnumerableMock {
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc721::ERC721Component::ERC721HooksTrait;
-    use openzeppelin_token::erc721::ERC721Component;
-    use openzeppelin_token::erc721::extensions::ERC721EnumerableComponent;
+    use crate::erc721::ERC721Component;
+    use crate::erc721::extensions::ERC721EnumerableComponent;
 
     use starknet::ContractAddress;
 

--- a/packages/token/src/tests/mocks/erc721_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc721_mocks.cairo
@@ -1,7 +1,7 @@
 #[starknet::contract]
 pub(crate) mod DualCaseERC721Mock {
+    use crate::erc721::{ERC721Component, ERC721HooksEmptyImpl};
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc721::{ERC721Component, ERC721HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC721Component, storage: erc721, event: ERC721Event);
@@ -56,8 +56,8 @@ pub(crate) mod DualCaseERC721Mock {
 
 #[starknet::contract]
 pub(crate) mod SnakeERC721Mock {
+    use crate::erc721::{ERC721Component, ERC721HooksEmptyImpl};
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc721::{ERC721Component, ERC721HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC721Component, storage: erc721, event: ERC721Event);
@@ -107,9 +107,9 @@ pub(crate) mod SnakeERC721Mock {
 
 #[starknet::contract]
 pub(crate) mod CamelERC721Mock {
+    use crate::erc721::ERC721Component::{ERC721Impl, ERC721MetadataImpl};
+    use crate::erc721::{ERC721Component, ERC721HooksEmptyImpl};
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc721::ERC721Component::{ERC721Impl, ERC721MetadataImpl};
-    use openzeppelin_token::erc721::{ERC721Component, ERC721HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC721Component, storage: erc721, event: ERC721Event);

--- a/packages/token/src/tests/mocks/erc721_receiver_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc721_receiver_mocks.cairo
@@ -2,8 +2,8 @@ const SUCCESS: felt252 = 'SUCCESS';
 
 #[starknet::contract]
 pub(crate) mod DualCaseERC721ReceiverMock {
+    use crate::erc721::ERC721ReceiverComponent;
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc721::ERC721ReceiverComponent;
     use starknet::ContractAddress;
 
     component!(path: ERC721ReceiverComponent, storage: erc721_receiver, event: ERC721ReceiverEvent);
@@ -72,8 +72,8 @@ pub(crate) mod DualCaseERC721ReceiverMock {
 
 #[starknet::contract]
 pub(crate) mod SnakeERC721ReceiverMock {
+    use crate::erc721::ERC721ReceiverComponent;
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc721::ERC721ReceiverComponent;
     use starknet::ContractAddress;
 
     component!(path: ERC721ReceiverComponent, storage: erc721_receiver, event: ERC721ReceiverEvent);
@@ -131,8 +131,8 @@ pub(crate) mod SnakeERC721ReceiverMock {
 
 #[starknet::contract]
 pub(crate) mod CamelERC721ReceiverMock {
+    use crate::erc721::ERC721ReceiverComponent;
     use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc721::ERC721ReceiverComponent;
     use starknet::ContractAddress;
 
     component!(path: ERC721ReceiverComponent, storage: erc721_receiver, event: ERC721ReceiverEvent);

--- a/packages/upgrades/src/tests/mocks/upgrades_mocks.cairo
+++ b/packages/upgrades/src/tests/mocks/upgrades_mocks.cairo
@@ -14,7 +14,7 @@ pub(crate) trait IUpgradesV1<TState> {
 
 #[starknet::contract]
 pub(crate) mod UpgradesV1 {
-    use openzeppelin_upgrades::UpgradeableComponent;
+    use crate::UpgradeableComponent;
     use starknet::ClassHash;
 
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
@@ -64,7 +64,7 @@ pub(crate) trait IUpgradesV2<TState> {
 
 #[starknet::contract]
 pub(crate) mod UpgradesV2 {
-    use openzeppelin_upgrades::UpgradeableComponent;
+    use crate::UpgradeableComponent;
     use starknet::ClassHash;
 
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);

--- a/packages/upgrades/src/tests/test_upgradeable.cairo
+++ b/packages/upgrades/src/tests/test_upgradeable.cairo
@@ -1,12 +1,8 @@
+use crate::tests::mocks::upgrades_mocks::{IUpgradesV1Dispatcher, IUpgradesV1DispatcherTrait};
+use crate::tests::mocks::upgrades_mocks::{IUpgradesV2Dispatcher, IUpgradesV2DispatcherTrait};
 use openzeppelin_test_common::upgrades::UpgradeableSpyHelpers;
 use openzeppelin_testing::constants::{CLASS_HASH_ZERO, FELT_VALUE as VALUE};
 use openzeppelin_testing::{declare_class, deploy};
-use openzeppelin_upgrades::tests::mocks::upgrades_mocks::{
-    IUpgradesV1Dispatcher, IUpgradesV1DispatcherTrait
-};
-use openzeppelin_upgrades::tests::mocks::upgrades_mocks::{
-    IUpgradesV2Dispatcher, IUpgradesV2DispatcherTrait
-};
 use snforge_std::{spy_events, ContractClass};
 
 //

--- a/packages/utils/src/cryptography/nonces.cairo
+++ b/packages/utils/src/cryptography/nonces.cairo
@@ -3,7 +3,7 @@
 
 #[starknet::component]
 pub mod NoncesComponent {
-    use openzeppelin_utils::interfaces::INonces;
+    use crate::interfaces::INonces;
     use starknet::ContractAddress;
     use starknet::storage::Map;
 

--- a/packages/utils/src/deployments.cairo
+++ b/packages/utils/src/deployments.cairo
@@ -7,7 +7,7 @@ use core::hash::{HashStateTrait, HashStateExTrait};
 use core::num::traits::Zero;
 use core::pedersen::PedersenTrait;
 use core::poseidon::PoseidonTrait;
-use openzeppelin_utils::serde::SerializedAppend;
+use crate::serde::SerializedAppend;
 use starknet::{ClassHash, ContractAddress};
 
 // 2**251 - 256

--- a/packages/utils/src/interfaces.cairo
+++ b/packages/utils/src/interfaces.cairo
@@ -1,6 +1,4 @@
-pub use openzeppelin_utils::cryptography::interface::{
-    INonces, INoncesDispatcher, INoncesDispatcherTrait
-};
-pub use openzeppelin_utils::deployments::interface::{
+pub use crate::cryptography::interface::{INonces, INoncesDispatcher, INoncesDispatcherTrait};
+pub use crate::deployments::interface::{
     IUniversalDeployer, IUniversalDeployerDispatcher, IUniversalDeployerDispatcherTrait
 };

--- a/packages/utils/src/structs/checkpoint.cairo
+++ b/packages/utils/src/structs/checkpoint.cairo
@@ -2,7 +2,7 @@
 // OpenZeppelin Contracts for Cairo v0.15.1 (utils/structs/checkpoint.cairo)
 
 use core::num::traits::Sqrt;
-use openzeppelin_utils::math;
+use crate::math;
 use starknet::storage_access::StorePacking;
 use super::storage_array::{StorageArray, StorageArrayTrait};
 

--- a/packages/utils/src/tests/mocks/nonces_mocks.cairo
+++ b/packages/utils/src/tests/mocks/nonces_mocks.cairo
@@ -1,6 +1,6 @@
 #[starknet::contract]
 pub(crate) mod NoncesMock {
-    use openzeppelin_utils::cryptography::nonces::NoncesComponent;
+    use crate::cryptography::nonces::NoncesComponent;
 
     component!(path: NoncesComponent, storage: nonces, event: NoncesEvent);
 

--- a/packages/utils/src/tests/test_nonces.cairo
+++ b/packages/utils/src/tests/test_nonces.cairo
@@ -1,9 +1,9 @@
 use core::num::traits::Zero;
+use crate::cryptography::interface::INonces;
+use crate::cryptography::nonces::NoncesComponent::InternalTrait;
+use crate::cryptography::nonces::NoncesComponent;
+use crate::tests::mocks::nonces_mocks::NoncesMock;
 use openzeppelin_testing::constants::OWNER;
-use openzeppelin_utils::cryptography::interface::INonces;
-use openzeppelin_utils::cryptography::nonces::NoncesComponent::InternalTrait;
-use openzeppelin_utils::cryptography::nonces::NoncesComponent;
-use openzeppelin_utils::tests::mocks::nonces_mocks::NoncesMock;
 
 type ComponentState = NoncesComponent::ComponentState<NoncesMock::ContractState>;
 

--- a/packages/utils/src/tests/test_snip12.cairo
+++ b/packages/utils/src/tests/test_snip12.cairo
@@ -1,9 +1,9 @@
 use core::hash::{HashStateTrait, HashStateExTrait};
 use core::poseidon::{PoseidonTrait, poseidon_hash_span};
-use openzeppelin_testing::constants::{OWNER, RECIPIENT};
-use openzeppelin_utils::cryptography::snip12::{
+use crate::cryptography::snip12::{
     STARKNET_DOMAIN_TYPE_HASH, StarknetDomain, StructHash, OffchainMessageHashImpl, SNIP12Metadata
 };
+use openzeppelin_testing::constants::{OWNER, RECIPIENT};
 use snforge_std::{start_cheat_chain_id, test_address};
 use starknet::ContractAddress;
 


### PR DESCRIPTION
This PR also:

- Refactor local imports to `use crate::`
- Removed unused imports
- Use PartialOrd default implementations in `merkle_tree::hashes`