### PR TITLE
Upgrade scarb edition to 2024_07

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -20,7 +20,7 @@ version.workspace = true
 
 [workspace.package]
 version = "0.16.0"
-edition = "2023_11"
+edition = "2024_07"
 cairo-version = "2.8.0"
 scarb-version = "2.8.0"
 authors = ["OpenZeppelin Community <maintainers@openzeppelin.org>"]

--- a/packages/access/src/accesscontrol/accesscontrol.cairo
+++ b/packages/access/src/accesscontrol/accesscontrol.cairo
@@ -13,9 +13,7 @@ pub mod AccessControlComponent {
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
-    use starknet::storage::Map;
-    use starknet::storage::StorageMapReadAccess;
-    use starknet::storage::StorageMapWriteAccess;
+    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess};
 
     #[storage]
     pub struct Storage {

--- a/packages/access/src/accesscontrol/accesscontrol.cairo
+++ b/packages/access/src/accesscontrol/accesscontrol.cairo
@@ -19,8 +19,8 @@ pub mod AccessControlComponent {
 
     #[storage]
     pub struct Storage {
-        AccessControl_role_admin: Map<felt252, felt252>,
-        AccessControl_role_member: Map<(felt252, ContractAddress), bool>,
+        pub AccessControl_role_admin: Map<felt252, felt252>,
+        pub AccessControl_role_member: Map<(felt252, ContractAddress), bool>,
     }
 
     #[event]

--- a/packages/access/src/accesscontrol/accesscontrol.cairo
+++ b/packages/access/src/accesscontrol/accesscontrol.cairo
@@ -14,9 +14,11 @@ pub mod AccessControlComponent {
     use starknet::ContractAddress;
     use starknet::get_caller_address;
     use starknet::storage::Map;
+    use starknet::storage::StorageMapReadAccess;
+    use starknet::storage::StorageMapWriteAccess;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         AccessControl_role_admin: Map<felt252, felt252>,
         AccessControl_role_member: Map<(felt252, ContractAddress), bool>,
     }

--- a/packages/access/src/ownable/ownable.cairo
+++ b/packages/access/src/ownable/ownable.cairo
@@ -20,9 +20,11 @@ pub mod OwnableComponent {
     use crate::ownable::interface;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         Ownable_owner: ContractAddress,
         Ownable_pending_owner: ContractAddress
     }

--- a/packages/access/src/ownable/ownable.cairo
+++ b/packages/access/src/ownable/ownable.cairo
@@ -20,8 +20,7 @@ pub mod OwnableComponent {
     use crate::ownable::interface;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 
     #[storage]
     pub struct Storage {

--- a/packages/access/src/ownable/ownable.cairo
+++ b/packages/access/src/ownable/ownable.cairo
@@ -25,8 +25,8 @@ pub mod OwnableComponent {
 
     #[storage]
     pub struct Storage {
-        Ownable_owner: ContractAddress,
-        Ownable_pending_owner: ContractAddress
+        pub Ownable_owner: ContractAddress,
+        pub Ownable_pending_owner: ContractAddress
     }
 
     #[event]

--- a/packages/access/src/tests/mocks/accesscontrol_mocks.cairo
+++ b/packages/access/src/tests/mocks/accesscontrol_mocks.cairo
@@ -15,11 +15,11 @@ pub(crate) mod DualCaseAccessControlMock {
     impl AccessControlInternalImpl = AccessControlComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        accesscontrol: AccessControlComponent::Storage,
+        pub accesscontrol: AccessControlComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -59,11 +59,11 @@ pub(crate) mod SnakeAccessControlMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        accesscontrol: AccessControlComponent::Storage,
+        pub accesscontrol: AccessControlComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage,
+        pub src5: SRC5Component::Storage,
     }
 
     #[event]
@@ -104,11 +104,11 @@ pub(crate) mod CamelAccessControlMock {
 
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        accesscontrol: AccessControlComponent::Storage,
+        pub accesscontrol: AccessControlComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -138,7 +138,7 @@ pub(crate) mod SnakeAccessControlPanicMock {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]
@@ -183,7 +183,7 @@ pub(crate) mod CamelAccessControlPanicMock {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]

--- a/packages/access/src/tests/mocks/non_implementing_mock.cairo
+++ b/packages/access/src/tests/mocks/non_implementing_mock.cairo
@@ -1,7 +1,7 @@
 #[starknet::contract]
 pub(crate) mod NonImplementingMock {
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[external(v0)]
     fn nope(self: @ContractState) -> bool {

--- a/packages/access/src/tests/mocks/ownable_mocks.cairo
+++ b/packages/access/src/tests/mocks/ownable_mocks.cairo
@@ -60,9 +60,9 @@ pub(crate) mod SnakeOwnableMock {
 
 #[starknet::contract]
 pub(crate) mod CamelOwnableMock {
-use crate::ownable::OwnableComponent;
-    use starknet::ContractAddress;
+    use crate::ownable::OwnableComponent;
     use crate::ownable::interface::IOwnable;
+    use starknet::ContractAddress;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
 

--- a/packages/access/src/tests/mocks/ownable_mocks.cairo
+++ b/packages/access/src/tests/mocks/ownable_mocks.cairo
@@ -60,8 +60,9 @@ pub(crate) mod SnakeOwnableMock {
 
 #[starknet::contract]
 pub(crate) mod CamelOwnableMock {
-    use crate::ownable::OwnableComponent;
+use crate::ownable::OwnableComponent;
     use starknet::ContractAddress;
+    use crate::ownable::interface::IOwnable;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
 
@@ -93,7 +94,7 @@ pub(crate) mod CamelOwnableMock {
     impl ExternalImpl of ExternalTrait {
         #[external(v0)]
         fn owner(self: @ContractState) -> ContractAddress {
-            self.ownable.Ownable_owner.read()
+            self.ownable.owner()
         }
     }
 }

--- a/packages/access/src/tests/mocks/ownable_mocks.cairo
+++ b/packages/access/src/tests/mocks/ownable_mocks.cairo
@@ -10,9 +10,9 @@ pub(crate) mod DualCaseOwnableMock {
     impl InternalImpl = OwnableComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        ownable: OwnableComponent::Storage
+        pub ownable: OwnableComponent::Storage
     }
 
     #[event]
@@ -40,9 +40,9 @@ pub(crate) mod SnakeOwnableMock {
     impl InternalImpl = OwnableComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        ownable: OwnableComponent::Storage
+        pub ownable: OwnableComponent::Storage
     }
 
     #[event]
@@ -72,9 +72,9 @@ pub(crate) mod CamelOwnableMock {
     impl InternalImpl = OwnableComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        ownable: OwnableComponent::Storage
+        pub ownable: OwnableComponent::Storage
     }
 
     #[event]
@@ -105,7 +105,7 @@ pub(crate) mod SnakeOwnablePanicMock {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]
@@ -134,7 +134,7 @@ pub(crate) mod CamelOwnablePanicMock {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]
@@ -170,7 +170,7 @@ pub(crate) mod DualCaseTwoStepOwnableMock {
     impl InternalImpl = OwnableComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
         ownable: OwnableComponent::Storage
     }

--- a/packages/access/src/tests/test_ownable.cairo
+++ b/packages/access/src/tests/test_ownable.cairo
@@ -1,3 +1,5 @@
+use starknet::storage::StoragePointerReadAccess;
+use starknet::storage::StoragePointerWriteAccess;
 use core::num::traits::Zero;
 use crate::ownable::OwnableComponent::InternalTrait;
 use crate::ownable::OwnableComponent;

--- a/packages/access/src/tests/test_ownable.cairo
+++ b/packages/access/src/tests/test_ownable.cairo
@@ -1,5 +1,3 @@
-use starknet::storage::StoragePointerReadAccess;
-use starknet::storage::StoragePointerWriteAccess;
 use core::num::traits::Zero;
 use crate::ownable::OwnableComponent::InternalTrait;
 use crate::ownable::OwnableComponent;
@@ -9,6 +7,8 @@ use crate::tests::mocks::ownable_mocks::DualCaseOwnableMock;
 use openzeppelin_test_common::ownable::OwnableSpyHelpers;
 use openzeppelin_testing::constants::{ZERO, OTHER, OWNER, RECIPIENT};
 use snforge_std::{spy_events, test_address, start_cheat_caller_address};
+use starknet::storage::StoragePointerReadAccess;
+use starknet::storage::StoragePointerWriteAccess;
 
 //
 // Setup

--- a/packages/access/src/tests/test_ownable.cairo
+++ b/packages/access/src/tests/test_ownable.cairo
@@ -7,8 +7,7 @@ use crate::tests::mocks::ownable_mocks::DualCaseOwnableMock;
 use openzeppelin_test_common::ownable::OwnableSpyHelpers;
 use openzeppelin_testing::constants::{ZERO, OTHER, OWNER, RECIPIENT};
 use snforge_std::{spy_events, test_address, start_cheat_caller_address};
-use starknet::storage::StoragePointerReadAccess;
-use starknet::storage::StoragePointerWriteAccess;
+ use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 
 //
 // Setup

--- a/packages/access/src/tests/test_ownable.cairo
+++ b/packages/access/src/tests/test_ownable.cairo
@@ -7,7 +7,7 @@ use crate::tests::mocks::ownable_mocks::DualCaseOwnableMock;
 use openzeppelin_test_common::ownable::OwnableSpyHelpers;
 use openzeppelin_testing::constants::{ZERO, OTHER, OWNER, RECIPIENT};
 use snforge_std::{spy_events, test_address, start_cheat_caller_address};
- use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 
 //
 // Setup

--- a/packages/access/src/tests/test_ownable_twostep.cairo
+++ b/packages/access/src/tests/test_ownable_twostep.cairo
@@ -1,5 +1,3 @@
-use starknet::storage::StoragePointerWriteAccess;
-use starknet::storage::StoragePointerReadAccess;
 use core::num::traits::Zero;
 use crate::ownable::OwnableComponent::{InternalTrait, OwnershipTransferStarted};
 use crate::ownable::OwnableComponent;
@@ -10,6 +8,8 @@ use openzeppelin_testing::constants::{ZERO, OWNER, OTHER, NEW_OWNER};
 use openzeppelin_testing::events::EventSpyExt;
 use snforge_std::{EventSpy, spy_events, start_cheat_caller_address, test_address};
 use starknet::ContractAddress;
+use starknet::storage::StoragePointerReadAccess;
+use starknet::storage::StoragePointerWriteAccess;
 
 //
 // Setup

--- a/packages/access/src/tests/test_ownable_twostep.cairo
+++ b/packages/access/src/tests/test_ownable_twostep.cairo
@@ -8,8 +8,7 @@ use openzeppelin_testing::constants::{ZERO, OWNER, OTHER, NEW_OWNER};
 use openzeppelin_testing::events::EventSpyExt;
 use snforge_std::{EventSpy, spy_events, start_cheat_caller_address, test_address};
 use starknet::ContractAddress;
-use starknet::storage::StoragePointerReadAccess;
-use starknet::storage::StoragePointerWriteAccess;
+use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 
 //
 // Setup

--- a/packages/access/src/tests/test_ownable_twostep.cairo
+++ b/packages/access/src/tests/test_ownable_twostep.cairo
@@ -1,3 +1,5 @@
+use starknet::storage::StoragePointerWriteAccess;
+use starknet::storage::StoragePointerReadAccess;
 use core::num::traits::Zero;
 use crate::ownable::OwnableComponent::{InternalTrait, OwnershipTransferStarted};
 use crate::ownable::OwnableComponent;

--- a/packages/account/src/account.cairo
+++ b/packages/account/src/account.cairo
@@ -19,8 +19,7 @@ pub mod AccountComponent {
     use starknet::get_caller_address;
     use starknet::get_contract_address;
     use starknet::get_tx_info;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 
     #[storage]
     pub struct Storage {

--- a/packages/account/src/account.cairo
+++ b/packages/account/src/account.cairo
@@ -24,7 +24,7 @@ pub mod AccountComponent {
 
     #[storage]
     pub struct Storage {
-        Account_public_key: felt252
+        pub Account_public_key: felt252
     }
 
     #[event]

--- a/packages/account/src/account.cairo
+++ b/packages/account/src/account.cairo
@@ -19,9 +19,11 @@ pub mod AccountComponent {
     use starknet::get_caller_address;
     use starknet::get_contract_address;
     use starknet::get_tx_info;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         Account_public_key: felt252
     }
 

--- a/packages/account/src/eth_account.cairo
+++ b/packages/account/src/eth_account.cairo
@@ -23,9 +23,11 @@ pub mod EthAccountComponent {
     use starknet::get_caller_address;
     use starknet::get_contract_address;
     use starknet::get_tx_info;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         EthAccount_public_key: EthPublicKey
     }
 

--- a/packages/account/src/eth_account.cairo
+++ b/packages/account/src/eth_account.cairo
@@ -28,7 +28,7 @@ pub mod EthAccountComponent {
 
     #[storage]
     pub struct Storage {
-        EthAccount_public_key: EthPublicKey
+        pub EthAccount_public_key: EthPublicKey
     }
 
     #[event]

--- a/packages/account/src/eth_account.cairo
+++ b/packages/account/src/eth_account.cairo
@@ -23,8 +23,7 @@ pub mod EthAccountComponent {
     use starknet::get_caller_address;
     use starknet::get_contract_address;
     use starknet::get_tx_info;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 
     #[storage]
     pub struct Storage {

--- a/packages/account/src/tests/mocks/account_mocks.cairo
+++ b/packages/account/src/tests/mocks/account_mocks.cairo
@@ -22,11 +22,11 @@ pub(crate) mod DualCaseAccountMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        account: AccountComponent::Storage,
+        pub account: AccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -64,11 +64,11 @@ pub(crate) mod SnakeAccountMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        account: AccountComponent::Storage,
+        pub account: AccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -108,11 +108,11 @@ pub(crate) mod CamelAccountMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        account: AccountComponent::Storage,
+        pub account: AccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -153,7 +153,7 @@ pub(crate) mod CamelAccountMock {
 #[starknet::contract]
 pub(crate) mod SnakeAccountPanicMock {
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]
@@ -190,7 +190,7 @@ pub(crate) mod SnakeAccountPanicMock {
 #[starknet::contract]
 pub(crate) mod CamelAccountPanicMock {
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]

--- a/packages/account/src/tests/mocks/eth_account_mocks.cairo
+++ b/packages/account/src/tests/mocks/eth_account_mocks.cairo
@@ -20,11 +20,11 @@ pub(crate) mod DualCaseEthAccountMock {
     impl EthAccountInternalImpl = EthAccountComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        eth_account: EthAccountComponent::Storage,
+        pub eth_account: EthAccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -60,11 +60,11 @@ pub(crate) mod SnakeEthAccountMock {
     impl EthAccountInternalImpl = EthAccountComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        eth_account: EthAccountComponent::Storage,
+        pub eth_account: EthAccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -103,11 +103,11 @@ pub(crate) mod CamelEthAccountMock {
     impl EthAccountInternalImpl = EthAccountComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        eth_account: EthAccountComponent::Storage,
+        pub eth_account: EthAccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -152,7 +152,7 @@ pub(crate) mod SnakeEthAccountPanicMock {
     use starknet::secp256_trait::Secp256Trait;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]
@@ -193,7 +193,7 @@ pub(crate) mod CamelEthAccountPanicMock {
     use starknet::secp256_trait::Secp256Trait;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]

--- a/packages/account/src/tests/mocks/non_implementing_mock.cairo
+++ b/packages/account/src/tests/mocks/non_implementing_mock.cairo
@@ -1,7 +1,7 @@
 #[starknet::contract]
 pub(crate) mod NonImplementingMock {
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[external(v0)]
     fn nope(self: @ContractState) -> bool {

--- a/packages/account/src/tests/mocks/simple_mock.cairo
+++ b/packages/account/src/tests/mocks/simple_mock.cairo
@@ -10,7 +10,7 @@ pub(crate) mod SimpleMock {
     use starknet::storage::StoragePointerWriteAccess;
     #[storage]
     pub struct Storage {
-        balance: felt252,
+        pub balance: felt252,
     }
 
     #[abi(embed_v0)]

--- a/packages/account/src/tests/mocks/simple_mock.cairo
+++ b/packages/account/src/tests/mocks/simple_mock.cairo
@@ -7,8 +7,8 @@ pub(crate) trait ISimpleMock<TContractState> {
 #[starknet::contract]
 pub(crate) mod SimpleMock {
     use starknet::storage::StoragePointerReadAccess;
-use starknet::storage::StoragePointerWriteAccess;
-#[storage]
+    use starknet::storage::StoragePointerWriteAccess;
+    #[storage]
     pub struct Storage {
         balance: felt252,
     }

--- a/packages/account/src/tests/mocks/simple_mock.cairo
+++ b/packages/account/src/tests/mocks/simple_mock.cairo
@@ -6,8 +6,7 @@ pub(crate) trait ISimpleMock<TContractState> {
 
 #[starknet::contract]
 pub(crate) mod SimpleMock {
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     #[storage]
     pub struct Storage {
         pub balance: felt252,

--- a/packages/account/src/tests/mocks/simple_mock.cairo
+++ b/packages/account/src/tests/mocks/simple_mock.cairo
@@ -6,8 +6,10 @@ pub(crate) trait ISimpleMock<TContractState> {
 
 #[starknet::contract]
 pub(crate) mod SimpleMock {
-    #[storage]
-    struct Storage {
+    use starknet::storage::StoragePointerReadAccess;
+use starknet::storage::StoragePointerWriteAccess;
+#[storage]
+    pub struct Storage {
         balance: felt252,
     }
 

--- a/packages/governance/src/tests/mocks/non_implementing_mock.cairo
+++ b/packages/governance/src/tests/mocks/non_implementing_mock.cairo
@@ -1,7 +1,7 @@
 #[starknet::contract]
 pub(crate) mod NonImplementingMock {
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[external(v0)]
     fn nope(self: @ContractState) -> bool {

--- a/packages/governance/src/tests/mocks/timelock_mocks.cairo
+++ b/packages/governance/src/tests/mocks/timelock_mocks.cairo
@@ -58,8 +58,8 @@ pub(crate) trait IMockContract<TState> {
 #[starknet::contract]
 pub(crate) mod MockContract {
     use starknet::storage::StoragePointerReadAccess;
-use starknet::storage::StoragePointerWriteAccess;
-use super::IMockContract;
+    use starknet::storage::StoragePointerWriteAccess;
+    use super::IMockContract;
 
     #[storage]
     struct Storage {
@@ -90,10 +90,10 @@ pub(crate) trait ITimelockAttacker<TState> {
 
 #[starknet::contract]
 pub(crate) mod TimelockAttackerMock {
-    use starknet::storage::StoragePointerWriteAccess;
-use starknet::storage::StoragePointerReadAccess;
-use crate::timelock::interface::{ITimelockDispatcher, ITimelockDispatcherTrait};
+    use crate::timelock::interface::{ITimelockDispatcher, ITimelockDispatcherTrait};
     use starknet::account::Call;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
     use super::ITimelockAttacker;
 
     const NO_PREDECESSOR: felt252 = 0;

--- a/packages/governance/src/tests/mocks/timelock_mocks.cairo
+++ b/packages/governance/src/tests/mocks/timelock_mocks.cairo
@@ -57,8 +57,7 @@ pub(crate) trait IMockContract<TState> {
 
 #[starknet::contract]
 pub(crate) mod MockContract {
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use super::IMockContract;
 
     #[storage]
@@ -92,8 +91,7 @@ pub(crate) trait ITimelockAttacker<TState> {
 pub(crate) mod TimelockAttackerMock {
     use crate::timelock::interface::{ITimelockDispatcher, ITimelockDispatcherTrait};
     use starknet::account::Call;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use super::ITimelockAttacker;
 
     const NO_PREDECESSOR: felt252 = 0;

--- a/packages/governance/src/tests/mocks/timelock_mocks.cairo
+++ b/packages/governance/src/tests/mocks/timelock_mocks.cairo
@@ -16,13 +16,13 @@ pub(crate) mod TimelockControllerMock {
     impl TimelockInternalImpl = TimelockControllerComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        access_control: AccessControlComponent::Storage,
+        pub access_control: AccessControlComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage,
+        pub src5: SRC5Component::Storage,
         #[substorage(v0)]
-        timelock: TimelockControllerComponent::Storage
+        pub timelock: TimelockControllerComponent::Storage
     }
 
     #[event]
@@ -62,8 +62,8 @@ pub(crate) mod MockContract {
     use super::IMockContract;
 
     #[storage]
-    struct Storage {
-        number: felt252,
+    pub struct Storage {
+        pub number: felt252,
     }
 
     #[abi(embed_v0)]
@@ -100,9 +100,9 @@ pub(crate) mod TimelockAttackerMock {
     const NO_SALT: felt252 = 0;
 
     #[storage]
-    struct Storage {
-        balance: felt252,
-        count: felt252
+    pub struct Storage {
+        pub balance: felt252,
+        pub count: felt252
     }
 
     #[abi(embed_v0)]

--- a/packages/governance/src/tests/mocks/timelock_mocks.cairo
+++ b/packages/governance/src/tests/mocks/timelock_mocks.cairo
@@ -57,7 +57,9 @@ pub(crate) trait IMockContract<TState> {
 
 #[starknet::contract]
 pub(crate) mod MockContract {
-    use super::IMockContract;
+    use starknet::storage::StoragePointerReadAccess;
+use starknet::storage::StoragePointerWriteAccess;
+use super::IMockContract;
 
     #[storage]
     struct Storage {
@@ -88,7 +90,9 @@ pub(crate) trait ITimelockAttacker<TState> {
 
 #[starknet::contract]
 pub(crate) mod TimelockAttackerMock {
-    use crate::timelock::interface::{ITimelockDispatcher, ITimelockDispatcherTrait};
+    use starknet::storage::StoragePointerWriteAccess;
+use starknet::storage::StoragePointerReadAccess;
+use crate::timelock::interface::{ITimelockDispatcher, ITimelockDispatcherTrait};
     use starknet::account::Call;
     use super::ITimelockAttacker;
 

--- a/packages/governance/src/tests/test_timelock.cairo
+++ b/packages/governance/src/tests/test_timelock.cairo
@@ -1,6 +1,3 @@
-use starknet::storage::StoragePointerWriteAccess;
-use starknet::storage::StorageMapReadAccess;
-use starknet::storage::StorageMapWriteAccess;
 use core::hash::{HashStateTrait, HashStateExTrait};
 use core::pedersen::PedersenTrait;
 use crate::tests::mocks::timelock_mocks::{IMockContractDispatcher, IMockContractDispatcherTrait};
@@ -36,6 +33,9 @@ use snforge_std::{
 use starknet::ContractAddress;
 use starknet::account::Call;
 use starknet::contract_address_const;
+use starknet::storage::StorageMapReadAccess;
+use starknet::storage::StorageMapWriteAccess;
+use starknet::storage::StoragePointerWriteAccess;
 
 type ComponentState =
     TimelockControllerComponent::ComponentState<TimelockControllerMock::ContractState>;

--- a/packages/governance/src/tests/test_timelock.cairo
+++ b/packages/governance/src/tests/test_timelock.cairo
@@ -1,3 +1,6 @@
+use starknet::storage::StoragePointerWriteAccess;
+use starknet::storage::StorageMapReadAccess;
+use starknet::storage::StorageMapWriteAccess;
 use core::hash::{HashStateTrait, HashStateExTrait};
 use core::pedersen::PedersenTrait;
 use crate::tests::mocks::timelock_mocks::{IMockContractDispatcher, IMockContractDispatcherTrait};
@@ -37,8 +40,8 @@ use starknet::contract_address_const;
 type ComponentState =
     TimelockControllerComponent::ComponentState<TimelockControllerMock::ContractState>;
 
-fn CONTRACT_STATE() -> TimelockControllerMock::ContractState {
-    TimelockControllerMock::contract_state_for_testing()
+fn CONTRACT_STATE() -> @TimelockControllerMock::ContractState {
+    @TimelockControllerMock::contract_state_for_testing()
 }
 
 fn COMPONENT_STATE() -> ComponentState {

--- a/packages/governance/src/tests/test_timelock.cairo
+++ b/packages/governance/src/tests/test_timelock.cairo
@@ -33,9 +33,7 @@ use snforge_std::{
 use starknet::ContractAddress;
 use starknet::account::Call;
 use starknet::contract_address_const;
-use starknet::storage::StorageMapReadAccess;
-use starknet::storage::StorageMapWriteAccess;
-use starknet::storage::StoragePointerWriteAccess;
+use starknet::storage::{StorageMapReadAccess, StorageMapWriteAccess, StoragePointerWriteAccess};
 
 type ComponentState =
     TimelockControllerComponent::ComponentState<TimelockControllerMock::ContractState>;

--- a/packages/governance/src/timelock/timelock_controller.cairo
+++ b/packages/governance/src/timelock/timelock_controller.cairo
@@ -31,6 +31,10 @@ pub mod TimelockControllerComponent {
     use starknet::SyscallResultTrait;
     use starknet::account::Call;
     use starknet::storage::Map;
+    use starknet::storage::StorageMapReadAccess;
+    use starknet::storage::StorageMapWriteAccess;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
     use super::OperationState;
 
     // Constants
@@ -40,7 +44,7 @@ pub mod TimelockControllerComponent {
     const DONE_TIMESTAMP: u64 = 1;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         TimelockController_timestamps: Map<felt252, u64>,
         TimelockController_min_delay: u64
     }

--- a/packages/governance/src/timelock/timelock_controller.cairo
+++ b/packages/governance/src/timelock/timelock_controller.cairo
@@ -30,11 +30,7 @@ pub mod TimelockControllerComponent {
     use starknet::ContractAddress;
     use starknet::SyscallResultTrait;
     use starknet::account::Call;
-    use starknet::storage::Map;
-    use starknet::storage::StorageMapReadAccess;
-    use starknet::storage::StorageMapWriteAccess;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess, StoragePointerWriteAccess};
     use super::OperationState;
 
     // Constants

--- a/packages/governance/src/timelock/timelock_controller.cairo
+++ b/packages/governance/src/timelock/timelock_controller.cairo
@@ -45,8 +45,8 @@ pub mod TimelockControllerComponent {
 
     #[storage]
     pub struct Storage {
-        TimelockController_timestamps: Map<felt252, u64>,
-        TimelockController_min_delay: u64
+        pub TimelockController_timestamps: Map<felt252, u64>,
+        pub TimelockController_min_delay: u64
     }
 
     #[event]

--- a/packages/governance/src/timelock/timelock_controller.cairo
+++ b/packages/governance/src/timelock/timelock_controller.cairo
@@ -30,7 +30,10 @@ pub mod TimelockControllerComponent {
     use starknet::ContractAddress;
     use starknet::SyscallResultTrait;
     use starknet::account::Call;
-    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess
+    };
     use super::OperationState;
 
     // Constants

--- a/packages/introspection/src/src5.cairo
+++ b/packages/introspection/src/src5.cairo
@@ -13,7 +13,7 @@ pub mod SRC5Component {
 
     #[storage]
     pub struct Storage {
-        SRC5_supported_interfaces: Map<felt252, bool>
+        pub SRC5_supported_interfaces: Map<felt252, bool>
     }
 
     pub mod Errors {

--- a/packages/introspection/src/src5.cairo
+++ b/packages/introspection/src/src5.cairo
@@ -7,9 +7,7 @@
 #[starknet::component]
 pub mod SRC5Component {
     use crate::interface;
-    use starknet::storage::Map;
-    use starknet::storage::StorageMapReadAccess;
-    use starknet::storage::StorageMapWriteAccess;
+    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess};
 
     #[storage]
     pub struct Storage {

--- a/packages/introspection/src/src5.cairo
+++ b/packages/introspection/src/src5.cairo
@@ -8,9 +8,11 @@
 pub mod SRC5Component {
     use crate::interface;
     use starknet::storage::Map;
+    use starknet::storage::StorageMapReadAccess;
+    use starknet::storage::StorageMapWriteAccess;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         SRC5_supported_interfaces: Map<felt252, bool>
     }
 

--- a/packages/introspection/src/tests/mocks/src5_mocks.cairo
+++ b/packages/introspection/src/tests/mocks/src5_mocks.cairo
@@ -8,9 +8,9 @@ pub(crate) mod SRC5Mock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]

--- a/packages/presets/src/account.cairo
+++ b/packages/presets/src/account.cairo
@@ -29,11 +29,11 @@ pub mod AccountUpgradeable {
     #[storage]
     pub struct Storage {
         #[substorage(v0)]
-        account: AccountComponent::Storage,
+        pub account: AccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage,
+        pub src5: SRC5Component::Storage,
         #[substorage(v0)]
-        upgradeable: UpgradeableComponent::Storage
+        pub upgradeable: UpgradeableComponent::Storage
     }
 
     #[event]

--- a/packages/presets/src/account.cairo
+++ b/packages/presets/src/account.cairo
@@ -27,7 +27,7 @@ pub mod AccountUpgradeable {
     impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
         account: AccountComponent::Storage,
         #[substorage(v0)]

--- a/packages/presets/src/erc1155.cairo
+++ b/packages/presets/src/erc1155.cairo
@@ -36,7 +36,7 @@ pub mod ERC1155Upgradeable {
     impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
         ownable: OwnableComponent::Storage,
         #[substorage(v0)]

--- a/packages/presets/src/erc1155.cairo
+++ b/packages/presets/src/erc1155.cairo
@@ -38,13 +38,13 @@ pub mod ERC1155Upgradeable {
     #[storage]
     pub struct Storage {
         #[substorage(v0)]
-        ownable: OwnableComponent::Storage,
+        pub ownable: OwnableComponent::Storage,
         #[substorage(v0)]
-        erc1155: ERC1155Component::Storage,
+        pub erc1155: ERC1155Component::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage,
+        pub src5: SRC5Component::Storage,
         #[substorage(v0)]
-        upgradeable: UpgradeableComponent::Storage
+        pub upgradeable: UpgradeableComponent::Storage
     }
 
     #[event]

--- a/packages/presets/src/erc20.cairo
+++ b/packages/presets/src/erc20.cairo
@@ -37,11 +37,11 @@ pub mod ERC20Upgradeable {
     #[storage]
     pub struct Storage {
         #[substorage(v0)]
-        ownable: OwnableComponent::Storage,
+        pub ownable: OwnableComponent::Storage,
         #[substorage(v0)]
-        erc20: ERC20Component::Storage,
+        pub erc20: ERC20Component::Storage,
         #[substorage(v0)]
-        upgradeable: UpgradeableComponent::Storage
+        pub upgradeable: UpgradeableComponent::Storage
     }
 
     #[event]

--- a/packages/presets/src/erc20.cairo
+++ b/packages/presets/src/erc20.cairo
@@ -35,7 +35,7 @@ pub mod ERC20Upgradeable {
     impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
         ownable: OwnableComponent::Storage,
         #[substorage(v0)]

--- a/packages/presets/src/erc721.cairo
+++ b/packages/presets/src/erc721.cairo
@@ -36,7 +36,7 @@ pub mod ERC721Upgradeable {
     impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
         ownable: OwnableComponent::Storage,
         #[substorage(v0)]

--- a/packages/presets/src/erc721.cairo
+++ b/packages/presets/src/erc721.cairo
@@ -38,13 +38,13 @@ pub mod ERC721Upgradeable {
     #[storage]
     pub struct Storage {
         #[substorage(v0)]
-        ownable: OwnableComponent::Storage,
+        pub ownable: OwnableComponent::Storage,
         #[substorage(v0)]
-        erc721: ERC721Component::Storage,
+        pub erc721: ERC721Component::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage,
+        pub src5: SRC5Component::Storage,
         #[substorage(v0)]
-        upgradeable: UpgradeableComponent::Storage
+        pub upgradeable: UpgradeableComponent::Storage
     }
 
     #[event]

--- a/packages/presets/src/eth_account.cairo
+++ b/packages/presets/src/eth_account.cairo
@@ -30,11 +30,11 @@ pub(crate) mod EthAccountUpgradeable {
     #[storage]
     pub struct Storage {
         #[substorage(v0)]
-        eth_account: EthAccountComponent::Storage,
+        pub eth_account: EthAccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage,
+        pub src5: SRC5Component::Storage,
         #[substorage(v0)]
-        upgradeable: UpgradeableComponent::Storage
+        pub upgradeable: UpgradeableComponent::Storage
     }
 
     #[event]

--- a/packages/presets/src/eth_account.cairo
+++ b/packages/presets/src/eth_account.cairo
@@ -28,7 +28,7 @@ pub(crate) mod EthAccountUpgradeable {
     impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
         eth_account: EthAccountComponent::Storage,
         #[substorage(v0)]

--- a/packages/presets/src/tests/mocks/account_mocks.cairo
+++ b/packages/presets/src/tests/mocks/account_mocks.cairo
@@ -22,11 +22,11 @@ pub(crate) mod DualCaseAccountMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        account: AccountComponent::Storage,
+        pub account: AccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -64,11 +64,11 @@ pub(crate) mod SnakeAccountMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        account: AccountComponent::Storage,
+        pub account: AccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -108,11 +108,11 @@ pub(crate) mod CamelAccountMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        account: AccountComponent::Storage,
+        pub account: AccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]

--- a/packages/presets/src/tests/mocks/erc1155_mocks.cairo
+++ b/packages/presets/src/tests/mocks/erc1155_mocks.cairo
@@ -20,11 +20,11 @@ pub(crate) mod SnakeERC1155Mock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc1155: ERC1155Component::Storage,
+        pub erc1155: ERC1155Component::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -71,11 +71,11 @@ pub(crate) mod CamelERC1155Mock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc1155: ERC1155Component::Storage,
+        pub erc1155: ERC1155Component::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]

--- a/packages/presets/src/tests/mocks/erc1155_receiver_mocks.cairo
+++ b/packages/presets/src/tests/mocks/erc1155_receiver_mocks.cairo
@@ -19,11 +19,11 @@ pub(crate) mod SnakeERC1155ReceiverMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc1155_receiver: ERC1155ReceiverComponent::Storage,
+        pub erc1155_receiver: ERC1155ReceiverComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]

--- a/packages/presets/src/tests/mocks/erc20_mocks.cairo
+++ b/packages/presets/src/tests/mocks/erc20_mocks.cairo
@@ -14,9 +14,9 @@ pub(crate) mod DualCaseERC20Mock {
     impl InternalImpl = ERC20Component::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc20: ERC20Component::Storage
+        pub erc20: ERC20Component::Storage
     }
 
     #[event]
@@ -53,9 +53,9 @@ pub(crate) mod SnakeERC20Mock {
     impl InternalImpl = ERC20Component::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc20: ERC20Component::Storage
+        pub erc20: ERC20Component::Storage
     }
 
     #[event]

--- a/packages/presets/src/tests/mocks/erc721_mocks.cairo
+++ b/packages/presets/src/tests/mocks/erc721_mocks.cairo
@@ -19,11 +19,11 @@ pub(crate) mod SnakeERC721Mock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc721: ERC721Component::Storage,
+        pub erc721: ERC721Component::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]

--- a/packages/presets/src/tests/mocks/erc721_receiver_mocks.cairo
+++ b/packages/presets/src/tests/mocks/erc721_receiver_mocks.cairo
@@ -18,11 +18,11 @@ pub(crate) mod SnakeERC721ReceiverMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc721_receiver: ERC721ReceiverComponent::Storage,
+        pub erc721_receiver: ERC721ReceiverComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -77,11 +77,11 @@ pub(crate) mod CamelERC721ReceiverMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc721_receiver: ERC721ReceiverComponent::Storage,
+        pub erc721_receiver: ERC721ReceiverComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]

--- a/packages/presets/src/tests/mocks/eth_account_mocks.cairo
+++ b/packages/presets/src/tests/mocks/eth_account_mocks.cairo
@@ -16,11 +16,11 @@ pub(crate) mod SnakeEthAccountMock {
     impl EthAccountInternalImpl = EthAccountComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        eth_account: EthAccountComponent::Storage,
+        pub eth_account: EthAccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]

--- a/packages/presets/src/tests/mocks/non_implementing_mock.cairo
+++ b/packages/presets/src/tests/mocks/non_implementing_mock.cairo
@@ -1,7 +1,7 @@
 #[starknet::contract]
 pub(crate) mod NonImplementingMock {
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[external(v0)]
     fn nope(self: @ContractState) -> bool {

--- a/packages/presets/src/tests/mocks/src5_mocks.cairo
+++ b/packages/presets/src/tests/mocks/src5_mocks.cairo
@@ -8,9 +8,9 @@ pub(crate) mod SRC5Mock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]

--- a/packages/presets/src/universal_deployer.cairo
+++ b/packages/presets/src/universal_deployer.cairo
@@ -15,7 +15,7 @@ pub mod UniversalDeployer {
     use starknet::get_caller_address;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[event]
     #[derive(Drop, PartialEq, starknet::Event)]

--- a/packages/security/src/initializable.cairo
+++ b/packages/security/src/initializable.cairo
@@ -9,8 +9,7 @@
 #[starknet::component]
 pub mod InitializableComponent {
     use crate::interface::IInitializable;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 
     #[storage]
     pub struct Storage {

--- a/packages/security/src/initializable.cairo
+++ b/packages/security/src/initializable.cairo
@@ -9,9 +9,11 @@
 #[starknet::component]
 pub mod InitializableComponent {
     use crate::interface::IInitializable;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         Initializable_initialized: bool
     }
 

--- a/packages/security/src/initializable.cairo
+++ b/packages/security/src/initializable.cairo
@@ -14,7 +14,7 @@ pub mod InitializableComponent {
 
     #[storage]
     pub struct Storage {
-        Initializable_initialized: bool
+        pub Initializable_initialized: bool
     }
 
     pub mod Errors {

--- a/packages/security/src/pausable.cairo
+++ b/packages/security/src/pausable.cairo
@@ -12,8 +12,7 @@ pub mod PausableComponent {
 
     use starknet::ContractAddress;
     use starknet::get_caller_address;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 
     #[storage]
     pub struct Storage {

--- a/packages/security/src/pausable.cairo
+++ b/packages/security/src/pausable.cairo
@@ -17,7 +17,7 @@ pub mod PausableComponent {
 
     #[storage]
     pub struct Storage {
-        Pausable_paused: bool
+        pub Pausable_paused: bool
     }
 
     #[event]

--- a/packages/security/src/pausable.cairo
+++ b/packages/security/src/pausable.cairo
@@ -12,9 +12,11 @@ pub mod PausableComponent {
 
     use starknet::ContractAddress;
     use starknet::get_caller_address;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         Pausable_paused: bool
     }
 

--- a/packages/security/src/reentrancyguard.cairo
+++ b/packages/security/src/reentrancyguard.cairo
@@ -7,8 +7,7 @@
 /// to a function.
 #[starknet::component]
 pub mod ReentrancyGuardComponent {
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     #[storage]
     pub struct Storage {
         pub ReentrancyGuard_entered: bool

--- a/packages/security/src/reentrancyguard.cairo
+++ b/packages/security/src/reentrancyguard.cairo
@@ -11,7 +11,7 @@ pub mod ReentrancyGuardComponent {
     use starknet::storage::StoragePointerWriteAccess;
     #[storage]
     pub struct Storage {
-        ReentrancyGuard_entered: bool
+        pub ReentrancyGuard_entered: bool
     }
 
     pub mod Errors {

--- a/packages/security/src/reentrancyguard.cairo
+++ b/packages/security/src/reentrancyguard.cairo
@@ -7,8 +7,10 @@
 /// to a function.
 #[starknet::component]
 pub mod ReentrancyGuardComponent {
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
     #[storage]
-    struct Storage {
+    pub struct Storage {
         ReentrancyGuard_entered: bool
     }
 

--- a/packages/security/src/tests/mocks/initializable_mocks.cairo
+++ b/packages/security/src/tests/mocks/initializable_mocks.cairo
@@ -9,9 +9,9 @@ pub(crate) mod InitializableMock {
         InitializableComponent::InitializableImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        initializable: InitializableComponent::Storage
+        pub initializable: InitializableComponent::Storage
     }
 
     #[event]

--- a/packages/security/src/tests/mocks/pausable_mocks.cairo
+++ b/packages/security/src/tests/mocks/pausable_mocks.cairo
@@ -9,9 +9,9 @@ pub(crate) mod PausableMock {
     impl InternalImpl = PausableComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        pausable: PausableComponent::Storage
+        pub pausable: PausableComponent::Storage
     }
 
     #[event]

--- a/packages/security/src/tests/mocks/reentrancy_mocks.cairo
+++ b/packages/security/src/tests/mocks/reentrancy_mocks.cairo
@@ -34,10 +34,10 @@ pub(crate) mod ReentrancyMock {
     impl InternalImpl = ReentrancyGuardComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
-        counter: felt252,
+    pub struct Storage {
+        pub counter: felt252,
         #[substorage(v0)]
-        reentrancy_guard: ReentrancyGuardComponent::Storage
+        pub reentrancy_guard: ReentrancyGuardComponent::Storage
     }
 
     #[event]
@@ -115,7 +115,7 @@ pub(crate) mod Attacker {
     use super::IReentrancyMockDispatcherTrait;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(embed_v0)]
     impl IAttackerImpl of super::IAttacker<ContractState> {

--- a/packages/security/src/tests/mocks/reentrancy_mocks.cairo
+++ b/packages/security/src/tests/mocks/reentrancy_mocks.cairo
@@ -17,11 +17,11 @@ pub(crate) trait IReentrancyMock<TState> {
 
 #[starknet::contract]
 pub(crate) mod ReentrancyMock {
-    use starknet::storage::StoragePointerReadAccess;
-use starknet::storage::StoragePointerWriteAccess;
-use crate::reentrancyguard::ReentrancyGuardComponent;
+    use crate::reentrancyguard::ReentrancyGuardComponent;
     use starknet::ContractAddress;
     use starknet::get_contract_address;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
     use super::IAttackerDispatcher;
     use super::IAttackerDispatcherTrait;
     use super::IReentrancyGuardedDispatcher;

--- a/packages/security/src/tests/mocks/reentrancy_mocks.cairo
+++ b/packages/security/src/tests/mocks/reentrancy_mocks.cairo
@@ -20,8 +20,7 @@ pub(crate) mod ReentrancyMock {
     use crate::reentrancyguard::ReentrancyGuardComponent;
     use starknet::ContractAddress;
     use starknet::get_contract_address;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use super::IAttackerDispatcher;
     use super::IAttackerDispatcherTrait;
     use super::IReentrancyGuardedDispatcher;

--- a/packages/security/src/tests/mocks/reentrancy_mocks.cairo
+++ b/packages/security/src/tests/mocks/reentrancy_mocks.cairo
@@ -17,7 +17,9 @@ pub(crate) trait IReentrancyMock<TState> {
 
 #[starknet::contract]
 pub(crate) mod ReentrancyMock {
-    use crate::reentrancyguard::ReentrancyGuardComponent;
+    use starknet::storage::StoragePointerReadAccess;
+use starknet::storage::StoragePointerWriteAccess;
+use crate::reentrancyguard::ReentrancyGuardComponent;
     use starknet::ContractAddress;
     use starknet::get_contract_address;
     use super::IAttackerDispatcher;

--- a/packages/security/src/tests/test_reentrancyguard.cairo
+++ b/packages/security/src/tests/test_reentrancyguard.cairo
@@ -4,6 +4,7 @@ use crate::tests::mocks::reentrancy_mocks::{
     ReentrancyMock, IReentrancyMockDispatcher, IReentrancyMockDispatcherTrait
 };
 use openzeppelin_testing as utils;
+use starknet::storage::StoragePointerReadAccess;
 
 type ComponentState = ReentrancyGuardComponent::ComponentState<ReentrancyMock::ContractState>;
 

--- a/packages/token/src/common/erc2981/erc2981.cairo
+++ b/packages/token/src/common/erc2981/erc2981.cairo
@@ -25,11 +25,10 @@ pub mod ERC2981Component {
     use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
-    use starknet::storage::Map;
-    use starknet::storage::StorageMapReadAccess;
-    use starknet::storage::StorageMapWriteAccess;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess
+    };
 
     // This default denominator is only used when the DefaultConfig
     // is in scope in the implementing contract.

--- a/packages/token/src/common/erc2981/erc2981.cairo
+++ b/packages/token/src/common/erc2981/erc2981.cairo
@@ -26,6 +26,10 @@ pub mod ERC2981Component {
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
     use starknet::storage::Map;
+    use starknet::storage::StorageMapReadAccess;
+    use starknet::storage::StorageMapWriteAccess;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
 
     // This default denominator is only used when the DefaultConfig
     // is in scope in the implementing contract.
@@ -38,7 +42,7 @@ pub mod ERC2981Component {
     }
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         ERC2981_default_royalty_info: RoyaltyInfo,
         ERC2981_token_royalty_info: Map<u256, RoyaltyInfo>,
     }

--- a/packages/token/src/common/erc2981/erc2981.cairo
+++ b/packages/token/src/common/erc2981/erc2981.cairo
@@ -43,8 +43,8 @@ pub mod ERC2981Component {
 
     #[storage]
     pub struct Storage {
-        ERC2981_default_royalty_info: RoyaltyInfo,
-        ERC2981_token_royalty_info: Map<u256, RoyaltyInfo>,
+        pub ERC2981_default_royalty_info: RoyaltyInfo,
+        pub ERC2981_token_royalty_info: Map<u256, RoyaltyInfo>,
     }
 
     mod Errors {

--- a/packages/token/src/erc1155/erc1155.cairo
+++ b/packages/token/src/erc1155/erc1155.cairo
@@ -17,11 +17,10 @@ pub mod ERC1155Component {
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
-    use starknet::storage::Map;
-    use starknet::storage::StorageMapReadAccess;
-    use starknet::storage::StorageMapWriteAccess;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess
+    };
 
     #[storage]
     pub struct Storage {

--- a/packages/token/src/erc1155/erc1155.cairo
+++ b/packages/token/src/erc1155/erc1155.cairo
@@ -18,9 +18,13 @@ pub mod ERC1155Component {
     use starknet::ContractAddress;
     use starknet::get_caller_address;
     use starknet::storage::Map;
+    use starknet::storage::StorageMapReadAccess;
+    use starknet::storage::StorageMapWriteAccess;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         ERC1155_balances: Map<(u256, ContractAddress), u256>,
         ERC1155_operator_approvals: Map<(ContractAddress, ContractAddress), bool>,
         ERC1155_uri: ByteArray,

--- a/packages/token/src/erc1155/erc1155.cairo
+++ b/packages/token/src/erc1155/erc1155.cairo
@@ -25,9 +25,9 @@ pub mod ERC1155Component {
 
     #[storage]
     pub struct Storage {
-        ERC1155_balances: Map<(u256, ContractAddress), u256>,
-        ERC1155_operator_approvals: Map<(ContractAddress, ContractAddress), bool>,
-        ERC1155_uri: ByteArray,
+        pub ERC1155_balances: Map<(u256, ContractAddress), u256>,
+        pub ERC1155_operator_approvals: Map<(ContractAddress, ContractAddress), bool>,
+        pub ERC1155_uri: ByteArray,
     }
 
     #[event]

--- a/packages/token/src/erc1155/erc1155_receiver.cairo
+++ b/packages/token/src/erc1155/erc1155_receiver.cairo
@@ -16,7 +16,7 @@ pub mod ERC1155ReceiverComponent {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[embeddable_as(ERC1155ReceiverImpl)]
     impl ERC1155Receiver<

--- a/packages/token/src/erc20/erc20.cairo
+++ b/packages/token/src/erc20/erc20.cairo
@@ -17,7 +17,10 @@ pub mod ERC20Component {
     use crate::erc20::interface;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
-    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess
+    };
 
     #[storage]
     pub struct Storage {

--- a/packages/token/src/erc20/erc20.cairo
+++ b/packages/token/src/erc20/erc20.cairo
@@ -25,11 +25,11 @@ pub mod ERC20Component {
 
     #[storage]
     pub struct Storage {
-        ERC20_name: ByteArray,
-        ERC20_symbol: ByteArray,
-        ERC20_total_supply: u256,
-        ERC20_balances: Map<ContractAddress, u256>,
-        ERC20_allowances: Map<(ContractAddress, ContractAddress), u256>,
+        pub ERC20_name: ByteArray,
+        pub ERC20_symbol: ByteArray,
+        pub ERC20_total_supply: u256,
+        pub ERC20_balances: Map<ContractAddress, u256>,
+        pub ERC20_allowances: Map<(ContractAddress, ContractAddress), u256>,
     }
 
     #[event]

--- a/packages/token/src/erc20/erc20.cairo
+++ b/packages/token/src/erc20/erc20.cairo
@@ -17,11 +17,7 @@ pub mod ERC20Component {
     use crate::erc20::interface;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
-    use starknet::storage::Map;
-    use starknet::storage::StorageMapReadAccess;
-    use starknet::storage::StorageMapWriteAccess;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess, StoragePointerWriteAccess};
 
     #[storage]
     pub struct Storage {

--- a/packages/token/src/erc20/erc20.cairo
+++ b/packages/token/src/erc20/erc20.cairo
@@ -18,9 +18,13 @@ pub mod ERC20Component {
     use starknet::ContractAddress;
     use starknet::get_caller_address;
     use starknet::storage::Map;
+    use starknet::storage::StorageMapReadAccess;
+    use starknet::storage::StorageMapWriteAccess;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         ERC20_name: ByteArray,
         ERC20_symbol: ByteArray,
         ERC20_total_supply: u256,

--- a/packages/token/src/erc20/extensions/erc20_votes.cairo
+++ b/packages/token/src/erc20/extensions/erc20_votes.cairo
@@ -25,7 +25,9 @@ pub mod ERC20VotesComponent {
     use openzeppelin_utils::nonces::NoncesComponent;
     use openzeppelin_utils::structs::checkpoint::{Checkpoint, Trace, TraceTrait};
     use starknet::ContractAddress;
-    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess};
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess
+    };
     use super::{Delegation, OffchainMessageHash, SNIP12Metadata};
 
     #[storage]

--- a/packages/token/src/erc20/extensions/erc20_votes.cairo
+++ b/packages/token/src/erc20/extensions/erc20_votes.cairo
@@ -33,9 +33,9 @@ pub mod ERC20VotesComponent {
 
     #[storage]
     pub struct Storage {
-        ERC20Votes_delegatee: Map<ContractAddress, ContractAddress>,
-        ERC20Votes_delegate_checkpoints: Map<ContractAddress, Trace>,
-        ERC20Votes_total_checkpoints: Trace
+        pub ERC20Votes_delegatee: Map<ContractAddress, ContractAddress>,
+        pub ERC20Votes_delegate_checkpoints: Map<ContractAddress, Trace>,
+        pub ERC20Votes_total_checkpoints: Trace
     }
 
     #[event]

--- a/packages/token/src/erc20/extensions/erc20_votes.cairo
+++ b/packages/token/src/erc20/extensions/erc20_votes.cairo
@@ -25,10 +25,7 @@ pub mod ERC20VotesComponent {
     use openzeppelin_utils::nonces::NoncesComponent;
     use openzeppelin_utils::structs::checkpoint::{Checkpoint, Trace, TraceTrait};
     use starknet::ContractAddress;
-    use starknet::storage::Map;
-    use starknet::storage::StorageMapReadAccess;
-    use starknet::storage::StorageMapWriteAccess;
-    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess};
     use super::{Delegation, OffchainMessageHash, SNIP12Metadata};
 
     #[storage]

--- a/packages/token/src/erc20/extensions/erc20_votes.cairo
+++ b/packages/token/src/erc20/extensions/erc20_votes.cairo
@@ -26,10 +26,13 @@ pub mod ERC20VotesComponent {
     use openzeppelin_utils::structs::checkpoint::{Checkpoint, Trace, TraceTrait};
     use starknet::ContractAddress;
     use starknet::storage::Map;
+    use starknet::storage::StorageMapReadAccess;
+    use starknet::storage::StorageMapWriteAccess;
+    use starknet::storage::StoragePointerReadAccess;
     use super::{Delegation, OffchainMessageHash, SNIP12Metadata};
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         ERC20Votes_delegatee: Map<ContractAddress, ContractAddress>,
         ERC20Votes_delegate_checkpoints: Map<ContractAddress, Trace>,
         ERC20Votes_total_checkpoints: Trace

--- a/packages/token/src/erc721/erc721.cairo
+++ b/packages/token/src/erc721/erc721.cairo
@@ -16,11 +16,10 @@ pub mod ERC721Component {
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
-    use starknet::storage::Map;
-    use starknet::storage::StorageMapReadAccess;
-    use starknet::storage::StorageMapWriteAccess;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess
+    };
 
     #[storage]
     pub struct Storage {

--- a/packages/token/src/erc721/erc721.cairo
+++ b/packages/token/src/erc721/erc721.cairo
@@ -24,13 +24,13 @@ pub mod ERC721Component {
 
     #[storage]
     pub struct Storage {
-        ERC721_name: ByteArray,
-        ERC721_symbol: ByteArray,
-        ERC721_owners: Map<u256, ContractAddress>,
-        ERC721_balances: Map<ContractAddress, u256>,
-        ERC721_token_approvals: Map<u256, ContractAddress>,
-        ERC721_operator_approvals: Map<(ContractAddress, ContractAddress), bool>,
-        ERC721_base_uri: ByteArray
+        pub ERC721_name: ByteArray,
+        pub ERC721_symbol: ByteArray,
+        pub ERC721_owners: Map<u256, ContractAddress>,
+        pub ERC721_balances: Map<ContractAddress, u256>,
+        pub ERC721_token_approvals: Map<u256, ContractAddress>,
+        pub ERC721_operator_approvals: Map<(ContractAddress, ContractAddress), bool>,
+        pub ERC721_base_uri: ByteArray
     }
 
     #[event]

--- a/packages/token/src/erc721/erc721.cairo
+++ b/packages/token/src/erc721/erc721.cairo
@@ -17,9 +17,13 @@ pub mod ERC721Component {
     use starknet::ContractAddress;
     use starknet::get_caller_address;
     use starknet::storage::Map;
+    use starknet::storage::StorageMapReadAccess;
+    use starknet::storage::StorageMapWriteAccess;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         ERC721_name: ByteArray,
         ERC721_symbol: ByteArray,
         ERC721_owners: Map<u256, ContractAddress>,

--- a/packages/token/src/erc721/erc721_receiver.cairo
+++ b/packages/token/src/erc721/erc721_receiver.cairo
@@ -17,7 +17,7 @@ pub mod ERC721ReceiverComponent {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[embeddable_as(ERC721ReceiverImpl)]
     impl ERC721Receiver<

--- a/packages/token/src/erc721/extensions/erc721_enumerable/erc721_enumerable.cairo
+++ b/packages/token/src/erc721/extensions/erc721_enumerable/erc721_enumerable.cairo
@@ -25,11 +25,10 @@ pub mod ERC721EnumerableComponent {
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
-    use starknet::storage::Map;
-    use starknet::storage::StorageMapReadAccess;
-    use starknet::storage::StorageMapWriteAccess;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess
+    };
 
     #[storage]
     pub struct Storage {

--- a/packages/token/src/erc721/extensions/erc721_enumerable/erc721_enumerable.cairo
+++ b/packages/token/src/erc721/extensions/erc721_enumerable/erc721_enumerable.cairo
@@ -33,11 +33,11 @@ pub mod ERC721EnumerableComponent {
 
     #[storage]
     pub struct Storage {
-        ERC721Enumerable_owned_tokens: Map<(ContractAddress, u256), u256>,
-        ERC721Enumerable_owned_tokens_index: Map<u256, u256>,
-        ERC721Enumerable_all_tokens_len: u256,
-        ERC721Enumerable_all_tokens: Map<u256, u256>,
-        ERC721Enumerable_all_tokens_index: Map<u256, u256>
+        pub ERC721Enumerable_owned_tokens: Map<(ContractAddress, u256), u256>,
+        pub ERC721Enumerable_owned_tokens_index: Map<u256, u256>,
+        pub ERC721Enumerable_all_tokens_len: u256,
+        pub ERC721Enumerable_all_tokens: Map<u256, u256>,
+        pub ERC721Enumerable_all_tokens_index: Map<u256, u256>
     }
 
     pub mod Errors {

--- a/packages/token/src/erc721/extensions/erc721_enumerable/erc721_enumerable.cairo
+++ b/packages/token/src/erc721/extensions/erc721_enumerable/erc721_enumerable.cairo
@@ -26,9 +26,13 @@ pub mod ERC721EnumerableComponent {
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
     use starknet::storage::Map;
+    use starknet::storage::StorageMapReadAccess;
+    use starknet::storage::StorageMapWriteAccess;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         ERC721Enumerable_owned_tokens: Map<(ContractAddress, u256), u256>,
         ERC721Enumerable_owned_tokens_index: Map<u256, u256>,
         ERC721Enumerable_all_tokens_len: u256,

--- a/packages/token/src/tests/erc1155/test_erc1155.cairo
+++ b/packages/token/src/tests/erc1155/test_erc1155.cairo
@@ -1,4 +1,3 @@
-use starknet::storage::StoragePointerReadAccess;
 use core::num::traits::Zero;
 use crate::erc1155::ERC1155Component::ERC1155CamelImpl;
 use crate::erc1155::ERC1155Component::{ERC1155Impl, ERC1155MetadataURIImpl, InternalImpl};
@@ -18,6 +17,7 @@ use openzeppelin_testing::constants::{
 };
 use snforge_std::{spy_events, test_address, start_cheat_caller_address};
 use starknet::ContractAddress;
+use starknet::storage::StoragePointerReadAccess;
 
 //
 // Setup

--- a/packages/token/src/tests/erc1155/test_erc1155.cairo
+++ b/packages/token/src/tests/erc1155/test_erc1155.cairo
@@ -1,3 +1,4 @@
+use starknet::storage::StoragePointerReadAccess;
 use core::num::traits::Zero;
 use crate::erc1155::ERC1155Component::ERC1155CamelImpl;
 use crate::erc1155::ERC1155Component::{ERC1155Impl, ERC1155MetadataURIImpl, InternalImpl};

--- a/packages/token/src/tests/erc20/test_erc20_votes.cairo
+++ b/packages/token/src/tests/erc20/test_erc20_votes.cairo
@@ -19,8 +19,7 @@ use snforge_std::{
     start_cheat_block_timestamp_global, start_cheat_caller_address, spy_events,
     start_cheat_chain_id_global, test_address
 };
-use starknet::storage::StorageMapReadAccess;
-use starknet::storage::StoragePointerReadAccess;
+use starknet::storage::{StorageMapReadAccess, StoragePointerReadAccess};
 use starknet::{ContractAddress, contract_address_const};
 
 //

--- a/packages/token/src/tests/erc20/test_erc20_votes.cairo
+++ b/packages/token/src/tests/erc20/test_erc20_votes.cairo
@@ -1,5 +1,3 @@
-use starknet::storage::StoragePointerReadAccess;
-use starknet::storage::StorageMapReadAccess;
 use core::num::traits::Bounded;
 use core::num::traits::Zero;
 use crate::erc20::ERC20Component::InternalImpl as ERC20Impl;
@@ -21,6 +19,8 @@ use snforge_std::{
     start_cheat_block_timestamp_global, start_cheat_caller_address, spy_events,
     start_cheat_chain_id_global, test_address
 };
+use starknet::storage::StorageMapReadAccess;
+use starknet::storage::StoragePointerReadAccess;
 use starknet::{ContractAddress, contract_address_const};
 
 //

--- a/packages/token/src/tests/erc20/test_erc20_votes.cairo
+++ b/packages/token/src/tests/erc20/test_erc20_votes.cairo
@@ -1,3 +1,5 @@
+use starknet::storage::StoragePointerReadAccess;
+use starknet::storage::StorageMapReadAccess;
 use core::num::traits::Bounded;
 use core::num::traits::Zero;
 use crate::erc20::ERC20Component::InternalImpl as ERC20Impl;

--- a/packages/token/src/tests/erc721/test_erc721.cairo
+++ b/packages/token/src/tests/erc721/test_erc721.cairo
@@ -1,3 +1,4 @@
+use starknet::storage::StorageMapReadAccess;
 use core::num::traits::Zero;
 use crate::erc721::ERC721Component::{ERC721Impl, ERC721CamelOnlyImpl};
 use crate::erc721::ERC721Component::{ERC721MetadataImpl, InternalImpl};

--- a/packages/token/src/tests/erc721/test_erc721.cairo
+++ b/packages/token/src/tests/erc721/test_erc721.cairo
@@ -1,4 +1,3 @@
-use starknet::storage::StorageMapReadAccess;
 use core::num::traits::Zero;
 use crate::erc721::ERC721Component::{ERC721Impl, ERC721CamelOnlyImpl};
 use crate::erc721::ERC721Component::{ERC721MetadataImpl, InternalImpl};
@@ -15,6 +14,7 @@ use openzeppelin_testing::constants::{
 use openzeppelin_testing::events::EventSpyExt;
 use snforge_std::{spy_events, test_address, start_cheat_caller_address};
 use starknet::ContractAddress;
+use starknet::storage::StorageMapReadAccess;
 
 //
 // Setup

--- a/packages/token/src/tests/erc721/test_erc721_enumerable.cairo
+++ b/packages/token/src/tests/erc721/test_erc721_enumerable.cairo
@@ -1,4 +1,3 @@
-use starknet::storage::StorageMapReadAccess;
 use crate::erc721::ERC721Component::{ERC721Impl, InternalImpl as ERC721InternalImpl};
 use crate::erc721::extensions::erc721_enumerable::ERC721EnumerableComponent::{
     ERC721EnumerableImpl, InternalImpl
@@ -10,6 +9,7 @@ use openzeppelin_introspection::interface::ISRC5_ID;
 use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
 use openzeppelin_testing::constants::{OWNER, RECIPIENT, OTHER, ZERO};
 use starknet::ContractAddress;
+use starknet::storage::StorageMapReadAccess;
 
 // Token IDs
 const TOKEN_1: u256 = 'TOKEN_1';

--- a/packages/token/src/tests/erc721/test_erc721_enumerable.cairo
+++ b/packages/token/src/tests/erc721/test_erc721_enumerable.cairo
@@ -1,3 +1,4 @@
+use starknet::storage::StorageMapReadAccess;
 use crate::erc721::ERC721Component::{ERC721Impl, InternalImpl as ERC721InternalImpl};
 use crate::erc721::extensions::erc721_enumerable::ERC721EnumerableComponent::{
     ERC721EnumerableImpl, InternalImpl

--- a/packages/token/src/tests/mocks/account_mocks.cairo
+++ b/packages/token/src/tests/mocks/account_mocks.cairo
@@ -22,11 +22,11 @@ pub(crate) mod DualCaseAccountMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        account: AccountComponent::Storage,
+        pub account: AccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -64,11 +64,11 @@ pub(crate) mod SnakeAccountMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        account: AccountComponent::Storage,
+        pub account: AccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -108,11 +108,11 @@ pub(crate) mod CamelAccountMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        account: AccountComponent::Storage,
+        pub account: AccountComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]

--- a/packages/token/src/tests/mocks/erc1155_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc1155_mocks.cairo
@@ -22,11 +22,11 @@ pub(crate) mod DualCaseERC1155Mock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc1155: ERC1155Component::Storage,
+        pub erc1155: ERC1155Component::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -73,11 +73,11 @@ pub(crate) mod SnakeERC1155Mock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc1155: ERC1155Component::Storage,
+        pub erc1155: ERC1155Component::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -124,11 +124,11 @@ pub(crate) mod CamelERC1155Mock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc1155: ERC1155Component::Storage,
+        pub erc1155: ERC1155Component::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -158,7 +158,7 @@ pub(crate) mod SnakeERC1155PanicMock {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]
@@ -235,7 +235,7 @@ pub(crate) mod CamelERC1155PanicMock {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]

--- a/packages/token/src/tests/mocks/erc1155_receiver_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc1155_receiver_mocks.cairo
@@ -17,11 +17,11 @@ pub(crate) mod DualCaseERC1155ReceiverMock {
     impl ERC1155ReceiverInternalImpl = ERC1155ReceiverComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc1155_receiver: ERC1155ReceiverComponent::Storage,
+        pub erc1155_receiver: ERC1155ReceiverComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -60,11 +60,11 @@ pub(crate) mod SnakeERC1155ReceiverMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc1155_receiver: ERC1155ReceiverComponent::Storage,
+        pub erc1155_receiver: ERC1155ReceiverComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -103,11 +103,11 @@ pub(crate) mod CamelERC1155ReceiverMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc1155_receiver: ERC1155ReceiverComponent::Storage,
+        pub erc1155_receiver: ERC1155ReceiverComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -130,7 +130,7 @@ pub(crate) mod SnakeERC1155ReceiverPanicMock {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[external(v0)]
     fn on_erc1155_received(
@@ -164,7 +164,7 @@ pub(crate) mod CamelERC1155ReceiverPanicMock {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[external(v0)]
     fn onERC1155Received(

--- a/packages/token/src/tests/mocks/erc20_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc20_mocks.cairo
@@ -14,9 +14,9 @@ pub(crate) mod DualCaseERC20Mock {
     impl InternalImpl = ERC20Component::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc20: ERC20Component::Storage
+        pub erc20: ERC20Component::Storage
     }
 
     #[event]
@@ -53,9 +53,9 @@ pub(crate) mod SnakeERC20Mock {
     impl InternalImpl = ERC20Component::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc20: ERC20Component::Storage
+        pub erc20: ERC20Component::Storage
     }
 
     #[event]
@@ -96,9 +96,9 @@ pub(crate) mod CamelERC20Mock {
     impl InternalImpl = ERC20Component::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc20: ERC20Component::Storage
+        pub erc20: ERC20Component::Storage
     }
 
     #[event]
@@ -153,7 +153,7 @@ pub(crate) mod SnakeERC20Panic {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]
@@ -223,7 +223,7 @@ pub(crate) mod CamelERC20Panic {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]

--- a/packages/token/src/tests/mocks/erc20_votes_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc20_votes_mocks.cairo
@@ -26,13 +26,13 @@ pub(crate) mod DualCaseERC20VotesMock {
     impl NoncesImpl = NoncesComponent::NoncesImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc20_votes: ERC20VotesComponent::Storage,
+        pub erc20_votes: ERC20VotesComponent::Storage,
         #[substorage(v0)]
-        erc20: ERC20Component::Storage,
+        pub erc20: ERC20Component::Storage,
         #[substorage(v0)]
-        nonces: NoncesComponent::Storage
+        pub nonces: NoncesComponent::Storage
     }
 
     #[event]

--- a/packages/token/src/tests/mocks/erc2981_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc2981_mocks.cairo
@@ -16,11 +16,11 @@ pub(crate) mod ERC2981Mock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc2981: ERC2981Component::Storage,
+        pub erc2981: ERC2981Component::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]

--- a/packages/token/src/tests/mocks/erc721_enumerable_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc721_enumerable_mocks.cairo
@@ -27,13 +27,13 @@ pub(crate) mod ERC721EnumerableMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc721: ERC721Component::Storage,
+        pub erc721: ERC721Component::Storage,
         #[substorage(v0)]
-        erc721_enumerable: ERC721EnumerableComponent::Storage,
+        pub erc721_enumerable: ERC721EnumerableComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -101,13 +101,13 @@ pub(crate) mod SnakeERC721EnumerableMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc721: ERC721Component::Storage,
+        pub erc721: ERC721Component::Storage,
         #[substorage(v0)]
-        erc721_enumerable: ERC721EnumerableComponent::Storage,
+        pub erc721_enumerable: ERC721EnumerableComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]

--- a/packages/token/src/tests/mocks/erc721_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc721_mocks.cairo
@@ -24,11 +24,11 @@ pub(crate) mod DualCaseERC721Mock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc721: ERC721Component::Storage,
+        pub erc721: ERC721Component::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -75,11 +75,11 @@ pub(crate) mod SnakeERC721Mock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc721: ERC721Component::Storage,
+        pub erc721: ERC721Component::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -128,11 +128,11 @@ pub(crate) mod CamelERC721Mock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc721: ERC721Component::Storage,
+        pub erc721: ERC721Component::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -191,7 +191,7 @@ pub(crate) mod SnakeERC721PanicMock {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]
@@ -284,7 +284,7 @@ pub(crate) mod CamelERC721PanicMock {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]

--- a/packages/token/src/tests/mocks/erc721_receiver_mocks.cairo
+++ b/packages/token/src/tests/mocks/erc721_receiver_mocks.cairo
@@ -18,11 +18,11 @@ pub(crate) mod DualCaseERC721ReceiverMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc721_receiver: ERC721ReceiverComponent::Storage,
+        pub erc721_receiver: ERC721ReceiverComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -88,11 +88,11 @@ pub(crate) mod SnakeERC721ReceiverMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc721_receiver: ERC721ReceiverComponent::Storage,
+        pub erc721_receiver: ERC721ReceiverComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -147,11 +147,11 @@ pub(crate) mod CamelERC721ReceiverMock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc721_receiver: ERC721ReceiverComponent::Storage,
+        pub erc721_receiver: ERC721ReceiverComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]
@@ -193,7 +193,7 @@ pub(crate) mod SnakeERC721ReceiverPanicMock {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]
@@ -217,7 +217,7 @@ pub(crate) mod CamelERC721ReceiverPanicMock {
     use starknet::ContractAddress;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[abi(per_item)]
     #[generate_trait]

--- a/packages/token/src/tests/mocks/non_implementing_mock.cairo
+++ b/packages/token/src/tests/mocks/non_implementing_mock.cairo
@@ -1,7 +1,7 @@
 #[starknet::contract]
 pub(crate) mod NonImplementingMock {
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[external(v0)]
     fn nope(self: @ContractState) -> bool {

--- a/packages/token/src/tests/mocks/src5_mocks.cairo
+++ b/packages/token/src/tests/mocks/src5_mocks.cairo
@@ -8,9 +8,9 @@ pub(crate) mod SRC5Mock {
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        src5: SRC5Component::Storage
+        pub src5: SRC5Component::Storage
     }
 
     #[event]

--- a/packages/upgrades/src/tests/mocks/upgrades_mocks.cairo
+++ b/packages/upgrades/src/tests/mocks/upgrades_mocks.cairo
@@ -16,8 +16,7 @@ pub(crate) trait IUpgradesV1<TState> {
 pub(crate) mod UpgradesV1 {
     use crate::UpgradeableComponent;
     use starknet::ClassHash;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
 
@@ -68,8 +67,7 @@ pub(crate) trait IUpgradesV2<TState> {
 pub(crate) mod UpgradesV2 {
     use crate::UpgradeableComponent;
     use starknet::ClassHash;
-    use starknet::storage::StoragePointerReadAccess;
-    use starknet::storage::StoragePointerWriteAccess;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
 

--- a/packages/upgrades/src/tests/mocks/upgrades_mocks.cairo
+++ b/packages/upgrades/src/tests/mocks/upgrades_mocks.cairo
@@ -24,10 +24,10 @@ pub(crate) mod UpgradesV1 {
     impl InternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        upgradeable: UpgradeableComponent::Storage,
-        value: felt252
+        pub upgradeable: UpgradeableComponent::Storage,
+        pub value: felt252
     }
 
     #[event]
@@ -76,11 +76,11 @@ pub(crate) mod UpgradesV2 {
     impl InternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        upgradeable: UpgradeableComponent::Storage,
-        value: felt252,
-        value2: felt252
+        pub upgradeable: UpgradeableComponent::Storage,
+        pub value: felt252,
+        pub value2: felt252
     }
 
     #[event]

--- a/packages/upgrades/src/tests/mocks/upgrades_mocks.cairo
+++ b/packages/upgrades/src/tests/mocks/upgrades_mocks.cairo
@@ -16,6 +16,8 @@ pub(crate) trait IUpgradesV1<TState> {
 pub(crate) mod UpgradesV1 {
     use crate::UpgradeableComponent;
     use starknet::ClassHash;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
 
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
 
@@ -66,6 +68,8 @@ pub(crate) trait IUpgradesV2<TState> {
 pub(crate) mod UpgradesV2 {
     use crate::UpgradeableComponent;
     use starknet::ClassHash;
+    use starknet::storage::StoragePointerReadAccess;
+    use starknet::storage::StoragePointerWriteAccess;
 
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
 

--- a/packages/upgrades/src/upgradeable.cairo
+++ b/packages/upgrades/src/upgradeable.cairo
@@ -11,7 +11,7 @@ pub mod UpgradeableComponent {
     use starknet::SyscallResultTrait;
 
     #[storage]
-    struct Storage {}
+    pub struct Storage {}
 
     #[event]
     #[derive(Drop, PartialEq, starknet::Event)]

--- a/packages/utils/src/cryptography/nonces.cairo
+++ b/packages/utils/src/cryptography/nonces.cairo
@@ -11,7 +11,7 @@ pub mod NoncesComponent {
 
     #[storage]
     pub struct Storage {
-        Nonces_nonces: Map<ContractAddress, felt252>
+        pub Nonces_nonces: Map<ContractAddress, felt252>
     }
 
     pub mod Errors {

--- a/packages/utils/src/cryptography/nonces.cairo
+++ b/packages/utils/src/cryptography/nonces.cairo
@@ -5,9 +5,7 @@
 pub mod NoncesComponent {
     use crate::interfaces::INonces;
     use starknet::ContractAddress;
-    use starknet::storage::Map;
-    use starknet::storage::StorageMapReadAccess;
-    use starknet::storage::StorageMapWriteAccess;
+    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess};
 
     #[storage]
     pub struct Storage {

--- a/packages/utils/src/cryptography/nonces.cairo
+++ b/packages/utils/src/cryptography/nonces.cairo
@@ -6,9 +6,11 @@ pub mod NoncesComponent {
     use crate::interfaces::INonces;
     use starknet::ContractAddress;
     use starknet::storage::Map;
+    use starknet::storage::StorageMapReadAccess;
+    use starknet::storage::StorageMapWriteAccess;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         Nonces_nonces: Map<ContractAddress, felt252>
     }
 

--- a/packages/utils/src/math.cairo
+++ b/packages/utils/src/math.cairo
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts for Cairo v0.16.0 (utils/math.cairo)
 
-use core::traits::Into;
+use core::traits::{Into, BitAnd, BitXor};
 
 /// Returns the average of two numbers. The result is rounded down.
 pub fn average<

--- a/packages/utils/src/tests/mocks/nonces_mocks.cairo
+++ b/packages/utils/src/tests/mocks/nonces_mocks.cairo
@@ -9,9 +9,9 @@ pub(crate) mod NoncesMock {
     impl InternalImpl = NoncesComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        nonces: NoncesComponent::Storage
+        pub nonces: NoncesComponent::Storage
     }
 
     #[event]


### PR DESCRIPTION
Fixes #1048 
This PR upgades our codebase to scarb [2024_07 edition](https://community.starknet.io/t/cairo-v2-7-0-is-coming/114362#the-2024_07-edition-3). Biggest changes are:
- The prelude is much smaller now, and doesn't include any method to access storage(bummer, I know!). So we have to manually import.
- Storage structs and it's members are not `pub` by default anymore. So we have to manually define them as `pub`. 
     - This is ok for components(since we want smart contract developers to be able to access compinent's storage variables in their contracts)
     - This is ok for mocks(we don't care)
     - For presets we might want to make it more restrictive, but we can decide in a later issue/PR.

#### PR Checklist
- [x] Tests
- [x] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->