### PR TITLE
Add missing entries to Test Utilities.

### DIFF
--- a/docs/modules/ROOT/pages/api/testing.adoc
+++ b/docs/modules/ROOT/pages/api/testing.adoc
@@ -36,6 +36,7 @@ use openzeppelin_testing::common;
 .Functions
 * xref:#testing-common-panic_data_to_byte_array[`++panic_data_to_byte_array(panic_data)++`]
 * xref:#testing-common-to_base_16_string[`++to_base_16_string(value)++`]
+* xref:#testing-common-to_base_16_string_no_padding[`++to_base_16_string_no_padding(value)++`]
 * xref:#testing-common-assert_entrypoint_not_found_error[`++assert_entrypoint_not_found_error(result, selector, contract_address)++`]
 
 .Traits
@@ -60,6 +61,13 @@ Converts panic data into a string (`ByteArray`).
 Converts a `felt252` to a `base16` string padded to 66 characters (including the `0x` prefix).
 
 [.contract-item]
+[[testing-common-to_base_16_string_no_padding]]
+==== `[.contract-item-name]#++to_base_16_string_no_padding++#++(value: felt252) → ByteArray++` [.item-kind]#function#
+
+Converts a `felt252` to a `base16` (hexadecimal) string without padding, but including the `0x`
+prefix.
+
+[.contract-item]
 [[testing-common-assert_entrypoint_not_found_error]]
 ==== `[.contract-item-name]#++assert_entrypoint_not_found_error++#<T, +Drop<T>>(result: SyscallResult<T>, selector: felt252, contract_address: ContractAddress)` [.item-kind]#function#
 
@@ -74,7 +82,7 @@ following the Starknet Foundry emitted error format.
 ==== `[.contract-item-name]#++IntoBase16StringTrait++#` [.item-kind]#trait#
 
 A helper trait that enables a value to be represented as a `base16`(hexadecimal) string padded to 66 characters
-(including the `0x` prefix). There's also a version with no padding for compatibility with Starknet Foundry `0.28.0` and above, where addresses and selectors are not padded properly. The type of the value must implement `Into<T, felt252>` to be
+(including the `0x` prefix). The type of the value must implement `Into<T, felt252>` to be
 convertible to `felt252`.
 
 Usage example:
@@ -88,6 +96,8 @@ let expected_panic_message = format!(
     contract_address.into_base_16_string()
 );
 ```
+
+NOTE: The no-padding version can be used in the same way by calling `selector.into_base_16_string_no_padding()`.
 
 [.contract]
 [[testing-deployment]]

--- a/packages/testing/src/common.cairo
+++ b/packages/testing/src/common.cairo
@@ -29,7 +29,7 @@ pub fn to_base_16_string(value: felt252) -> ByteArray {
     format!("0x{}", string)
 }
 
-/// Converts a `felt252` to a `base16`(hexadecimal) string without padding, but including the `0x`
+/// Converts a `felt252` to a `base16` (hexadecimal) string without padding, but including the `0x`
 /// prefix.
 /// We need this because Starknet Foundry has a way of representing addresses and selectors that
 /// does not include 0's after `Ox`.


### PR DESCRIPTION
`to_base_16_string_no_padding` was not documented.