### PR TITLE
Refactor hooks contract storage access

### DIFF
--- a/docs/modules/ROOT/pages/api/erc721.adoc
+++ b/docs/modules/ROOT/pages/api/erc721.adoc
@@ -863,7 +863,7 @@ mod ERC721EnumerableContract {
             token_id: u256,
             auth: ContractAddress
         ) {
-            let mut contract_state = ERC721Component::HasComponent::get_contract_mut(ref self);
+            let mut contract_state = self.get_contract_mut();
             contract_state.erc721_enumerable.before_update(to, token_id);
         }
     }

--- a/docs/modules/ROOT/pages/components.adoc
+++ b/docs/modules/ROOT/pages/components.adoc
@@ -508,7 +508,7 @@ mod MyToken {
             amount: u256
         ) {
             // Access local state from component state
-            let contract_state = ERC20Component::HasComponent::get_contract(@self);
+            let contract_state = self.get_contract();
             // Call function from integrated component
             contract_state.pausable.assert_not_paused();
         }

--- a/docs/modules/ROOT/pages/governance.adoc
+++ b/docs/modules/ROOT/pages/governance.adoc
@@ -297,7 +297,7 @@ mod ERC20VotesContract {
             recipient: ContractAddress,
             amount: u256
         ) {
-            let mut contract_state = ERC20Component::HasComponent::get_contract_mut(ref self);
+            let mut contract_state = self.get_contract_mut();
             contract_state.erc20_votes.transfer_voting_units(from, recipient, amount);
         }
     }
@@ -390,7 +390,7 @@ pub mod ERC721VotesContract {
             token_id: u256,
             auth: ContractAddress
         ) {
-            let mut contract_state = ERC721Component::HasComponent::get_contract_mut(ref self);
+            let mut contract_state = self.get_contract_mut();
 
             // We use the internal function here since it does not check if the token
             // id exists which is necessary for mints

--- a/packages/test_common/src/mocks/erc721.cairo
+++ b/packages/test_common/src/mocks/erc721.cairo
@@ -233,7 +233,7 @@ pub mod ERC721EnumerableMock {
             token_id: u256,
             auth: ContractAddress
         ) {
-            let mut contract_state = ERC721Component::HasComponent::get_contract_mut(ref self);
+            let mut contract_state = self.get_contract_mut();
             contract_state.erc721_enumerable.before_update(to, token_id);
         }
     }

--- a/packages/test_common/src/mocks/votes.cairo
+++ b/packages/test_common/src/mocks/votes.cairo
@@ -70,7 +70,7 @@ pub mod ERC721VotesMock {
             token_id: u256,
             auth: ContractAddress
         ) {
-            let mut contract_state = ERC721Component::HasComponent::get_contract_mut(ref self);
+            let mut contract_state = self.get_contract_mut();
 
             // We use the internal function here since it does not check if the token id exists
             // which is necessary for mints
@@ -149,7 +149,7 @@ pub mod ERC20VotesMock {
             recipient: ContractAddress,
             amount: u256
         ) {
-            let mut contract_state = ERC20Component::HasComponent::get_contract_mut(ref self);
+            let mut contract_state = self.get_contract_mut();
             contract_state.erc20_votes.transfer_voting_units(from, recipient, amount);
         }
     }


### PR DESCRIPTION
Avoid the extra verbosity of explicitly calling the HasComponent implementation.