### PR TITLE
Deprecate dualcase dispatchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `execute_calls` function from account utils (#1150)
   - calls param type changed from `Array<Call>` to `Span<Call>`
 
+### Deprecated
+
+- DualCase dispatchers
+
 ## 0.16.0 (2024-08-30)
 
 ### Added

--- a/docs/modules/ROOT/pages/interfaces.adoc
+++ b/docs/modules/ROOT/pages/interfaces.adoc
@@ -152,6 +152,8 @@ pub trait IERC20Camel<TState> {
 
 == `DualCase` dispatchers
 
+WARNING: `DualCase` dispatchers are deprecated, and they will be removed from the library soon.
+
 WARNING: `DualCase` dispatchers won't work on live chains (`mainnet` or testnets) until they implement panic handling in their runtime. Dispatchers work fine in testing environments.
 
 In order to ease this transition, OpenZeppelin Contracts for Cairo offer what we call `DualCase` dispatchers such as `DualCaseERC721` or `DualCaseAccount`.


### PR DESCRIPTION
Mark dual dispatchers as deprecated both in the CHANGELOG and the docsite, for users to be aware that they will be removed soon.