### PR TITLE
Improve packages READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,18 +116,9 @@ mod MyToken {
 
 ## Learn
 
-<!-- ### Documentation
+### Documentation
 
-Check out the [full documentation site](https://docs.openzeppelin.com/contracts-cairo)! Featuring:
-
-- [Accounts](https://docs.openzeppelin.com/contracts-cairo/0.6.1/accounts)
-- [ERC20](https://docs.openzeppelin.com/contracts-cairo/0.6.1/erc20)
-- [ERC721](https://docs.openzeppelin.com/contracts-cairo/0.6.1/erc721)
-- [ERC1155](https://docs.openzeppelin.com/contracts-cairo/0.6.1/erc1155)
-- [Contract extensibility pattern](https://docs.openzeppelin.com/contracts-cairo/0.6.1/extensibility)
-- [Proxies and upgrades](https://docs.openzeppelin.com/contracts-cairo/0.6.1/proxies)
-- [Security](https://docs.openzeppelin.com/contracts-cairo/0.6.1/security)
-- [Utilities](https://docs.openzeppelin.com/contracts-cairo/0.6.1/utilities) -->
+Check out the [full documentation site](https://docs.openzeppelin.com/contracts-cairo)!
 
 ### Cairo
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ Edit `scarb.toml` and add:
 
 ```toml
 [dependencies]
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.17.0" }
+openzeppelin = "0.17.0"
 ```
 
-The previous example would import the entire library. we can also add each package as a separated dependency to improve the time for building by not including modules that won't be used:
+The previous example would import the entire library. We can also add each package as a separated dependency to improve the building time by not including modules that won't be used:
 
 ```toml
 [dependencies]
-openzeppelin_token = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.17.0" }
+openzeppelin_token = "0.17.0"
 ```
 
 Build the project to download it:
@@ -72,8 +72,7 @@ For example, this is how to write an ERC20-compliant contract:
 ```cairo
 #[starknet::contract]
 mod MyToken {
-    // If only the token package was added as a dependency, use `openzeppelin_token::` instead
-    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Edit `scarb.toml` and add:
 openzeppelin = "0.17.0"
 ```
 
-The previous example would import the entire library. We can also add each package as a separated dependency to improve the building time by not including modules that won't be used:
+The previous example would import the entire library. We can also add each package as a separate dependency to improve the building time by not including modules that won't be used:
 
 ```toml
 [dependencies]

--- a/packages/access/README.md
+++ b/packages/access/README.md
@@ -1,6 +1,6 @@
 ## Access Control
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/access](https://docs.openzeppelin.com/contracts-cairo/api/access)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/access](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/access)
 
 This crate provides ways to restrict who can access the functions of a contract or when they can do it.
 
@@ -12,9 +12,9 @@ and assigned each to multiple accounts.
 
 ### Interfaces
 
-- [`IAccessControl`](https://docs.openzeppelin.com/contracts-cairo/api/access#IAccessControl)
+- [`IAccessControl`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/access#IAccessControl)
 
 ### Components
 
-- [`OwnableComponent`](https://docs.openzeppelin.com/contracts-cairo/api/access#OwnableComponent)
-- [`AccessControlComponent`](https://docs.openzeppelin.com/contracts-cairo/api/access#AccessControlComponent)
+- [`OwnableComponent`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/access#OwnableComponent)
+- [`AccessControlComponent`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/access#AccessControlComponent)

--- a/packages/access/README.md
+++ b/packages/access/README.md
@@ -1,20 +1,20 @@
 ## Access Control
 
-> **NOTE:** This document is better viewed at https://docs.openzeppelin.com/contracts-cairo/api/access
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/access](https://docs.openzeppelin.com/contracts-cairo/api/access)
 
 This crate provides ways to restrict who can access the functions of a contract or when they can do it.
 
-- `Ownable` is a simple mechanism with a single "owner" role that can be assigned to a single contract (usually an account). This mechanism
-can be useful in simple scenarios, but fine grained access needs are likely to outgrow it.
+- `Ownable` is a simple mechanism with a single "owner" role that can be assigned to a single contract (usually an
+account). This mechanism can be useful in simple scenarios, but fine grained access needs are likely to outgrow it.
 
 - `AccessControl` provides a general role based access control mechanism. Multiple hierarchical roles can be created
 and assigned each to multiple accounts.
 
 ### Interfaces
 
-- `IAccessControl`
+- [`IAccessControl`](https://docs.openzeppelin.com/contracts-cairo/api/access#IAccessControl)
 
 ### Components
 
-- `OwnableComponent`
-- `AccessControlComponent`
+- [`OwnableComponent`](https://docs.openzeppelin.com/contracts-cairo/api/access#OwnableComponent)
+- [`AccessControlComponent`](https://docs.openzeppelin.com/contracts-cairo/api/access#AccessControlComponent)

--- a/packages/account/README.md
+++ b/packages/account/README.md
@@ -1,6 +1,6 @@
 ## Account
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/account](https://docs.openzeppelin.com/contracts-cairo/api/account)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/account](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/account)
 
 This crate provides components to implement account contracts that can be used for interacting with the network.
 
@@ -12,11 +12,11 @@ This crate provides components to implement account contracts that can be used f
 
 ### Interfaces
 
-- [`ISRC6`](https://docs.openzeppelin.com/contracts-cairo/api/account#ISRC6)
-- [`ISRC9_V2`](https://docs.openzeppelin.com/contracts-cairo/api/account#ISRC9_V2)
+- [`ISRC6`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/account#ISRC6)
+- [`ISRC9_V2`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/account#ISRC9_V2)
 
 ### Components
 
-- [`AccountComponent`](https://docs.openzeppelin.com/contracts-cairo/api/account#AccountComponent)
-- [`EthAccountComponent`](https://docs.openzeppelin.com/contracts-cairo/api/account#EthAccountComponent)
-- [`SRC9Component`](https://docs.openzeppelin.com/contracts-cairo/api/account#SRC9Component)
+- [`AccountComponent`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/account#AccountComponent)
+- [`EthAccountComponent`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/account#EthAccountComponent)
+- [`SRC9Component`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/account#SRC9Component)

--- a/packages/account/README.md
+++ b/packages/account/README.md
@@ -1,6 +1,6 @@
 ## Account
 
-> **NOTE:** This document is better viewed at https://docs.openzeppelin.com/contracts-cairo/api/account
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/account](https://docs.openzeppelin.com/contracts-cairo/api/account)
 
 This crate provides components to implement account contracts that can be used for interacting with the network.
 
@@ -12,11 +12,11 @@ This crate provides components to implement account contracts that can be used f
 
 ### Interfaces
 
-- `ISRC6`
-- `ISRC9_V2`
+- [`ISRC6`](https://docs.openzeppelin.com/contracts-cairo/api/account#ISRC6)
+- [`ISRC9_V2`](https://docs.openzeppelin.com/contracts-cairo/api/account#ISRC9_V2)
 
 ### Components
 
-- `AccountComponent`
-- `EthAccountComponent`
-- `SRC9Component`
+- [`AccountComponent`](https://docs.openzeppelin.com/contracts-cairo/api/account#AccountComponent)
+- [`EthAccountComponent`](https://docs.openzeppelin.com/contracts-cairo/api/account#EthAccountComponent)
+- [`SRC9Component`](https://docs.openzeppelin.com/contracts-cairo/api/account#SRC9Component)

--- a/packages/finance/README.md
+++ b/packages/finance/README.md
@@ -1,5 +1,7 @@
 ## Finance
 
+> **NOTE:** Documentation will soon be added to [https://docs.openzeppelin.com/contracts-cairo](https://docs.openzeppelin.com/contracts-cairo)
+
 This crate includes primitives for financial systems.
 
 ### Interfaces

--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -1,14 +1,14 @@
 ## Governance
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/governance](https://docs.openzeppelin.com/contracts-cairo/api/governance)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/governance](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/governance)
 
 This crate includes primitives for on-chain governance.
 
 ### Interfaces
 
-- [`ITimelock`](https://docs.openzeppelin.com/contracts-cairo/api/governance#ITimelock)
-- [`IVotes`](https://docs.openzeppelin.com/contracts-cairo/api/governance#IVotes)
+- [`ITimelock`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/governance#ITimelock)
+- [`IVotes`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/governance#IVotes)
 
 ### Components
 
-- [`TimelockControllerComponent`](https://docs.openzeppelin.com/contracts-cairo/api/governance#TimelockControllerComponent)
+- [`TimelockControllerComponent`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/governance#TimelockControllerComponent)

--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -1,14 +1,14 @@
 ## Governance
 
-> **NOTE:** This document is better viewed at https://docs.openzeppelin.com/contracts-cairo/api/governance
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/governance](https://docs.openzeppelin.com/contracts-cairo/api/governance)
 
 This crate includes primitives for on-chain governance.
 
 ### Interfaces
 
-- `ITimelock`
-- `IVotes`
+- [`ITimelock`](https://docs.openzeppelin.com/contracts-cairo/api/governance#ITimelock)
+- [`IVotes`](https://docs.openzeppelin.com/contracts-cairo/api/governance#IVotes)
 
 ### Components
 
-- `TimelockControllerComponent`
+- [`TimelockControllerComponent`](https://docs.openzeppelin.com/contracts-cairo/api/governance#TimelockControllerComponent)

--- a/packages/introspection/README.md
+++ b/packages/introspection/README.md
@@ -1,14 +1,13 @@
 ## Introspection
 
-> **NOTE:** This document is better viewed at https://docs.openzeppelin.com/contracts-cairo/api/introspection
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/introspection](https://docs.openzeppelin.com/contracts-cairo/api/introspection)
 
 This crate handles [type introspection](https://en.wikipedia.org/wiki/Type_introspection) of contracts. In other words, it examines which functions can be called on a given contract. This is referred to as the contract's interface.
-examining which functions can be called on them. This is usually referred to as a contract’s interface.
 
 ### Interfaces
 
-- `ISRC5`
+- [`ISRC5`](https://docs.openzeppelin.com/contracts-cairo/api/introspection#ISRC5)
 
 ### Components
 
-- `SRC5Component`
+- [`SRC5Component`](https://docs.openzeppelin.com/contracts-cairo/api/introspection#SRC5Component)

--- a/packages/introspection/README.md
+++ b/packages/introspection/README.md
@@ -1,13 +1,13 @@
 ## Introspection
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/introspection](https://docs.openzeppelin.com/contracts-cairo/api/introspection)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/introspection](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/introspection)
 
 This crate handles [type introspection](https://en.wikipedia.org/wiki/Type_introspection) of contracts. In other words, it examines which functions can be called on a given contract. This is referred to as the contract's interface.
 
 ### Interfaces
 
-- [`ISRC5`](https://docs.openzeppelin.com/contracts-cairo/api/introspection#ISRC5)
+- [`ISRC5`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/introspection#ISRC5)
 
 ### Components
 
-- [`SRC5Component`](https://docs.openzeppelin.com/contracts-cairo/api/introspection#SRC5Component)
+- [`SRC5Component`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/introspection#SRC5Component)

--- a/packages/merkle_tree/README.md
+++ b/packages/merkle_tree/README.md
@@ -1,6 +1,6 @@
 ## Merkle Tree
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/introspection](https://docs.openzeppelin.com/contracts-cairo/api/introspection)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/merkle-tree](https://docs.openzeppelin.com/contracts-cairo/api/merkle-tree)
 
 This crate provides a set of utilities for verifying Merkle Tree proofs on-chain. The tree and the proofs can be
 generated using this [JavaScript library](https://github.com/ericnordelo/strk-merkle-tree) both for Pedersen and Poseidon

--- a/packages/merkle_tree/README.md
+++ b/packages/merkle_tree/README.md
@@ -1,6 +1,6 @@
 ## Merkle Tree
 
-> **NOTE:** This document is better viewed at https://docs.openzeppelin.com/contracts-cairo/api/introspection
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/introspection](https://docs.openzeppelin.com/contracts-cairo/api/introspection)
 
 This crate provides a set of utilities for verifying Merkle Tree proofs on-chain. The tree and the proofs can be
 generated using this [JavaScript library](https://github.com/ericnordelo/strk-merkle-tree) both for Pedersen and Poseidon

--- a/packages/merkle_tree/README.md
+++ b/packages/merkle_tree/README.md
@@ -1,6 +1,6 @@
 ## Merkle Tree
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/merkle-tree](https://docs.openzeppelin.com/contracts-cairo/api/merkle-tree)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/merkle-tree](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/merkle-tree)
 
 This crate provides a set of utilities for verifying Merkle Tree proofs on-chain. The tree and the proofs can be
 generated using this [JavaScript library](https://github.com/ericnordelo/strk-merkle-tree) both for Pedersen and Poseidon

--- a/packages/merkle_tree/Scarb.toml
+++ b/packages/merkle_tree/Scarb.toml
@@ -1,4 +1,3 @@
-
 [package]
 name = "openzeppelin_merkle_tree"
 readme = "README.md"

--- a/packages/presets/README.md
+++ b/packages/presets/README.md
@@ -1,6 +1,6 @@
 ## Presets
 
-> **NOTE:** This document is better viewed at https://docs.openzeppelin.com/contracts-cairo/presets
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/presets](https://docs.openzeppelin.com/contracts-cairo/presets)
 
 Presets are ready-to-deploy contracts provided by the library. Since presets are intended to be very simple and as
 generic as possible, there’s no support for custom or complex contracts such as `ERC20Pausable` or `ERC721Mintable`.
@@ -10,9 +10,9 @@ For contract customization and combination of modules you can use
 
 ### Presets
 
-- `AccountUpgradeable`
-- `ERC20Upgradeable`
-- `ERC721Upgradeable`
-- `ERC1155Upgradeable`
-- `EthAccountUpgradeable`
-- `UniversalDeployer`
+- [`AccountUpgradeable`](https://docs.openzeppelin.com/contracts-cairo/api/account#AccountUpgradeable)
+- [`ERC20Upgradeable`](https://docs.openzeppelin.com/contracts-cairo/api/erc20#ERC20Upgradeable)
+- [`ERC721Upgradeable`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#ERC721Upgradeable)
+- [`ERC1155Upgradeable`](https://docs.openzeppelin.com/contracts-cairo/api/erc1155#ERC1155Upgradeable)
+- [`EthAccountUpgradeable`](https://docs.openzeppelin.com/contracts-cairo/api/account#EthAccountUpgradeable)
+- [`UniversalDeployer`](https://docs.openzeppelin.com/contracts-cairo/api/udc#UniversalDeployer)

--- a/packages/presets/README.md
+++ b/packages/presets/README.md
@@ -1,6 +1,6 @@
 ## Presets
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/presets](https://docs.openzeppelin.com/contracts-cairo/presets)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/0.17.0/presets](https://docs.openzeppelin.com/contracts-cairo/0.17.0/presets)
 
 Presets are ready-to-deploy contracts provided by the library. Since presets are intended to be very simple and as
 generic as possible, there’s no support for custom or complex contracts such as `ERC20Pausable` or `ERC721Mintable`.
@@ -10,9 +10,9 @@ For contract customization and combination of modules you can use
 
 ### Presets
 
-- [`AccountUpgradeable`](https://docs.openzeppelin.com/contracts-cairo/api/account#AccountUpgradeable)
-- [`ERC20Upgradeable`](https://docs.openzeppelin.com/contracts-cairo/api/erc20#ERC20Upgradeable)
-- [`ERC721Upgradeable`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#ERC721Upgradeable)
-- [`ERC1155Upgradeable`](https://docs.openzeppelin.com/contracts-cairo/api/erc1155#ERC1155Upgradeable)
-- [`EthAccountUpgradeable`](https://docs.openzeppelin.com/contracts-cairo/api/account#EthAccountUpgradeable)
-- [`UniversalDeployer`](https://docs.openzeppelin.com/contracts-cairo/api/udc#UniversalDeployer)
+- [`AccountUpgradeable`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/account#AccountUpgradeable)
+- [`ERC20Upgradeable`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc20#ERC20Upgradeable)
+- [`ERC721Upgradeable`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc721#ERC721Upgradeable)
+- [`ERC1155Upgradeable`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc1155#ERC1155Upgradeable)
+- [`EthAccountUpgradeable`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/account#EthAccountUpgradeable)
+- [`UniversalDeployer`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/udc#UniversalDeployer)

--- a/packages/security/README.md
+++ b/packages/security/README.md
@@ -1,11 +1,11 @@
 ## Security
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/security](https://docs.openzeppelin.com/contracts-cairo/api/security)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/security](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/security)
 
 This crate provides components to handle common security-related tasks such as pausing a contract.
 
 ### Components
 
-- [`InitializableComponent`](https://docs.openzeppelin.com/contracts-cairo/api/security#InitializableComponent)
-- [`PausableComponent`](https://docs.openzeppelin.com/contracts-cairo/api/security#PausableComponent)
-- [`ReentrancyGuardComponent`](https://docs.openzeppelin.com/contracts-cairo/api/security#ReentrancyGuardComponent)
+- [`InitializableComponent`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/security#InitializableComponent)
+- [`PausableComponent`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/security#PausableComponent)
+- [`ReentrancyGuardComponent`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/security#ReentrancyGuardComponent)

--- a/packages/security/README.md
+++ b/packages/security/README.md
@@ -1,11 +1,11 @@
 ## Security
 
-> **NOTE:** This document is better viewed at https://docs.openzeppelin.com/contracts-cairo/api/security
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/security](https://docs.openzeppelin.com/contracts-cairo/api/security)
 
 This crate provides components to handle common security-related tasks such as pausing a contract.
 
 ### Components
 
-- `InitializableComponent`
-- `PausableComponent`
-- `ReentrancyGuardComponent`
+- [`InitializableComponent`](https://docs.openzeppelin.com/contracts-cairo/api/security#InitializableComponent)
+- [`PausableComponent`](https://docs.openzeppelin.com/contracts-cairo/api/security#PausableComponent)
+- [`ReentrancyGuardComponent`](https://docs.openzeppelin.com/contracts-cairo/api/security#ReentrancyGuardComponent)

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,13 +1,13 @@
 ## Testing
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/testing](https://docs.openzeppelin.com/contracts-cairo/api/testing)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/testing](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/testing)
 
 This crate provides various helper functions for declaring, deploying,
 and testing smart contracts using the `snforge` toolchain from Starknet Foundry.
 
 ### Modules
 
-- [`common`](https://docs.openzeppelin.com/contracts-cairo/api/testing#testing-common)
-- [`deployment`](https://docs.openzeppelin.com/contracts-cairo/api/testing#testing-deployment)
-- [`events`](https://docs.openzeppelin.com/contracts-cairo/api/testing#testing-events)
-- [`signing`](https://docs.openzeppelin.com/contracts-cairo/api/testing#testing-signing)
+- [`common`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/testing#testing-common)
+- [`deployment`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/testing#testing-deployment)
+- [`events`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/testing#testing-events)
+- [`signing`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/testing#testing-signing)

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,13 +1,13 @@
 ## Testing
 
-> **NOTE:** This document is better viewed at https://docs.openzeppelin.com/contracts-cairo/api/testing
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/testing](https://docs.openzeppelin.com/contracts-cairo/api/testing)
 
 This crate provides various helper functions for declaring, deploying,
 and testing smart contracts using the `snforge` toolchain from Starknet Foundry.
 
 ### Modules
 
-- `common`
-- `deployment`
-- `events`
-- `signing`
+- [`common`](https://docs.openzeppelin.com/contracts-cairo/api/testing#testing-common)
+- [`deployment`](https://docs.openzeppelin.com/contracts-cairo/api/testing#testing-deployment)
+- [`events`](https://docs.openzeppelin.com/contracts-cairo/api/testing#testing-events)
+- [`signing`](https://docs.openzeppelin.com/contracts-cairo/api/testing#testing-signing)

--- a/packages/token/README.md
+++ b/packages/token/README.md
@@ -5,58 +5,58 @@ standards.
 
 ### ERC20
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/erc20](https://docs.openzeppelin.com/contracts-cairo/api/erc20)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc20](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc20)
 
 #### Interfaces
 
-- [`IERC20`](https://docs.openzeppelin.com/contracts-cairo/api/erc20#IERC20)
-- [`IERC20Metadata`](https://docs.openzeppelin.com/contracts-cairo/api/erc20#IERC20Metadata)
+- [`IERC20`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc20#IERC20)
+- [`IERC20Metadata`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc20#IERC20Metadata)
 
 #### Components
 
-- [`ERC20Component`](https://docs.openzeppelin.com/contracts-cairo/api/erc20#ERC20Component)
-- [`ERC20VotesComponent`](https://docs.openzeppelin.com/contracts-cairo/api/erc20#ERC20VotesComponent)
+- [`ERC20Component`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc20#ERC20Component)
+- [`ERC20VotesComponent`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc20#ERC20VotesComponent)
 
 ### ERC721
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/erc721](https://docs.openzeppelin.com/contracts-cairo/api/erc721)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc721](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc721)
 
 #### Interfaces
 
-- [`IERC721`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#IERC721)
-- [`IERC721Metadata`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#IERC721Metadata)
-- [`IERC721Receiver`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#IERC721Receiver)
-- [`IERC721Enumerable`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#IERC721Enumerable)
+- [`IERC721`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc721#IERC721)
+- [`IERC721Metadata`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc721#IERC721Metadata)
+- [`IERC721Receiver`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc721#IERC721Receiver)
+- [`IERC721Enumerable`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc721#IERC721Enumerable)
 
 #### Components
 
-- [`ERC721Component`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#ERC721Component)
-- [`ERC721ReceiverComponent`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#ERC721ReceiverComponent)
-- [`ERC721EnumerableComponent`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#ERC721EnumerableComponent)
+- [`ERC721Component`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc721#ERC721Component)
+- [`ERC721ReceiverComponent`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc721#ERC721ReceiverComponent)
+- [`ERC721EnumerableComponent`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc721#ERC721EnumerableComponent)
 
 ### ERC1155
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/erc1155](https://docs.openzeppelin.com/contracts-cairo/api/erc1155)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc1155](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc1155)
 
 #### Interfaces
 
-- [`IERC1155`](https://docs.openzeppelin.com/contracts-cairo/api/erc1155#IERC1155)
-- [`IERC1155MetadataURI`](https://docs.openzeppelin.com/contracts-cairo/api/erc1155#IERC1155MetadataURI)
-- [`IERC1155Receiver`](https://docs.openzeppelin.com/contracts-cairo/api/erc1155#IERC1155Receiver)
+- [`IERC1155`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc1155#IERC1155)
+- [`IERC1155MetadataURI`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc1155#IERC1155MetadataURI)
+- [`IERC1155Receiver`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc1155#IERC1155Receiver)
 
 #### Components
 
-- [`ERC1155Component`](https://docs.openzeppelin.com/contracts-cairo/api/erc1155#ERC1155Component)
-- [`ERC1155ReceiverComponent`](https://docs.openzeppelin.com/contracts-cairo/api/erc1155#ERC1155ReceiverComponent)
+- [`ERC1155Component`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc1155#ERC1155Component)
+- [`ERC1155ReceiverComponent`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/erc1155#ERC1155ReceiverComponent)
 
 ### Common
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/token_common](https://docs.openzeppelin.com/contracts-cairo/api/token_common)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/token_common](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/token_common)
 
 #### Interfaces
 
-- [`IERC2981`](https://docs.openzeppelin.com/contracts-cairo/api/token_common#IERC2981)
+- [`IERC2981`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/token_common#IERC2981)
 
 #### Components
 
-- [`ERC2981Component`](https://docs.openzeppelin.com/contracts-cairo/api/token_common#ERC2981Component)
+- [`ERC2981Component`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/token_common#ERC2981Component)

--- a/packages/token/README.md
+++ b/packages/token/README.md
@@ -5,58 +5,58 @@ standards.
 
 ### ERC20
 
-> **NOTE:** This document is better viewed at https://docs.openzeppelin.com/contracts-cairo/api/erc20
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/erc20](https://docs.openzeppelin.com/contracts-cairo/api/erc20)
 
 #### Interfaces
 
-- `IERC20`
-- `IERC20Metadata`
+- [`IERC20`](https://docs.openzeppelin.com/contracts-cairo/api/erc20#IERC20)
+- [`IERC20Metadata`](https://docs.openzeppelin.com/contracts-cairo/api/erc20#IERC20Metadata)
 
 #### Components
 
-- `ERC20Component`
-- `ERC20VotesComponent`
+- [`ERC20Component`](https://docs.openzeppelin.com/contracts-cairo/api/erc20#ERC20Component)
+- [`ERC20VotesComponent`](https://docs.openzeppelin.com/contracts-cairo/api/erc20#ERC20VotesComponent)
 
 ### ERC721
 
-> **NOTE:** This document is better viewed at https://docs.openzeppelin.com/contracts-cairo/api/erc721
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/erc721](https://docs.openzeppelin.com/contracts-cairo/api/erc721)
 
 #### Interfaces
 
-- `IERC721`
-- `IERC721Metadata`
-- `IERC721Receiver`
-- `IERC721Enumerable`
+- [`IERC721`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#IERC721)
+- [`IERC721Metadata`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#IERC721Metadata)
+- [`IERC721Receiver`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#IERC721Receiver)
+- [`IERC721Enumerable`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#IERC721Enumerable)
 
 #### Components
 
-- `ERC721Component`
-- `ERC721ReceiverComponent`
-- `ERC721EnumerableComponent`
+- [`ERC721Component`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#ERC721Component)
+- [`ERC721ReceiverComponent`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#ERC721ReceiverComponent)
+- [`ERC721EnumerableComponent`](https://docs.openzeppelin.com/contracts-cairo/api/erc721#ERC721EnumerableComponent)
 
 ### ERC1155
 
-> **NOTE:** This document is better viewed at https://docs.openzeppelin.com/contracts-cairo/api/erc1155
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/erc1155](https://docs.openzeppelin.com/contracts-cairo/api/erc1155)
 
 #### Interfaces
 
-- `IERC1155`
-- `IERC1155MetadataURI`
-- `IERC1155Receiver`
+- [`IERC1155`](https://docs.openzeppelin.com/contracts-cairo/api/erc1155#IERC1155)
+- [`IERC1155MetadataURI`](https://docs.openzeppelin.com/contracts-cairo/api/erc1155#IERC1155MetadataURI)
+- [`IERC1155Receiver`](https://docs.openzeppelin.com/contracts-cairo/api/erc1155#IERC1155Receiver)
 
 #### Components
 
-- `ERC1155Component`
-- `ERC1155ReceiverComponent`
+- [`ERC1155Component`](https://docs.openzeppelin.com/contracts-cairo/api/erc1155#ERC1155Component)
+- [`ERC1155ReceiverComponent`](https://docs.openzeppelin.com/contracts-cairo/api/erc1155#ERC1155ReceiverComponent)
 
 ### Common
 
-> **NOTE:** This document is better viewed at https://docs.openzeppelin.com/contracts-cairo/api/token_common
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/token_common](https://docs.openzeppelin.com/contracts-cairo/api/token_common)
 
 #### Interfaces
 
-- `IERC2981`
+- [`IERC2981`](https://docs.openzeppelin.com/contracts-cairo/api/token_common#IERC2981)
 
 #### Components
 
-- `ERC2981Component`
+- [`ERC2981Component`](https://docs.openzeppelin.com/contracts-cairo/api/token_common#ERC2981Component)

--- a/packages/upgrades/README.md
+++ b/packages/upgrades/README.md
@@ -1,13 +1,13 @@
 ## Upgrades
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/upgrades](https://docs.openzeppelin.com/contracts-cairo/api/upgrades)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/upgrades](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/upgrades)
 
 This crate provides an interface and component used for upgradeability.
 
 ### Interfaces
 
-- [`IUpgradeable`](https://docs.openzeppelin.com/contracts-cairo/api/upgrades#IUpgradeable)
+- [`IUpgradeable`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/upgrades#IUpgradeable)
 
 ### Components
 
-- [`UpgradeableComponent`](https://docs.openzeppelin.com/contracts-cairo/api/upgrades#UpgradeableComponent)
+- [`UpgradeableComponent`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/upgrades#UpgradeableComponent)

--- a/packages/upgrades/README.md
+++ b/packages/upgrades/README.md
@@ -1,13 +1,13 @@
 ## Upgrades
 
-> **NOTE:** This document is better viewed at https://docs.openzeppelin.com/contracts-cairo/api/upgrades
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/upgrades](https://docs.openzeppelin.com/contracts-cairo/api/upgrades)
 
 This crate provides an interface and component used for upgradeability.
 
 ### Interfaces
 
-- `IUpgradeable`
+- [`IUpgradeable`](https://docs.openzeppelin.com/contracts-cairo/api/upgrades#IUpgradeable)
 
 ### Components
 
-- `UpgradeableComponent`
+- [`UpgradeableComponent`](https://docs.openzeppelin.com/contracts-cairo/api/upgrades#UpgradeableComponent)

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,4 +1,4 @@
-## Upgrades
+## Utils
 
 > **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/utilities](https://docs.openzeppelin.com/contracts-cairo/api/utilities)
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,19 +1,19 @@
 ## Upgrades
 
-> **NOTE:** This document is better viewed at https://docs.openzeppelin.com/contracts-cairo/api/utilities
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/utilities](https://docs.openzeppelin.com/contracts-cairo/api/utilities)
 
 This crate provides components and libraries containing miscellaneous utilities.
 
 ### Core utilities
 
-- `utils`
-- `cryptography`
-- `deployments`
-- `math`
-- `selectors`
-- `serde`
+- [`utils`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#utils)
+- [`cryptography`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#cryptography)
+- [`deployments`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#deployments)
+- [`math`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#math)
+- [`selectors`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#selectors)
+- [`serde`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#serde)
 
 ### Cryptography
 
-- `NoncesComponent`
-- `snip12`
+- [`NoncesComponent`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#NoncesComponent)
+- [`snip12`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#snip12)

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,19 +1,19 @@
 ## Utils
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/api/utilities](https://docs.openzeppelin.com/contracts-cairo/api/utilities)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/utilities](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/utilities)
 
 This crate provides components and libraries containing miscellaneous utilities.
 
 ### Core utilities
 
-- [`utils`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#utils)
-- [`cryptography`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#cryptography)
-- [`deployments`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#deployments)
-- [`math`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#math)
-- [`selectors`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#selectors)
-- [`serde`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#serde)
+- [`utils`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/utilities#utils)
+- [`cryptography`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/utilities#cryptography)
+- [`deployments`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/utilities#deployments)
+- [`math`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/utilities#math)
+- [`selectors`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/utilities#selectors)
+- [`serde`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/utilities#serde)
 
 ### Cryptography
 
-- [`NoncesComponent`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#NoncesComponent)
-- [`snip12`](https://docs.openzeppelin.com/contracts-cairo/api/utilities#snip12)
+- [`NoncesComponent`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/utilities#NoncesComponent)
+- [`snip12`](https://docs.openzeppelin.com/contracts-cairo/0.17.0/api/utilities#snip12)


### PR DESCRIPTION
This PR fixes a copy-paste issue in the introspection package README, also accommodates READMEs to the UI of the scarb registry (fixing links not showing), and adds some extra links.