### PR TITLE
Add missing manifest import

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -90,6 +90,7 @@ dependencies = [
  "openzeppelin_testing",
  "openzeppelin_token",
  "openzeppelin_upgrades",
+ "openzeppelin_utils",
  "snforge_std",
 ]
 
@@ -131,6 +132,7 @@ dependencies = [
  "openzeppelin_introspection",
  "openzeppelin_test_common",
  "openzeppelin_testing",
+ "openzeppelin_utils",
  "snforge_std",
 ]
 

--- a/packages/presets/Scarb.toml
+++ b/packages/presets/Scarb.toml
@@ -28,6 +28,7 @@ openzeppelin_finance = { path = "../finance" }
 openzeppelin_introspection = { path = "../introspection" }
 openzeppelin_token = { path = "../token" }
 openzeppelin_upgrades = { path = "../upgrades" }
+openzeppelin_utils = { path = "../utils" }
 
 [dev-dependencies]
 assert_macros.workspace = true

--- a/packages/token/Scarb.toml
+++ b/packages/token/Scarb.toml
@@ -27,6 +27,7 @@ starknet.workspace = true
 openzeppelin_account = { path = "../account" }
 openzeppelin_introspection = { path = "../introspection" }
 openzeppelin_governance = { path = "../governance" }
+openzeppelin_utils = { path = "../utils" }
 
 [dev-dependencies]
 assert_macros.workspace = true


### PR DESCRIPTION
Add missing imports - stop relying on access to transient dep. 

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
