### PR TITLE
Remove git import references and colon use clauses in docs

### DIFF
--- a/docs/modules/ROOT/pages/access.adoc
+++ b/docs/modules/ROOT/pages/access.adoc
@@ -26,7 +26,7 @@ xref:/api/access.adoc#OwnableComponent-initializer[`initializer`] like this:
 ----
 #[starknet::contract]
 mod MyContract {
-    use openzeppelin::access::ownable::OwnableComponent;
+    use openzeppelin_access::ownable::OwnableComponent;
     use starknet::ContractAddress;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
@@ -174,9 +174,9 @@ const MINTER_ROLE: felt252 = selector!("MINTER_ROLE");
 
 #[starknet::contract]
 mod MyContract {
-    use openzeppelin::access::accesscontrol::AccessControlComponent;
-    use openzeppelin::introspection::src5::SRC5Component;
-    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin_access::accesscontrol::AccessControlComponent;
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
     use super::MINTER_ROLE;
 
@@ -265,9 +265,9 @@ const BURNER_ROLE: felt252 = selector!("BURNER_ROLE");
 
 #[starknet::contract]
 mod MyContract {
-    use openzeppelin::access::accesscontrol::AccessControlComponent;
-    use openzeppelin::introspection::src5::SRC5Component;
-    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin_access::accesscontrol::AccessControlComponent;
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
     use super::{MINTER_ROLE, BURNER_ROLE};
 
@@ -387,10 +387,10 @@ const BURNER_ROLE: felt252 = selector!("BURNER_ROLE");
 
 #[starknet::contract]
 mod MyContract {
-    use openzeppelin::access::accesscontrol::AccessControlComponent;
-    use openzeppelin::access::accesscontrol::DEFAULT_ADMIN_ROLE;
-    use openzeppelin::introspection::src5::SRC5Component;
-    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin_access::accesscontrol::AccessControlComponent;
+    use openzeppelin_access::accesscontrol::DEFAULT_ADMIN_ROLE;
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
     use super::{MINTER_ROLE, BURNER_ROLE};
 

--- a/docs/modules/ROOT/pages/accounts.adoc
+++ b/docs/modules/ROOT/pages/accounts.adoc
@@ -112,8 +112,8 @@ Constructing an account contract requires integrating both {account-component} a
 ----
 #[starknet::contract(account)]
 mod MyAccount {
-    use openzeppelin::account::AccountComponent;
-    use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin_account::AccountComponent;
+    use openzeppelin_introspection::src5::SRC5Component;
 
     component!(path: AccountComponent, storage: account, event: AccountEvent);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
@@ -202,9 +202,9 @@ Here’s an example of a basic contract:
 ----
 #[starknet::contract(account)]
 mod MyEthAccount {
-    use openzeppelin::account::EthAccountComponent;
-    use openzeppelin::account::interface::EthPublicKey;
-    use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin_account::EthAccountComponent;
+    use openzeppelin_account::interface::EthPublicKey;
+    use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ClassHash;
 
     component!(path: EthAccountComponent, storage: eth_account, event: EthAccountEvent);
@@ -303,8 +303,8 @@ First, let's take the example account we created before and deploy it:
 ```[,cairo]
 #[starknet::contract(account)]
 mod MyAccount {
-    use openzeppelin::account::AccountComponent;
-    use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin_account::AccountComponent;
+    use openzeppelin_introspection::src5::SRC5Component;
 
     component!(path: AccountComponent, storage: account, event: AccountEvent);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
@@ -386,9 +386,9 @@ First, let's take the example account we created before and deploy it:
 ```[,cairo]
 #[starknet::contract(account)]
 mod MyEthAccount {
-    use openzeppelin::account::EthAccountComponent;
-    use openzeppelin::account::interface::EthPublicKey;
-    use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin_account::EthAccountComponent;
+    use openzeppelin_account::interface::EthPublicKey;
+    use openzeppelin_introspection::src5::SRC5Component;
 
     component!(path: EthAccountComponent, storage: eth_account, event: EthAccountEvent);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);

--- a/docs/modules/ROOT/pages/api/access.adoc
+++ b/docs/modules/ROOT/pages/api/access.adoc
@@ -23,7 +23,7 @@ assigned each to multiple accounts.
 === `++OwnableComponent++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/access/src/ownable/ownable.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::access::ownable::OwnableComponent;
+use openzeppelin_access::ownable::OwnableComponent;
 ```
 
 `Ownable` provides a basic access control mechanism where an account
@@ -264,7 +264,7 @@ Emitted when the ownership is transferred.
 :RoleAdminChanged: xref:#IAccessControl-RoleAdminChanged[RoleAdminChanged]
 
 ```cairo
-use openzeppelin::access::accesscontrol::interface::IAccessControl;
+use openzeppelin_access::accesscontrol::interface::IAccessControl;
 ```
 
 External interface of AccessControl.
@@ -395,7 +395,7 @@ Emitted when `account` is revoked `role`.
 :revoke_role: xref:#AccessControlComponent-revoke_role[revoke_role]
 
 ```cairo
-use openzeppelin::access::accesscontrol::AccessControlComponent;
+use openzeppelin_access::accesscontrol::AccessControlComponent;
 ```
 
 Component that allows contracts to implement role-based access control mechanisms.

--- a/docs/modules/ROOT/pages/api/account.adoc
+++ b/docs/modules/ROOT/pages/api/account.adoc
@@ -17,7 +17,7 @@ include::../utils/_common.adoc[]
 === `++ISRC6++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/account/src/interface.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::account::interface::ISRC6;
+use openzeppelin_account::interface::ISRC6;
 ```
 
 Interface of the SRC6 Standard Account as defined in the {snip6}.
@@ -74,7 +74,7 @@ Returns the short string `'VALID'` if valid, otherwise it reverts.
 :starknet-curve: https://docs.starknet.io/documentation/architecture_and_concepts/Cryptography/stark-curve/[Starknet curve]
 
 ```cairo
-use openzeppelin::account::AccountComponent;
+use openzeppelin_account::AccountComponent;
 ```
 Account component implementing xref:ISRC6[`ISRC6`] for signatures over the {starknet-curve}.
 
@@ -324,7 +324,7 @@ Emitted when a `public_key` is removed.
 :secp256k1-curve: https://en.bitcoin.it/wiki/Secp256k1[Secp256k1 curve]
 
 ```cairo
-use openzeppelin::account::eth_account::EthAccountComponent;
+use openzeppelin_account::eth_account::EthAccountComponent;
 ```
 Account component implementing xref:ISRC6[`ISRC6`] for signatures over the {secp256k1-curve}.
 
@@ -575,7 +575,7 @@ Emitted when a `public_key` is removed.
 === `++ISRC9_V2++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/account/src/extensions/src9/interface.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::account::extensions::src9::ISRC9_V2;
+use openzeppelin_account::extensions::src9::ISRC9_V2;
 ```
 
 Interface of the SRC9 Standard as defined in the {snip9}.
@@ -625,7 +625,7 @@ Get the status of a given nonce. `true` if the nonce is available to use.
 === `++SRC9Component++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/account/src/extensions/src9/src9.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::account::extensions::SRC9Component;
+use openzeppelin_account::extensions::SRC9Component;
 ```
 
 OutsideExecution component implementing xref:ISRC9_V2[`ISRC9_V2`].
@@ -701,7 +701,7 @@ Initializes the account by registering the `ISRC9_V2` interface Id.
 === `++AccountUpgradeable++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/presets/src/account.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::presets::AccountUpgradeable;
+use openzeppelin_presets::AccountUpgradeable;
 ```
 
 Upgradeable account contract leveraging xref:#AccountComponent[AccountComponent].
@@ -762,7 +762,7 @@ Requirements:
 === `++EthAccountUpgradeable++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/presets/src/eth_account.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::presets::EthAccountUpgradeable;
+use openzeppelin_presets::EthAccountUpgradeable;
 ```
 
 Upgradeable account contract leveraging xref:#EthAccountComponent[EthAccountComponent].

--- a/docs/modules/ROOT/pages/api/erc1155.adoc
+++ b/docs/modules/ROOT/pages/api/erc1155.adoc
@@ -20,7 +20,7 @@ TIP: For an overview of ERC1155, read our xref:erc1155.adoc[ERC1155 guide].
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::token::erc1155::interface::IERC1155;
+use openzeppelin_token::erc1155::interface::IERC1155;
 ```
 Interface of the IERC1155 standard as defined in {eip1155}.
 
@@ -130,7 +130,7 @@ Emitted when the token URI is updated to `value` for the `id` token.
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::token::erc1155::interface::IERC1155MetadataURI;
+use openzeppelin_token::erc1155::interface::IERC1155MetadataURI;
 ```
 Interface for the optional metadata function in {eip1155-metadata}[EIP1155].
 
@@ -160,7 +160,7 @@ Returns the Uniform Resource Identifier (URI) for the `token_id` token.
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::token::erc1155::ERC1155Component;
+use openzeppelin_token::erc1155::ERC1155Component;
 ```
 
 ERC1155 component implementing <<IERC1155,IERC1155>> and <<IERC1155MetadataURI,IERC1155MetadataURI>>.
@@ -246,7 +246,7 @@ Hooks are functions which implementations can extend the functionality of the co
 using ERC1155Component is expected to provide an implementation of the ERC1155HooksTrait. For basic token contracts, an
 empty implementation with no logic must be provided.
 
-TIP: You can use `openzeppelin::token::erc1155::ERC1155HooksEmptyImpl` which is already available as part of the library
+TIP: You can use `openzeppelin_token::erc1155::ERC1155HooksEmptyImpl` which is already available as part of the library
 for this purpose.
 
 [.contract-item]
@@ -547,7 +547,7 @@ See <<IERC1155-URI,IERC1155::URI>>.
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::token::erc1155::interface::IERC1155Receiver;
+use openzeppelin_token::erc1155::interface::IERC1155Receiver;
 ```
 
 Interface for contracts that support receiving token transfers from `ERC1155` contracts.
@@ -587,7 +587,7 @@ via <<IERC1155-safe_batch_transfer_from,IERC1155::safe_batch_transfer_from>> by 
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::token::erc1155::ERC1155ReceiverComponent;
+use openzeppelin_token::erc1155::ERC1155ReceiverComponent;
 ```
 
 ERC1155Receiver component implementing <<IERC1155Receiver,IERC1155Receiver>>.
@@ -663,7 +663,7 @@ Registers the `IERC1155Receiver` interface ID as supported through introspection
 === `++ERC1155Upgradeable++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/presets/src/erc1155.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::presets::ERC1155;
+use openzeppelin_presets::ERC1155;
 ```
 
 Upgradeable ERC1155 contract leveraging xref:#ERC1155Component[ERC1155Component].

--- a/docs/modules/ROOT/pages/api/erc20.adoc
+++ b/docs/modules/ROOT/pages/api/erc20.adoc
@@ -20,7 +20,7 @@ TIP: For an overview of ERC20, read our {erc20-guide}.
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::token::erc20::interface::IERC20;
+use openzeppelin_token::erc20::interface::IERC20;
 ```
 
 Interface of the IERC20 standard as defined in {eip20}.
@@ -118,7 +118,7 @@ Emitted when the allowance of a `spender` for an `owner` is set.
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::token::erc20::interface::IERC20Metadata;
+use openzeppelin_token::erc20::interface::IERC20Metadata;
 ```
 
 Interface for the optional metadata functions in {eip20}.
@@ -166,7 +166,7 @@ NOTE: This information is only used for _display_ purposes: it in no way affects
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::token::erc20::ERC20Component;
+use openzeppelin_token::erc20::ERC20Component;
 ```
 ERC20 component extending <<IERC20,IERC20>> and <<IERC20Metadata,IERC20Metadata>>.
 
@@ -242,7 +242,7 @@ Hooks are functions which implementations can extend the functionality of the co
 using ERC20Component is expected to provide an implementation of the ERC20HooksTrait. For basic token contracts, an
 empty implementation with no logic must be provided.
 
-TIP: You can use `openzeppelin::token::erc20::ERC20HooksEmptyImpl` which is already available as part of the library
+TIP: You can use `openzeppelin_token::erc20::ERC20HooksEmptyImpl` which is already available as part of the library
 for this purpose.
 
 [.contract-item]
@@ -463,7 +463,7 @@ See <<IERC20-Approval,IERC20::Approval>>.
 === `++ERC20VotesComponent++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/token/src/erc20/extensions/erc20_votes.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::token::extensions::ERC20VotesComponent;
+use openzeppelin_token::extensions::ERC20VotesComponent;
 ```
 
 :DelegateChanged: xref:ERC20VotesComponent-DelegateChanged[DelegateChanged]
@@ -657,7 +657,7 @@ Emitted when `delegate` votes are updated from `previous_votes` to `new_votes`.
 === `++ERC20Upgradeable++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/presets/src/erc20.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::presets::ERC20Upgradeable;
+use openzeppelin_presets::ERC20Upgradeable;
 ```
 
 Upgradeable ERC20 contract leveraging xref:#ERC20Component[ERC20Component] with a fixed-supply mechanism for token distribution.

--- a/docs/modules/ROOT/pages/api/erc721.adoc
+++ b/docs/modules/ROOT/pages/api/erc721.adoc
@@ -20,7 +20,7 @@ TIP: For an overview of ERC721, read our xref:erc721.adoc[ERC721 guide].
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::token::erc721::interface::IERC721;
+use openzeppelin_token::erc721::interface::IERC721;
 ```
 Interface of the IERC721 standard as defined in {eip721}.
 
@@ -139,7 +139,7 @@ Emitted when `token_id` token is transferred from `from` to `to`.
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::token::erc721::interface::IERC721Metadata;
+use openzeppelin_token::erc721::interface::IERC721Metadata;
 ```
 
 Interface for the optional metadata functions in {eip721}.
@@ -185,7 +185,7 @@ If the URI is not set for `token_id`, the return value will be an empty `ByteArr
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::token::erc721::ERC721Component;
+use openzeppelin_token::erc721::ERC721Component;
 ```
 
 ERC721 component implementing <<IERC721,IERC721>> and <<IERC721Metadata,IERC721Metadata>>.
@@ -292,7 +292,7 @@ Hooks are functions which implementations can extend the functionality of the co
 using ERC721Component is expected to provide an implementation of the ERC721HooksTrait. For basic token contracts, an
 empty implementation with no logic must be provided.
 
-TIP: You can use `openzeppelin::token::erc721::ERC721HooksEmptyImpl` which is already available as part of the library
+TIP: You can use `openzeppelin_token::erc721::ERC721HooksEmptyImpl` which is already available as part of the library
 for this purpose.
 
 [.contract-item]
@@ -697,7 +697,7 @@ See <<IERC721-Transfer,IERC721::Transfer>>.
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::token::erc721::interface::IERC721Receiver;
+use openzeppelin_token::erc721::interface::IERC721Receiver;
 ```
 
 Interface for contracts that support receiving `safe_transfer_from` transfers.
@@ -728,7 +728,7 @@ Whenever an IERC721 `token_id` token is transferred to this non-account contract
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::token::erc721::ERC721ReceiverComponent;
+use openzeppelin_token::erc721::ERC721ReceiverComponent;
 ```
 
 ERC721Receiver component implementing <<IERC721Receiver,IERC721Receiver>>.
@@ -835,7 +835,7 @@ Use along with xref:#IERC721-balance_of[IERC721::balance_of] to enumerate all of
 === `++ERC721EnumerableComponent++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/token/src/erc721/extensions/erc721_enumerable.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::token::erc721::extensions::ERC721EnumerableComponent;
+use openzeppelin_token::erc721::extensions::ERC721EnumerableComponent;
 ```
 
 Extension of ERC721 as defined in the EIP that adds enumerability of all the token ids in the contract as well as all token ids owned by each account.
@@ -978,7 +978,7 @@ This has 0(1) time complexity but alters the indexed order by swapping `token_id
 === `++ERC721Upgradeable++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/presets/src/erc721.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::presets::ERC721Upgradeable;
+use openzeppelin_presets::ERC721Upgradeable;
 ```
 
 Upgradeable ERC721 contract leveraging xref:#ERC721Component[ERC721Component].

--- a/docs/modules/ROOT/pages/api/governance.adoc
+++ b/docs/modules/ROOT/pages/api/governance.adoc
@@ -20,7 +20,7 @@ In a governance system, `TimelockControllerComponent` is in charge of introducin
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::governance::timelock::interface::ITimelock;
+use openzeppelin_governance::timelock::interface::ITimelock;
 ```
 
 [.contract-index]
@@ -246,7 +246,7 @@ include::../utils/_common.adoc[]
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::governance::timelock::TimelockControllerComponent;
+use openzeppelin_governance::timelock::TimelockControllerComponent;
 ```
 
 [.contract-index#TimelockControllerComponent-Embeddable-Mixin-Impl]
@@ -604,7 +604,7 @@ Emitted when the minimum delay for future operations is modified.
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::governance::utils::interfaces::IVotes;
+use openzeppelin_governance::utils::interfaces::IVotes;
 ```
 
 Common interface for Votes-enabled contracts. For an implementation example see

--- a/docs/modules/ROOT/pages/api/introspection.adoc
+++ b/docs/modules/ROOT/pages/api/introspection.adoc
@@ -13,7 +13,7 @@ This crate handles https://en.wikipedia.org/wiki/Type_introspection[type introsp
 === `++ISRC5++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/introspection/src/interface.cairo#L7[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::introspection::interface::ISRC5;
+use openzeppelin_introspection::interface::ISRC5;
 ```
 
 Interface of the SRC5 Introspection Standard as defined in {snip5}.
@@ -47,7 +47,7 @@ on how to compute this ID.
 === `++SRC5Component++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/introspection/src/src5.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::introspection::src5::SRC5Component;
+use openzeppelin_introspection::src5::SRC5Component;
 ```
 
 SRC5 component extending xref:ISRC5[`ISRC5`].

--- a/docs/modules/ROOT/pages/api/merkle-tree.adoc
+++ b/docs/modules/ROOT/pages/api/merkle-tree.adoc
@@ -23,7 +23,7 @@ NOTE: `openzeppelin_merkle_tree` doesn't have dependencies outside of `corelib`,
 ====
 To use it as a standalone package, you can add it in your `Scarb.toml` as follows:
 
-`openzeppelin_merkle_tree = { git = "https://github.com/openzeppelin/cairo-contracts.git", tag = "v0.X.X" }`
+`openzeppelin_merkle_tree = "0.17.0"`
 ====
 
 == Modules

--- a/docs/modules/ROOT/pages/api/security.adoc
+++ b/docs/modules/ROOT/pages/api/security.adoc
@@ -11,7 +11,7 @@ This crate provides components to handle common security-related tasks.
 === `++InitializableComponent++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/security/src/initializable.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::security::InitializableComponent;
+use openzeppelin_security::InitializableComponent;
 ```
 
 Component enabling one-time initialization for contracts.
@@ -64,7 +64,7 @@ Requirements:
 :Unpaused: xref:PausableComponent-Unpaused[Unpaused]
 
 ```cairo
-use openzeppelin::security::PausableComponent;
+use openzeppelin_security::PausableComponent;
 ```
 
 Component to implement an emergency stop mechanism.
@@ -166,7 +166,7 @@ Emitted when the contract is unpaused by `account`.
 === `++ReentrancyGuardComponent++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/security/src/reentrancyguard.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::security::ReentrancyGuardComponent;
+use openzeppelin_security::ReentrancyGuardComponent;
 ```
 
 Component to help prevent reentrant calls.

--- a/docs/modules/ROOT/pages/api/testing.adoc
+++ b/docs/modules/ROOT/pages/api/testing.adoc
@@ -15,7 +15,7 @@ be added as a separate dependency in `Scarb.toml`:
 
 ```
 [dev-dependencies]
-openzeppelin_testing = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.17.0" }
+openzeppelin_testing = "0.17.0"
 ```
 
 == Test Utilities

--- a/docs/modules/ROOT/pages/api/token_common.adoc
+++ b/docs/modules/ROOT/pages/api/token_common.adoc
@@ -16,7 +16,7 @@ This module provides extensions and utilities that are common to multiple token 
 
 [.hljs-theme-dark]
 ```cairo
-use openzeppelin::token::common::erc2981::IERC2981;
+use openzeppelin_token::common::erc2981::IERC2981;
 ```
 
 [.contract-index]
@@ -49,7 +49,7 @@ unit of exchange.
 === `++ERC2981Component++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/token/src/common/erc2981/erc2981.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::token::common::erc2981::ERC2981Component;
+use openzeppelin_token::common::erc2981::ERC2981Component;
 ```
 
 ERC2981 component extending <<IERC2981,IERC2981>>.

--- a/docs/modules/ROOT/pages/api/udc.adoc
+++ b/docs/modules/ROOT/pages/api/udc.adoc
@@ -11,7 +11,7 @@ Reference of the Universal Deployer Contract (UDC) interface and preset.
 === `++IUniversalDeployer++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/utils/src/deployments/interface.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::utils::interfaces::IUniversalDeployer;
+use openzeppelin_utils::interfaces::IUniversalDeployer;
 ```
 
 [.contract-index]
@@ -54,7 +54,7 @@ Emitted when `deployer` deploys a contract through the Universal Deployer Contra
 === `++UniversalDeployer++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/presets/src/universal_deployer.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::presets::UniversalDeployer;
+use openzeppelin_presets::UniversalDeployer;
 ```
 
 The standard Universal Deployer Contract.

--- a/docs/modules/ROOT/pages/api/upgrades.adoc
+++ b/docs/modules/ROOT/pages/api/upgrades.adoc
@@ -14,7 +14,7 @@ This crate provides interfaces and utilities related to upgradeability.
 :Upgraded: xref:UpgradeableComponent-Upgraded[Upgraded]
 
 ```cairo
-use openzeppelin::upgrades::interface::IUpgradeable;
+use openzeppelin_upgrades::interface::IUpgradeable;
 ```
 
 Interface of an upgradeable contract.
@@ -41,7 +41,7 @@ NOTE: This function is usually protected by an xref:access.adoc[Access Control] 
 === `++UpgradeableComponent++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/upgrades/src/upgradeable.cairo[{github-icon},role=heading-link]
 
 ```cairo
-use openzeppelin::upgrades::upgradeable::UpgradeableComponent;
+use openzeppelin_upgrades::upgradeable::UpgradeableComponent;
 ```
 
 Upgradeable component.

--- a/docs/modules/ROOT/pages/api/utilities.adoc
+++ b/docs/modules/ROOT/pages/api/utilities.adoc
@@ -11,7 +11,7 @@ This crate provides miscellaneous components and libraries containing utility fu
 === `++utils++`
 
 ```cairo
-use openzeppelin::utils;
+use openzeppelin_utils;
 ```
 
 Module containing core utilities of the library.
@@ -74,8 +74,8 @@ casting and unwrapping the result multiple times.
 Usage example:
 
 ```cairo
-use openzeppelin::utils::selectors;
-use openzeppelin::utils::UnwrapAndCast;
+use openzeppelin_utils::selectors;
+use openzeppelin_utils::UnwrapAndCast;
 
 fn call_and_cast_to_bool(target: ContractAddress, args: Span<felt252>) -> bool {
     try_selector_with_fallback(
@@ -99,31 +99,31 @@ Note that it can be automatically casted to any type implementing the `Serde` tr
 [[utils-cryptography]]
 ==== `[.contract-item-name]#++cryptography++#` [.item-kind]#module#
 
-See xref:#cryptography[`openzeppelin::utils::cryptography`].
+See xref:#cryptography[`openzeppelin_utils::cryptography`].
 
 [.contract-item]
 [[utils-deployments]]
 ==== `[.contract-item-name]#++deployments++#` [.item-kind]#module#
 
-See xref:#deployments[`openzeppelin::utils::deployments`].
+See xref:#deployments[`openzeppelin_utils::deployments`].
 
 [.contract-item]
 [[utils-math]]
 ==== `[.contract-item-name]#++math++#` [.item-kind]#module#
 
-See xref:#math[`openzeppelin::utils::math`].
+See xref:#math[`openzeppelin_utils::math`].
 
 [.contract-item]
 [[utils-selectors]]
 ==== `[.contract-item-name]#++selectors++#` [.item-kind]#module#
 
-See xref:#selectors[`openzeppelin::utils::selectors`].
+See xref:#selectors[`openzeppelin_utils::selectors`].
 
 [.contract-item]
 [[utils-serde]]
 ==== `[.contract-item-name]#++serde++#` [.item-kind]#module#
 
-See xref:#serde[`openzeppelin::utils::serde`].
+See xref:#serde[`openzeppelin_utils::serde`].
 
 [.contract]
 [[cryptography]]
@@ -132,7 +132,7 @@ See xref:#serde[`openzeppelin::utils::serde`].
 :snip12: https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md[SNIP12]
 
 ```cairo
-use openzeppelin::utils::cryptography;
+use openzeppelin_utils::cryptography;
 ```
 
 Module containing utilities related to cryptography.
@@ -152,13 +152,13 @@ Module containing utilities related to cryptography.
 [[cryptography-nonces]]
 ==== `[.contract-item-name]#++nonces++#` [.item-kind]#module#
 
-See xref:#NoncesComponent[`openzeppelin::utils::cryptography::nonces::NoncesComponent`].
+See xref:#NoncesComponent[`openzeppelin_utils::cryptography::nonces::NoncesComponent`].
 
 [.contract-item]
 [[cryptography-snip12]]
 ==== `[.contract-item-name]#++snip12++#` [.item-kind]#module#
 
-See xref:#snip12[`openzeppelin::utils::cryptography::snip12`].
+See xref:#snip12[`openzeppelin_utils::cryptography::snip12`].
 
 [.contract]
 [[deployments]]
@@ -167,7 +167,7 @@ See xref:#snip12[`openzeppelin::utils::cryptography::snip12`].
 :udc-doc: xref:/udc.adoc[Universal Deployer Contract]
 
 ```cairo
-use openzeppelin::utils::deployments;
+use openzeppelin_utils::deployments;
 ```
 
 Module containing utility functions for calculating contract addresses through {deploy_syscall} and the {udc-doc} (UDC).
@@ -227,7 +227,7 @@ Origin-dependent deployments hash `salt` with `caller_address` (member of {deplo
 === `++math++`
 
 ```cairo
-use openzeppelin::utils::math;
+use openzeppelin_utils::math;
 ```
 
 Module containing math utilities.
@@ -255,7 +255,7 @@ NOTE: `T` is a generic value matching different numeric implementations.
 === `++selectors++`
 
 ```cairo
-use openzeppelin::utils::selectors;
+use openzeppelin_utils::selectors;
 ```
 
 :selectors: https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.17.0/packages/utils/src/selectors.cairo[selectors.cairo]
@@ -268,7 +268,7 @@ To see the full list of selectors, see {selectors}.
 === `++serde++`
 
 ```cairo
-use openzeppelin::utils::serde;
+use openzeppelin_utils::serde;
 ```
 
 Module containing utilities related to serialization and deserialization of Cairo data structures.
@@ -293,7 +293,7 @@ implementing the `Serde` trait to a `felt252` buffer.
 Usage example:
 
 ```cairo
-use openzeppelin::utils::serde::SerializedAppend;
+use openzeppelin_utils::serde::SerializedAppend;
 use starknet::ContractAddress;
 
 fn to_calldata(recipient: ContractAddress, amount: u256) -> Array<felt252> {
@@ -314,7 +314,7 @@ that implements the `Serde` trait.
 === `++NoncesComponent++`
 
 ```cairo
-use openzeppelin::utils::cryptography::nonces::NoncesComponent;
+use openzeppelin_utils::cryptography::nonces::NoncesComponent;
 ```
 
 This component provides a simple mechanism for handling incremental
@@ -371,7 +371,7 @@ Same as `use_nonce` but checking that `nonce` is the next valid one for `owner`.
 === `++snip12++`
 
 ```cairo
-use openzeppelin::utils::snip12;
+use openzeppelin_utils::snip12;
 ```
 
 Supports on-chain generation of message hashes compliant with {snip12}.

--- a/docs/modules/ROOT/pages/components.adoc
+++ b/docs/modules/ROOT/pages/components.adoc
@@ -25,7 +25,7 @@ The contract should first import the component and declare it with the `componen
 #[starknet::contract]
 mod MyContract {
     // Import the component
-    use openzeppelin::security::InitializableComponent;
+    use openzeppelin_security::InitializableComponent;
 
     // Declare the component
     component!(path: InitializableComponent, storage: initializable, event: InitializableEvent);
@@ -40,7 +40,7 @@ Note that even if the component doesn't define any events, the compiler will sti
 ----
 #[starknet::contract]
 mod MyContract {
-    use openzeppelin::security::InitializableComponent;
+    use openzeppelin_security::InitializableComponent;
 
     component!(path: InitializableComponent, storage: initializable, event: InitializableEvent);
 
@@ -79,7 +79,7 @@ Integrating an implementation looks like this:
 [,cairo]
 ----
 mod MyContract {
-    use openzeppelin::security::InitializableComponent;
+    use openzeppelin_security::InitializableComponent;
 
     component!(path: InitializableComponent, storage: initializable, event: InitializableEvent);
 
@@ -99,7 +99,7 @@ A function on the contract level can expose it like this:
 ----
 #[starknet::contract]
 mod MyContract {
-    use openzeppelin::security::InitializableComponent;
+    use openzeppelin_security::InitializableComponent;
 
     component!(path: InitializableComponent, storage: initializable, event: InitializableEvent);
 
@@ -202,8 +202,8 @@ Here's a full example of an account contract that embeds the `AccountMixinImpl`:
 ----
 #[starknet::contract]
 mod Account {
-    use openzeppelin::account::AccountComponent;
-    use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin_account::AccountComponent;
+    use openzeppelin_introspection::src5::SRC5Component;
 
     component!(path: AccountComponent, storage: account, event: AccountEvent);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
@@ -254,7 +254,7 @@ Let's look at how a contract would integrate {ownable-component}:
 ----
 #[starknet::contract]
 mod MyContract {
-    use openzeppelin::access::ownable::OwnableComponent;
+    use openzeppelin_access::ownable::OwnableComponent;
     use starknet::ContractAddress;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
@@ -301,8 +301,8 @@ Here's an example of how to use the Immutable Component Config pattern with the 
 ----
 #[starknet::contract]
 mod MyContract {
-    use openzeppelin::introspection::src5::SRC5Component;
-    use openzeppelin::token::common::erc2981::ERC2981Component;
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_token::common::erc2981::ERC2981Component;
     use starknet::contract_address_const;
 
     component!(path: ERC2981Component, storage: erc2981, event: ERC2981Event);
@@ -359,9 +359,9 @@ In the following example, the `DefaultConfig` trait is used to define the `FEE_D
 ----
 #[starknet::contract]
 mod MyContract {
-    use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin_introspection::src5::SRC5Component;
     // Bring the DefaultConfig trait into scope
-    use openzeppelin::token::common::erc2981::{ERC2981Component, DefaultConfig};
+    use openzeppelin_token::common::erc2981::{ERC2981Component, DefaultConfig};
     use starknet::contract_address_const;
 
     component!(path: ERC2981Component, storage: erc2981, event: ERC2981Event);
@@ -417,8 +417,8 @@ Creating a contract with `AccessControlComponent` should look like this:
 ----
 #[starknet::contract]
 mod MyContract {
-    use openzeppelin::access::accesscontrol::AccessControlComponent;
-    use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin_access::accesscontrol::AccessControlComponent;
+    use openzeppelin_introspection::src5::SRC5Component;
 
     component!(path: AccessControlComponent, storage: accesscontrol, event: AccessControlEvent);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
@@ -481,9 +481,9 @@ The following snippet leverages the `before_update` hook to include this behavio
 ----
 #[starknet::contract]
 mod MyToken {
-    use openzeppelin::security::pausable::PausableComponent::InternalTrait;
-    use openzeppelin::security::pausable::PausableComponent;
-    use openzeppelin::token::erc20::ERC20Component;
+    use openzeppelin_security::pausable::PausableComponent::InternalTrait;
+    use openzeppelin_security::pausable::PausableComponent;
+    use openzeppelin_token::erc20::ERC20Component;
     use starknet::ContractAddress;
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);
@@ -535,8 +535,8 @@ The using contract just needs to bring the implementation into scope like this:
 ----
 #[starknet::contract]
 mod MyToken {
-    use openzeppelin::token::erc20::ERC20Component;
-    use openzeppelin::token::erc20::ERC20HooksEmptyImpl;
+    use openzeppelin_token::erc20::ERC20Component;
+    use openzeppelin_token::erc20::ERC20HooksEmptyImpl;
 
     (...)
 }
@@ -558,10 +558,10 @@ Here's the setup:
 ----
 #[starknet::contract]
 mod ERC20Pausable {
-    use openzeppelin::security::pausable::PausableComponent;
-    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin_security::pausable::PausableComponent;
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     // Import the ERC20 interfaces to create custom implementations
-    use openzeppelin::token::erc20::interface::{IERC20, IERC20CamelOnly};
+    use openzeppelin_token::erc20::interface::{IERC20, IERC20CamelOnly};
     use starknet::ContractAddress;
 
     component!(path: PausableComponent, storage: pausable, event: PausableEvent);
@@ -662,7 +662,7 @@ To do so, use the same syntax as calling an implementation method except replace
 ----
 #[starknet::contract]
 mod MyContract {
-    use openzeppelin::security::InitializableComponent;
+    use openzeppelin_security::InitializableComponent;
 
     component!(path: InitializableComponent, storage: initializable, event: InitializableEvent);
 

--- a/docs/modules/ROOT/pages/erc1155.adoc
+++ b/docs/modules/ROOT/pages/erc1155.adoc
@@ -34,8 +34,8 @@ Here's an example of a basic contract:
 ----
 #[starknet::contract]
 mod MyERC1155 {
-    use openzeppelin::introspection::src5::SRC5Component;
-    use openzeppelin::token::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_token::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC1155Component, storage: erc1155, event: ERC1155Event);
@@ -227,8 +227,8 @@ Here's an example of a simple token receiver contract:
 ----
 #[starknet::contract]
 mod MyTokenReceiver {
-    use openzeppelin::introspection::src5::SRC5Component;
-    use openzeppelin::token::erc1155::ERC1155ReceiverComponent;
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_token::erc1155::ERC1155ReceiverComponent;
     use starknet::ContractAddress;
 
     component!(path: ERC1155ReceiverComponent, storage: erc1155_receiver, event: ERC1155ReceiverEvent);

--- a/docs/modules/ROOT/pages/erc20.adoc
+++ b/docs/modules/ROOT/pages/erc20.adoc
@@ -23,7 +23,7 @@ Here's what that looks like:
 ----
 #[starknet::contract]
 mod MyToken {
-    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);
@@ -170,7 +170,7 @@ TIP: Note that we are not using the MixinImpl in this case, since we need to cus
 ----
 #[starknet::contract]
 mod MyToken {
-    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);

--- a/docs/modules/ROOT/pages/erc721.adoc
+++ b/docs/modules/ROOT/pages/erc721.adoc
@@ -18,8 +18,8 @@ Here's an example of a basic contract:
 ----
 #[starknet::contract]
 mod MyNFT {
-    use openzeppelin::introspection::src5::SRC5Component;
-    use openzeppelin::token::erc721::{ERC721Component, ERC721HooksEmptyImpl};
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_token::erc721::{ERC721Component, ERC721HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC721Component, storage: erc721, event: ERC721Event);
@@ -195,8 +195,8 @@ Here's an example of a simple token receiver contract:
 ----
 #[starknet::contract]
 mod MyTokenReceiver {
-    use openzeppelin::introspection::src5::SRC5Component;
-    use openzeppelin::token::erc721::ERC721ReceiverComponent;
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_token::erc721::ERC721ReceiverComponent;
     use starknet::ContractAddress;
 
     component!(path: ERC721ReceiverComponent, storage: erc721_receiver, event: ERC721ReceiverEvent);

--- a/docs/modules/ROOT/pages/governance.adoc
+++ b/docs/modules/ROOT/pages/governance.adoc
@@ -95,9 +95,9 @@ Here's an example of a simple timelock contract:
 ----
 #[starknet::contract]
 mod TimelockControllerContract {
-    use openzeppelin::access::accesscontrol::AccessControlComponent;
-    use openzeppelin::governance::timelock::TimelockControllerComponent;
-    use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin_access::accesscontrol::AccessControlComponent;
+    use openzeppelin_governance::timelock::TimelockControllerComponent;
+    use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
 
     component!(path: AccessControlComponent, storage: access_control, event: AccessControlEvent);

--- a/docs/modules/ROOT/pages/guides/erc20-supply.adoc
+++ b/docs/modules/ROOT/pages/guides/erc20-supply.adoc
@@ -15,7 +15,7 @@ We can achieve this by setting the token supply in the constructor which will ex
 ----
 #[starknet::contract]
 mod MyToken {
-    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);
@@ -69,7 +69,7 @@ Let's make a few changes to the almighty `MyToken` contract and create a minting
 ----
 #[starknet::contract]
 mod MyToken {
-    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);

--- a/docs/modules/ROOT/pages/guides/snip12.adoc
+++ b/docs/modules/ROOT/pages/guides/snip12.adoc
@@ -26,7 +26,7 @@ Note that some declarations are omitted for brevity. The full example will be av
 ----
 #[starknet::contract]
 mod CustomERC20 {
-    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);
@@ -117,12 +117,12 @@ NOTE: In practice it's better to compute the type hash off-chain and hardcode it
 
 === 3. Implement the `StructHash` trait for the struct.
 
-You can import the trait from: `openzeppelin::utils::snip12::StructHash`. And this implementation
+You can import the trait from: `openzeppelin_utils::snip12::StructHash`. And this implementation
 is nothing more than the encoding of the message as defined in the {snip}.
 
 [,cairo]
 ----
-use openzeppelin::utils::snip12::StructHash;
+use openzeppelin_utils::snip12::StructHash;
 
 use core::hash::HashStateExTrait;
 use hash::{HashStateTrait, Hash};
@@ -155,7 +155,7 @@ because the `chain_id` is obtained on-chain, and the `revision` is hardcoded to 
 
 [,cairo]
 ----
-use openzeppelin::utils::snip12::SNIP12Metadata;
+use openzeppelin_utils::snip12::SNIP12Metadata;
 
 impl SNIP12MetadataImpl of SNIP12Metadata {
     fn name() -> felt252 { 'DAPP_NAME' }
@@ -169,7 +169,7 @@ the trait is not bounded to the ContractState, like this:
 
 [,cairo]
 ----
-use openzeppelin::utils::snip12::SNIP12Metadata;
+use openzeppelin_utils::snip12::SNIP12Metadata;
 
 impl SNIP12MetadataImpl of SNIP12Metadata {
     fn name() -> felt252 {
@@ -190,7 +190,7 @@ using the `get_message_hash` function. The implementation is already available a
 
 [,cairo]
 ----
-use openzeppelin::utils::snip12::{SNIP12Metadata, StructHash, OffchainMessageHashImpl};
+use openzeppelin_utils::snip12::{SNIP12Metadata, StructHash, OffchainMessageHashImpl};
 
 use core::hash::HashStateExTrait;
 use hash::{HashStateTrait, Hash};
@@ -251,7 +251,7 @@ and the {nonces}[`NoncesComponent`] to handle nonces to prevent replay attacks.
 
 [,cairo]
 ----
-use openzeppelin::utils::snip12::{SNIP12Metadata, StructHash, OffchainMessageHashImpl};
+use openzeppelin_utils::snip12::{SNIP12Metadata, StructHash, OffchainMessageHashImpl};
 
 use core::hash::HashStateExTrait;
 use hash::{HashStateTrait, Hash};
@@ -278,9 +278,9 @@ impl StructHashImpl of StructHash<Message> {
 
 #[starknet::contract]
 mod CustomERC20 {
-    use openzeppelin::account::dual_account::{DualCaseAccount, DualCaseAccountTrait};
-    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
-    use openzeppelin::utils::cryptography::nonces::NoncesComponent;
+    use openzeppelin_account::dual_account::{DualCaseAccount, DualCaseAccountTrait};
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin_utils::cryptography::nonces::NoncesComponent;
     use starknet::ContractAddress;
 
     use super::{Message, OffchainMessageHashImpl, SNIP12Metadata};

--- a/docs/modules/ROOT/pages/guides/src5-migration.adoc
+++ b/docs/modules/ROOT/pages/guides/src5-migration.adoc
@@ -36,8 +36,8 @@ Here's the setup:
 ----
 #[starknet::contract]
 mod MigratingContract {
-    use openzeppelin::introspection::src5::SRC5Component;
-    use openzeppelin::security::initializable::InitializableComponent;
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_security::initializable::InitializableComponent;
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
     component!(path: InitializableComponent, storage: initializable, event: InitializableEvent);
@@ -84,7 +84,7 @@ The contract should implement an `InternalImpl` and add a function to register t
 ----
 #[starknet::contract]
 mod MigratingContract {
-    use openzeppelin::token::erc721::interface::{IERC721_ID, IERC721_METADATA_ID};
+    use openzeppelin_token::erc721::interface::{IERC721_ID, IERC721_METADATA_ID};
 
     (...)
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -21,8 +21,8 @@ before proceeding, and run the following command to check that the installation 
 ----
 $ scarb --version
 
-scarb 2.8.0 (09590f5fc 2024-08-27)
-cairo: 2.8.0 (https://crates.io/crates/cairo-lang-compiler/2.8.0)
+scarb 2.8.2 (a37b4cbfc 2024-09-09)
+cairo: 2.8.2 (https://crates.io/crates/cairo-lang-compiler/2.8.2)
 sierra: 1.6.0
 ----
 
@@ -58,7 +58,7 @@ Install the library by declaring it as a dependency in the project's `Scarb.toml
 [,text]
 ----
 [dependencies]
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.17.0" }
+openzeppelin = "0.17.0"
 ----
 
 WARNING: Make sure the tag matches the target release.
@@ -72,7 +72,7 @@ Copy the code into `src/lib.cairo`.
 ----
 #[starknet::contract]
 mod MyERC20Token {
-    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);

--- a/docs/modules/ROOT/pages/interfaces.adoc
+++ b/docs/modules/ROOT/pages/interfaces.adoc
@@ -7,13 +7,13 @@ This section describes the interfaces OpenZeppelin Contracts for Cairo offer, an
 Interfaces can be found in the module tree under the `interface` submodule, such as `token::erc20::interface`. For example:
 
 ```cairo
-use openzeppelin::token::erc20::interface::IERC20;
+use openzeppelin_token::erc20::interface::IERC20;
 ```
 
 or
 
 ```cairo
-use openzeppelin::token::erc20::dual20::DualCaseERC20;
+use openzeppelin_token::erc20::dual20::DualCaseERC20;
 ```
 
 NOTE: For simplicity, we'll use ERC20 as example but the same concepts apply to other modules.

--- a/docs/modules/ROOT/pages/introspection.adoc
+++ b/docs/modules/ROOT/pages/introspection.adoc
@@ -26,7 +26,7 @@ Here is an example contract:
 ----
 #[starknet::contract]
 mod MyContract {
-    use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin_introspection::src5::SRC5Component;
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 
@@ -82,8 +82,8 @@ For a contract to declare its support for a given interface, we recommend using 
 ----
 #[starknet::contract]
 mod MyContract {
-    use openzeppelin::account::interface;
-    use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin_account::interface;
+    use openzeppelin_introspection::src5::SRC5Component;
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 
@@ -122,9 +122,9 @@ Use the `supports_interface` function to query a contract's support for a given 
 ----
 #[starknet::contract]
 mod MyContract {
-    use openzeppelin::account::interface;
-    use openzeppelin::introspection::interface::ISRC5DispatcherTrait;
-    use openzeppelin::introspection::interface::ISRC5Dispatcher;
+    use openzeppelin_account::interface;
+    use openzeppelin_introspection::interface::ISRC5DispatcherTrait;
+    use openzeppelin_introspection::interface::ISRC5Dispatcher;
     use starknet::ContractAddress;
 
     #[storage]

--- a/docs/modules/ROOT/pages/presets.adoc
+++ b/docs/modules/ROOT/pages/presets.adoc
@@ -76,10 +76,10 @@ Copy the target preset contract from the {presets_dir} and paste it in the new p
 
 #[starknet::contract]
 mod ERC20Upgradeable {
-    use openzeppelin::access::ownable::OwnableComponent;
-    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
-    use openzeppelin::upgrades::UpgradeableComponent;
-    use openzeppelin::upgrades::interface::IUpgradeable;
+    use openzeppelin_access::ownable::OwnableComponent;
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use openzeppelin_upgrades::UpgradeableComponent;
+    use openzeppelin_upgrades::interface::IUpgradeable;
     use starknet::{ContractAddress, ClassHash};
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);

--- a/docs/modules/ROOT/pages/security.adoc
+++ b/docs/modules/ROOT/pages/security.adoc
@@ -1,6 +1,6 @@
 = Security
 
-The following documentation provides context, reasoning, and examples of modules found under `openzeppelin::security`.
+The following documentation provides context, reasoning, and examples of modules found under `openzeppelin_security`.
 
 CAUTION: Expect these modules to evolve.
 
@@ -18,7 +18,7 @@ You can use the component in your contracts like this:
 ----
 #[starknet::contract]
 mod MyInitializableContract {
-    use openzeppelin::security::InitializableComponent;
+    use openzeppelin_security::InitializableComponent;
 
     component!(path: InitializableComponent, storage: initializable, event: InitializableEvent);
 
@@ -82,8 +82,8 @@ For example (using the xref:api/access.adoc#OwnableComponent[Ownable] component 
 ----
 #[starknet::contract]
 mod MyPausableContract {
-    use openzeppelin::access::ownable::OwnableComponent;
-    use openzeppelin::security::PausableComponent;
+    use openzeppelin_access::ownable::OwnableComponent;
+    use openzeppelin_security::PausableComponent;
     use starknet::ContractAddress;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
@@ -176,7 +176,7 @@ The protected function must call `start` before the first function statement, an
 ----
 #[starknet::contract]
 mod MyReentrancyContract {
-    use openzeppelin::security::ReentrancyGuardComponent;
+    use openzeppelin_security::ReentrancyGuardComponent;
 
     component!(
         path: ReentrancyGuardComponent, storage: reentrancy_guard, event: ReentrancyGuardEvent

--- a/docs/modules/ROOT/pages/udc.adoc
+++ b/docs/modules/ROOT/pages/udc.adoc
@@ -41,7 +41,7 @@ Here's an implementation example in Cairo:
 
 [,cairo]
 ----
-use openzeppelin::utils::interfaces::{IUniversalDeployerDispatcher, IUniversalDeployerDispatcherTrait};
+use openzeppelin_utils::interfaces::{IUniversalDeployerDispatcher, IUniversalDeployerDispatcherTrait};
 
 const UDC_ADDRESS: felt252 = 0x04a64cd09a853868621d94cae9952b106f2c36a3f81260f85de6696c6b050221;
 

--- a/docs/modules/ROOT/pages/upgrades.adoc
+++ b/docs/modules/ROOT/pages/upgrades.adoc
@@ -51,9 +51,9 @@ NOTE: We will be using the following module to implement the {i_upgradeable} int
 ----
 #[starknet::contract]
 mod UpgradeableContract {
-    use openzeppelin::access::ownable::OwnableComponent;
-    use openzeppelin::upgrades::UpgradeableComponent;
-    use openzeppelin::upgrades::interface::IUpgradeable;
+    use openzeppelin_access::ownable::OwnableComponent;
+    use openzeppelin_upgrades::UpgradeableComponent;
+    use openzeppelin_upgrades::interface::IUpgradeable;
     use starknet::ClassHash;
     use starknet::ContractAddress;
 


### PR DESCRIPTION
This PR does:

- Uses the package name version instead of the scoped one in docs (`openzeppelin_token` instead of `openzeppelin::token`), since this version always works no matter if the user declares the standalone version or the full library.
- Removes git references when declaring packages in Scarb.toml, and uses registry instead.