### PR TITLE
Test token hooks

### DIFF
--- a/packages/test_common/src/mocks/erc1155.cairo
+++ b/packages/test_common/src/mocks/erc1155.cairo
@@ -51,10 +51,61 @@ pub mod DualCaseERC1155Mock {
     }
 }
 
-/// Similar to `DualCaseERC1155Mock`, but emits events for `before_update` and `after_update` hooks.
+#[starknet::contract]
+pub mod SnakeERC1155Mock {
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_token::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
+    use starknet::ContractAddress;
+
+    component!(path: ERC1155Component, storage: erc1155, event: ERC1155Event);
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
+
+    // ERC1155
+    #[abi(embed_v0)]
+    impl ERC1155Impl = ERC1155Component::ERC1155Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC1155MetadataURIImpl =
+        ERC1155Component::ERC1155MetadataURIImpl<ContractState>;
+    impl ERC1155InternalImpl = ERC1155Component::InternalImpl<ContractState>;
+
+    // SRC5
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+
+    #[storage]
+    pub struct Storage {
+        #[substorage(v0)]
+        pub erc1155: ERC1155Component::Storage,
+        #[substorage(v0)]
+        pub src5: SRC5Component::Storage
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        ERC1155Event: ERC1155Component::Event,
+        #[flat]
+        SRC5Event: SRC5Component::Event
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        base_uri: ByteArray,
+        recipient: ContractAddress,
+        token_id: u256,
+        value: u256
+    ) {
+        self.erc1155.initializer(base_uri);
+        self.erc1155.mint_with_acceptance_check(recipient, token_id, value, array![].span());
+    }
+}
+
+/// Similar to `SnakeERC1155Mock`, but emits events for `before_update` and `after_update` hooks.
 /// This is used to test that the hooks are called with the correct arguments.
 #[starknet::contract]
-pub mod ERC1155MockWithHooks {
+pub mod SnakeERC1155MockWithHooks {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_token::erc1155::{ERC1155Component};
     use starknet::ContractAddress;
@@ -145,57 +196,6 @@ pub mod ERC1155MockWithHooks {
             let mut contract_state = self.get_contract_mut();
             contract_state.emit(AfterUpdate { from, to, token_ids, values });
         }
-    }
-}
-
-#[starknet::contract]
-pub mod SnakeERC1155Mock {
-    use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
-    use starknet::ContractAddress;
-
-    component!(path: ERC1155Component, storage: erc1155, event: ERC1155Event);
-    component!(path: SRC5Component, storage: src5, event: SRC5Event);
-
-    // ERC1155
-    #[abi(embed_v0)]
-    impl ERC1155Impl = ERC1155Component::ERC1155Impl<ContractState>;
-    #[abi(embed_v0)]
-    impl ERC1155MetadataURIImpl =
-        ERC1155Component::ERC1155MetadataURIImpl<ContractState>;
-    impl ERC1155InternalImpl = ERC1155Component::InternalImpl<ContractState>;
-
-    // SRC5
-    #[abi(embed_v0)]
-    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
-
-    #[storage]
-    pub struct Storage {
-        #[substorage(v0)]
-        pub erc1155: ERC1155Component::Storage,
-        #[substorage(v0)]
-        pub src5: SRC5Component::Storage
-    }
-
-    #[event]
-    #[derive(Drop, starknet::Event)]
-    enum Event {
-        #[flat]
-        ERC1155Event: ERC1155Component::Event,
-        #[flat]
-        SRC5Event: SRC5Component::Event
-    }
-
-    #[constructor]
-    fn constructor(
-        ref self: ContractState,
-        base_uri: ByteArray,
-        recipient: ContractAddress,
-        token_id: u256,
-        value: u256
-    ) {
-        self.erc1155.initializer(base_uri);
-        self.erc1155.mint_with_acceptance_check(recipient, token_id, value, array![].span());
     }
 }
 

--- a/packages/test_common/src/mocks/erc1155.cairo
+++ b/packages/test_common/src/mocks/erc1155.cairo
@@ -51,6 +51,103 @@ pub mod DualCaseERC1155Mock {
     }
 }
 
+/// Similar to `DualCaseERC1155Mock`, but emits events for `before_update` and `after_update` hooks.
+/// This is used to test that the hooks are called with the correct arguments.
+#[starknet::contract]
+pub mod ERC1155MockWithHooks {
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_token::erc1155::{ERC1155Component};
+    use starknet::ContractAddress;
+
+    component!(path: ERC1155Component, storage: erc1155, event: ERC1155Event);
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
+
+    // ERC1155
+    #[abi(embed_v0)]
+    impl ERC1155Impl = ERC1155Component::ERC1155Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC1155MetadataURIImpl =
+        ERC1155Component::ERC1155MetadataURIImpl<ContractState>;
+    impl ERC1155InternalImpl = ERC1155Component::InternalImpl<ContractState>;
+
+    // SRC5
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+
+    #[storage]
+    pub struct Storage {
+        #[substorage(v0)]
+        pub erc1155: ERC1155Component::Storage,
+        #[substorage(v0)]
+        pub src5: SRC5Component::Storage
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        #[flat]
+        ERC1155Event: ERC1155Component::Event,
+        #[flat]
+        SRC5Event: SRC5Component::Event,
+        BeforeUpdate: BeforeUpdate,
+        AfterUpdate: AfterUpdate
+    }
+
+    /// Event used to test that `before_update` hook is called.
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub struct BeforeUpdate {
+        pub from: ContractAddress,
+        pub to: ContractAddress,
+        pub token_ids: Span<u256>,
+        pub values: Span<u256>
+    }
+
+    /// Event used to test that `after_update` hook is called.
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub struct AfterUpdate {
+        pub from: ContractAddress,
+        pub to: ContractAddress,
+        pub token_ids: Span<u256>,
+        pub values: Span<u256>
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        base_uri: ByteArray,
+        recipient: ContractAddress,
+        token_id: u256,
+        value: u256
+    ) {
+        self.erc1155.initializer(base_uri);
+        self.erc1155.mint_with_acceptance_check(recipient, token_id, value, array![].span());
+    }
+
+    impl ERC1155HooksImpl of ERC1155Component::ERC1155HooksTrait<ContractState> {
+        fn before_update(
+            ref self: ERC1155Component::ComponentState<ContractState>,
+            from: ContractAddress,
+            to: ContractAddress,
+            token_ids: Span<u256>,
+            values: Span<u256>
+        ) {
+            let mut contract_state = self.get_contract_mut();
+            contract_state.emit(BeforeUpdate { from, to, token_ids, values });
+        }
+
+        fn after_update(
+            ref self: ERC1155Component::ComponentState<ContractState>,
+            from: ContractAddress,
+            to: ContractAddress,
+            token_ids: Span<u256>,
+            values: Span<u256>
+        ) {
+            let mut contract_state = self.get_contract_mut();
+            contract_state.emit(AfterUpdate { from, to, token_ids, values });
+        }
+    }
+}
+
 #[starknet::contract]
 pub mod SnakeERC1155Mock {
     use openzeppelin_introspection::src5::SRC5Component;

--- a/packages/test_common/src/mocks/erc20.cairo
+++ b/packages/test_common/src/mocks/erc20.cairo
@@ -38,10 +38,50 @@ pub mod DualCaseERC20Mock {
         self.erc20.mint(recipient, initial_supply);
     }
 }
-/// Similar to `DualCaseERC20Mock`, but emits events for `before_update` and `after_update` hooks.
+
+#[starknet::contract]
+pub mod SnakeERC20Mock {
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use starknet::ContractAddress;
+
+    component!(path: ERC20Component, storage: erc20, event: ERC20Event);
+
+    #[abi(embed_v0)]
+    impl ERC20Impl = ERC20Component::ERC20Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC20MetadataImpl = ERC20Component::ERC20MetadataImpl<ContractState>;
+    impl InternalImpl = ERC20Component::InternalImpl<ContractState>;
+
+    #[storage]
+    pub struct Storage {
+        #[substorage(v0)]
+        pub erc20: ERC20Component::Storage
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        ERC20Event: ERC20Component::Event
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        name: ByteArray,
+        symbol: ByteArray,
+        initial_supply: u256,
+        recipient: ContractAddress
+    ) {
+        self.erc20.initializer(name, symbol);
+        self.erc20.mint(recipient, initial_supply);
+    }
+}
+
+/// Similar to `SnakeERC20Mock`, but emits events for `before_update` and `after_update` hooks.
 /// This is used to test that the hooks are called with the correct arguments.
 #[starknet::contract]
-pub mod ERC20MockWithHooks {
+pub mod SnakeERC20MockWithHooks {
     use openzeppelin_token::erc20::{ERC20Component};
     use starknet::ContractAddress;
 
@@ -116,45 +156,6 @@ pub mod ERC20MockWithHooks {
             let mut contract_state = self.get_contract_mut();
             contract_state.emit(AfterUpdate { from, recipient, amount });
         }
-    }
-}
-
-#[starknet::contract]
-pub mod SnakeERC20Mock {
-    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
-    use starknet::ContractAddress;
-
-    component!(path: ERC20Component, storage: erc20, event: ERC20Event);
-
-    #[abi(embed_v0)]
-    impl ERC20Impl = ERC20Component::ERC20Impl<ContractState>;
-    #[abi(embed_v0)]
-    impl ERC20MetadataImpl = ERC20Component::ERC20MetadataImpl<ContractState>;
-    impl InternalImpl = ERC20Component::InternalImpl<ContractState>;
-
-    #[storage]
-    pub struct Storage {
-        #[substorage(v0)]
-        pub erc20: ERC20Component::Storage
-    }
-
-    #[event]
-    #[derive(Drop, starknet::Event)]
-    enum Event {
-        #[flat]
-        ERC20Event: ERC20Component::Event
-    }
-
-    #[constructor]
-    fn constructor(
-        ref self: ContractState,
-        name: ByteArray,
-        symbol: ByteArray,
-        initial_supply: u256,
-        recipient: ContractAddress
-    ) {
-        self.erc20.initializer(name, symbol);
-        self.erc20.mint(recipient, initial_supply);
     }
 }
 

--- a/packages/test_common/src/mocks/erc20.cairo
+++ b/packages/test_common/src/mocks/erc20.cairo
@@ -38,6 +38,88 @@ pub mod DualCaseERC20Mock {
         self.erc20.mint(recipient, initial_supply);
     }
 }
+/// Same as `DualCaseERC20Mock`, but emits events for `before_update` and `after_update` hooks.
+/// This is used to test that the hooks are called with the correct arguments.
+#[starknet::contract]
+pub mod DualCaseERC20MockWithHooks {
+    use openzeppelin_token::erc20::{ERC20Component};
+    use starknet::ContractAddress;
+
+    component!(path: ERC20Component, storage: erc20, event: ERC20Event);
+
+    #[abi(embed_v0)]
+    impl ERC20Impl = ERC20Component::ERC20Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC20MetadataImpl = ERC20Component::ERC20MetadataImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC20CamelOnlyImpl = ERC20Component::ERC20CamelOnlyImpl<ContractState>;
+    impl InternalImpl = ERC20Component::InternalImpl<ContractState>;
+
+    #[storage]
+    pub struct Storage {
+        #[substorage(v0)]
+        pub erc20: ERC20Component::Storage
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        #[flat]
+        ERC20Event: ERC20Component::Event,
+        BeforeUpdate: BeforeUpdate,
+        AfterUpdate: AfterUpdate
+    }
+
+    /// Event used to test that `before_update` hook is called.
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub struct BeforeUpdate {
+        pub from: ContractAddress,
+        pub recipient: ContractAddress,
+        pub amount: u256
+    }
+
+    /// Event used to test that `after_update` hook is called.
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub struct AfterUpdate {
+        pub from: ContractAddress,
+        pub recipient: ContractAddress,
+        pub amount: u256
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        name: ByteArray,
+        symbol: ByteArray,
+        initial_supply: u256,
+        recipient: ContractAddress
+    ) {
+        self.erc20.initializer(name, symbol);
+        self.erc20.mint(recipient, initial_supply);
+    }
+
+    impl ERC20VotesHooksImpl of ERC20Component::ERC20HooksTrait<ContractState> {
+        fn before_update(
+            ref self: ERC20Component::ComponentState<ContractState>,
+            from: ContractAddress,
+            recipient: ContractAddress,
+            amount: u256
+        ) {
+            let mut contract_state = self.get_contract_mut();
+            contract_state.emit(BeforeUpdate { from, recipient, amount });
+        }
+
+        fn after_update(
+            ref self: ERC20Component::ComponentState<ContractState>,
+            from: ContractAddress,
+            recipient: ContractAddress,
+            amount: u256
+        ) {
+            let mut contract_state = self.get_contract_mut();
+            contract_state.emit(AfterUpdate { from, recipient, amount });
+        }
+    }
+}
 
 #[starknet::contract]
 pub mod SnakeERC20Mock {

--- a/packages/test_common/src/mocks/erc20.cairo
+++ b/packages/test_common/src/mocks/erc20.cairo
@@ -38,10 +38,10 @@ pub mod DualCaseERC20Mock {
         self.erc20.mint(recipient, initial_supply);
     }
 }
-/// Same as `DualCaseERC20Mock`, but emits events for `before_update` and `after_update` hooks.
+/// Similar to `DualCaseERC20Mock`, but emits events for `before_update` and `after_update` hooks.
 /// This is used to test that the hooks are called with the correct arguments.
 #[starknet::contract]
-pub mod DualCaseERC20MockWithHooks {
+pub mod ERC20MockWithHooks {
     use openzeppelin_token::erc20::{ERC20Component};
     use starknet::ContractAddress;
 
@@ -51,8 +51,6 @@ pub mod DualCaseERC20MockWithHooks {
     impl ERC20Impl = ERC20Component::ERC20Impl<ContractState>;
     #[abi(embed_v0)]
     impl ERC20MetadataImpl = ERC20Component::ERC20MetadataImpl<ContractState>;
-    #[abi(embed_v0)]
-    impl ERC20CamelOnlyImpl = ERC20Component::ERC20CamelOnlyImpl<ContractState>;
     impl InternalImpl = ERC20Component::InternalImpl<ContractState>;
 
     #[storage]

--- a/packages/test_common/src/mocks/erc20.cairo
+++ b/packages/test_common/src/mocks/erc20.cairo
@@ -42,7 +42,7 @@ pub mod DualCaseERC20Mock {
 /// This is used to test that the hooks are called with the correct arguments.
 #[starknet::contract]
 pub mod ERC20MockWithHooks {
-    use openzeppelin_token::erc20::{ERC20Component};
+    use openzeppelin_token::erc20::ERC20Component;
     use starknet::ContractAddress;
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);

--- a/packages/test_common/src/mocks/erc20.cairo
+++ b/packages/test_common/src/mocks/erc20.cairo
@@ -98,7 +98,7 @@ pub mod DualCaseERC20MockWithHooks {
         self.erc20.mint(recipient, initial_supply);
     }
 
-    impl ERC20VotesHooksImpl of ERC20Component::ERC20HooksTrait<ContractState> {
+    impl ERC20HooksImpl of ERC20Component::ERC20HooksTrait<ContractState> {
         fn before_update(
             ref self: ERC20Component::ComponentState<ContractState>,
             from: ContractAddress,

--- a/packages/test_common/src/mocks/erc721.cairo
+++ b/packages/test_common/src/mocks/erc721.cairo
@@ -56,6 +56,104 @@ pub mod DualCaseERC721Mock {
     }
 }
 
+/// Same as `DualCaseERC721Mock`, but emits events for `before_update` and `after_update` hooks.
+/// This is used to test that the hooks are called with the correct arguments.
+#[starknet::contract]
+pub mod DualCaseERC721MockWithHooks {
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_token::erc721::ERC721Component;
+    use starknet::ContractAddress;
+
+    component!(path: ERC721Component, storage: erc721, event: ERC721Event);
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
+
+    // ERC721
+    #[abi(embed_v0)]
+    impl ERC721Impl = ERC721Component::ERC721Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC721MetadataImpl = ERC721Component::ERC721MetadataImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC721CamelOnly = ERC721Component::ERC721CamelOnlyImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC721MetadataCamelOnly =
+        ERC721Component::ERC721MetadataCamelOnlyImpl<ContractState>;
+    impl ERC721InternalImpl = ERC721Component::InternalImpl<ContractState>;
+
+    // SRC5
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+
+    #[storage]
+    pub struct Storage {
+        #[substorage(v0)]
+        pub erc721: ERC721Component::Storage,
+        #[substorage(v0)]
+        pub src5: SRC5Component::Storage
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        #[flat]
+        ERC721Event: ERC721Component::Event,
+        #[flat]
+        SRC5Event: SRC5Component::Event,
+        BeforeUpdate: BeforeUpdate,
+        AfterUpdate: AfterUpdate
+    }
+
+    /// Event used to test that `before_update` hook is called.
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub struct BeforeUpdate {
+        pub to: ContractAddress,
+        pub token_id: u256,
+        pub auth: ContractAddress
+    }
+
+    /// Event used to test that `after_update` hook is called.
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub struct AfterUpdate {
+        pub to: ContractAddress,
+        pub token_id: u256,
+        pub auth: ContractAddress
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        name: ByteArray,
+        symbol: ByteArray,
+        base_uri: ByteArray,
+        recipient: ContractAddress,
+        token_id: u256
+    ) {
+        self.erc721.initializer(name, symbol, base_uri);
+        self.erc721.mint(recipient, token_id);
+    }
+
+    impl ERC721HooksImpl of ERC721Component::ERC721HooksTrait<ContractState> {
+        fn before_update(
+            ref self: ERC721Component::ComponentState<ContractState>,
+            to: ContractAddress,
+            token_id: u256,
+            auth: ContractAddress
+        ) {
+            let mut contract_state = self.get_contract_mut();
+            contract_state.emit(BeforeUpdate { to, token_id, auth });
+        }
+
+        fn after_update(
+            ref self: ERC721Component::ComponentState<ContractState>,
+            to: ContractAddress,
+            token_id: u256,
+            auth: ContractAddress
+        ) {
+            let mut contract_state = self.get_contract_mut();
+            contract_state.emit(AfterUpdate { to, token_id, auth });
+        }
+    }
+}
+
 #[starknet::contract]
 pub mod SnakeERC721Mock {
     use openzeppelin_introspection::src5::SRC5Component;

--- a/packages/test_common/src/mocks/erc721.cairo
+++ b/packages/test_common/src/mocks/erc721.cairo
@@ -56,10 +56,10 @@ pub mod DualCaseERC721Mock {
     }
 }
 
-/// Same as `DualCaseERC721Mock`, but emits events for `before_update` and `after_update` hooks.
+/// Similar as `DualCaseERC721Mock`, but emits events for `before_update` and `after_update` hooks.
 /// This is used to test that the hooks are called with the correct arguments.
 #[starknet::contract]
-pub mod DualCaseERC721MockWithHooks {
+pub mod ERC721MockWithHooks {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_token::erc721::ERC721Component;
     use starknet::ContractAddress;
@@ -72,11 +72,6 @@ pub mod DualCaseERC721MockWithHooks {
     impl ERC721Impl = ERC721Component::ERC721Impl<ContractState>;
     #[abi(embed_v0)]
     impl ERC721MetadataImpl = ERC721Component::ERC721MetadataImpl<ContractState>;
-    #[abi(embed_v0)]
-    impl ERC721CamelOnly = ERC721Component::ERC721CamelOnlyImpl<ContractState>;
-    #[abi(embed_v0)]
-    impl ERC721MetadataCamelOnly =
-        ERC721Component::ERC721MetadataCamelOnlyImpl<ContractState>;
     impl ERC721InternalImpl = ERC721Component::InternalImpl<ContractState>;
 
     // SRC5

--- a/packages/test_common/src/mocks/erc721.cairo
+++ b/packages/test_common/src/mocks/erc721.cairo
@@ -56,10 +56,61 @@ pub mod DualCaseERC721Mock {
     }
 }
 
-/// Similar as `DualCaseERC721Mock`, but emits events for `before_update` and `after_update` hooks.
+#[starknet::contract]
+pub mod SnakeERC721Mock {
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_token::erc721::{ERC721Component, ERC721HooksEmptyImpl};
+    use starknet::ContractAddress;
+
+    component!(path: ERC721Component, storage: erc721, event: ERC721Event);
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
+
+    // ERC721
+    #[abi(embed_v0)]
+    impl ERC721Impl = ERC721Component::ERC721Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC721MetadataImpl = ERC721Component::ERC721MetadataImpl<ContractState>;
+    impl ERC721InternalImpl = ERC721Component::InternalImpl<ContractState>;
+
+    // SRC5
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+
+    #[storage]
+    pub struct Storage {
+        #[substorage(v0)]
+        pub erc721: ERC721Component::Storage,
+        #[substorage(v0)]
+        pub src5: SRC5Component::Storage
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        ERC721Event: ERC721Component::Event,
+        #[flat]
+        SRC5Event: SRC5Component::Event
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        name: ByteArray,
+        symbol: ByteArray,
+        base_uri: ByteArray,
+        recipient: ContractAddress,
+        token_id: u256
+    ) {
+        self.erc721.initializer(name, symbol, base_uri);
+        self.erc721.mint(recipient, token_id);
+    }
+}
+
+/// Similar as `SnakeERC721Mock`, but emits events for `before_update` and `after_update` hooks.
 /// This is used to test that the hooks are called with the correct arguments.
 #[starknet::contract]
-pub mod ERC721MockWithHooks {
+pub mod SnakeERC721MockWithHooks {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_token::erc721::ERC721Component;
     use starknet::ContractAddress;
@@ -146,57 +197,6 @@ pub mod ERC721MockWithHooks {
             let mut contract_state = self.get_contract_mut();
             contract_state.emit(AfterUpdate { to, token_id, auth });
         }
-    }
-}
-
-#[starknet::contract]
-pub mod SnakeERC721Mock {
-    use openzeppelin_introspection::src5::SRC5Component;
-    use openzeppelin_token::erc721::{ERC721Component, ERC721HooksEmptyImpl};
-    use starknet::ContractAddress;
-
-    component!(path: ERC721Component, storage: erc721, event: ERC721Event);
-    component!(path: SRC5Component, storage: src5, event: SRC5Event);
-
-    // ERC721
-    #[abi(embed_v0)]
-    impl ERC721Impl = ERC721Component::ERC721Impl<ContractState>;
-    #[abi(embed_v0)]
-    impl ERC721MetadataImpl = ERC721Component::ERC721MetadataImpl<ContractState>;
-    impl ERC721InternalImpl = ERC721Component::InternalImpl<ContractState>;
-
-    // SRC5
-    #[abi(embed_v0)]
-    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
-
-    #[storage]
-    pub struct Storage {
-        #[substorage(v0)]
-        pub erc721: ERC721Component::Storage,
-        #[substorage(v0)]
-        pub src5: SRC5Component::Storage
-    }
-
-    #[event]
-    #[derive(Drop, starknet::Event)]
-    enum Event {
-        #[flat]
-        ERC721Event: ERC721Component::Event,
-        #[flat]
-        SRC5Event: SRC5Component::Event
-    }
-
-    #[constructor]
-    fn constructor(
-        ref self: ContractState,
-        name: ByteArray,
-        symbol: ByteArray,
-        base_uri: ByteArray,
-        recipient: ContractAddress,
-        token_id: u256
-    ) {
-        self.erc721.initializer(name, symbol, base_uri);
-        self.erc721.mint(recipient, token_id);
     }
 }
 

--- a/packages/token/src/tests/erc1155/test_erc1155.cairo
+++ b/packages/token/src/tests/erc1155/test_erc1155.cairo
@@ -10,7 +10,7 @@ use openzeppelin_test_common::erc1155::{
 use openzeppelin_test_common::erc1155::{
     setup_account, deploy_another_account_at, setup_src5, setup_receiver
 };
-use openzeppelin_test_common::mocks::erc1155::{DualCaseERC1155Mock, ERC1155MockWithHooks};
+use openzeppelin_test_common::mocks::erc1155::{DualCaseERC1155Mock, SnakeERC1155MockWithHooks};
 use openzeppelin_testing::constants::{
     EMPTY_DATA, ZERO, OWNER, RECIPIENT, OPERATOR, OTHER, TOKEN_ID, TOKEN_ID_2, TOKEN_VALUE,
     TOKEN_VALUE_2
@@ -27,7 +27,7 @@ use starknet::storage::StoragePointerReadAccess;
 
 type ComponentState = ERC1155Component::ComponentState<DualCaseERC1155Mock::ContractState>;
 type ComponentStateWithHooks =
-    ERC1155Component::ComponentState<ERC1155MockWithHooks::ContractState>;
+    ERC1155Component::ComponentState<SnakeERC1155MockWithHooks::ContractState>;
 
 fn CONTRACT_STATE() -> DualCaseERC1155Mock::ContractState {
     DualCaseERC1155Mock::contract_state_for_testing()
@@ -1386,8 +1386,8 @@ impl ERC1155HooksSpyHelpersImpl of ERC1155HooksSpyHelpers {
         token_ids: Span<u256>,
         values: Span<u256>
     ) {
-        let expected = ERC1155MockWithHooks::Event::BeforeUpdate(
-            ERC1155MockWithHooks::BeforeUpdate { from, to, token_ids, values }
+        let expected = SnakeERC1155MockWithHooks::Event::BeforeUpdate(
+            SnakeERC1155MockWithHooks::BeforeUpdate { from, to, token_ids, values }
         );
         self.assert_emitted_single(contract, expected);
     }
@@ -1400,8 +1400,8 @@ impl ERC1155HooksSpyHelpersImpl of ERC1155HooksSpyHelpers {
         token_ids: Span<u256>,
         values: Span<u256>
     ) {
-        let expected = ERC1155MockWithHooks::Event::AfterUpdate(
-            ERC1155MockWithHooks::AfterUpdate { from, to, token_ids, values }
+        let expected = SnakeERC1155MockWithHooks::Event::AfterUpdate(
+            SnakeERC1155MockWithHooks::AfterUpdate { from, to, token_ids, values }
         );
         self.assert_emitted_single(contract, expected);
     }

--- a/packages/token/src/tests/erc20/test_erc20.cairo
+++ b/packages/token/src/tests/erc20/test_erc20.cairo
@@ -16,8 +16,7 @@ use starknet::ContractAddress;
 //
 
 type ComponentState = ERC20Component::ComponentState<DualCaseERC20Mock::ContractState>;
-type ComponentStateWithHooks =
-    ERC20Component::ComponentState<ERC20MockWithHooks::ContractState>;
+type ComponentStateWithHooks = ERC20Component::ComponentState<ERC20MockWithHooks::ContractState>;
 
 fn COMPONENT_STATE() -> ComponentState {
     ERC20Component::component_state_for_testing()

--- a/packages/token/src/tests/erc20/test_erc20.cairo
+++ b/packages/token/src/tests/erc20/test_erc20.cairo
@@ -572,7 +572,6 @@ fn test_update_calls_before_update_hook() {
     let mut spy = spy_events();
     let contract_address = test_address();
 
-    start_cheat_caller_address(contract_address, OWNER());
     state.update(OWNER(), RECIPIENT(), VALUE);
 
     spy.assert_event_before_update(contract_address, OWNER(), RECIPIENT(), VALUE);
@@ -585,7 +584,6 @@ fn test_update_calls_after_update_hook() {
     let mut spy = spy_events();
     let contract_address = test_address();
 
-    start_cheat_caller_address(contract_address, OWNER());
     state.update(OWNER(), RECIPIENT(), VALUE);
 
     spy.assert_event_after_update(contract_address, OWNER(), RECIPIENT(), VALUE);

--- a/packages/token/src/tests/erc20/test_erc20.cairo
+++ b/packages/token/src/tests/erc20/test_erc20.cairo
@@ -3,7 +3,7 @@ use crate::erc20::ERC20Component::{ERC20CamelOnlyImpl, ERC20Impl};
 use crate::erc20::ERC20Component::{ERC20MetadataImpl, InternalImpl};
 use crate::erc20::ERC20Component;
 use openzeppelin_test_common::erc20::ERC20SpyHelpers;
-use openzeppelin_test_common::mocks::erc20::{DualCaseERC20Mock, ERC20MockWithHooks};
+use openzeppelin_test_common::mocks::erc20::{DualCaseERC20Mock, SnakeERC20MockWithHooks};
 use openzeppelin_testing::constants::{
     ZERO, OWNER, SPENDER, RECIPIENT, NAME, SYMBOL, DECIMALS, SUPPLY, VALUE
 };
@@ -16,7 +16,8 @@ use starknet::ContractAddress;
 //
 
 type ComponentState = ERC20Component::ComponentState<DualCaseERC20Mock::ContractState>;
-type ComponentStateWithHooks = ERC20Component::ComponentState<ERC20MockWithHooks::ContractState>;
+type ComponentStateWithHooks =
+    ERC20Component::ComponentState<SnakeERC20MockWithHooks::ContractState>;
 
 fn COMPONENT_STATE() -> ComponentState {
     ERC20Component::component_state_for_testing()
@@ -658,8 +659,8 @@ impl ERC20HooksSpyHelpersImpl of ERC20HooksSpyHelpers {
         recipient: ContractAddress,
         amount: u256
     ) {
-        let expected = ERC20MockWithHooks::Event::BeforeUpdate(
-            ERC20MockWithHooks::BeforeUpdate { from, recipient, amount }
+        let expected = SnakeERC20MockWithHooks::Event::BeforeUpdate(
+            SnakeERC20MockWithHooks::BeforeUpdate { from, recipient, amount }
         );
         self.assert_emitted_single(contract, expected);
     }
@@ -671,8 +672,8 @@ impl ERC20HooksSpyHelpersImpl of ERC20HooksSpyHelpers {
         recipient: ContractAddress,
         amount: u256
     ) {
-        let expected = ERC20MockWithHooks::Event::AfterUpdate(
-            ERC20MockWithHooks::AfterUpdate { from, recipient, amount }
+        let expected = SnakeERC20MockWithHooks::Event::AfterUpdate(
+            SnakeERC20MockWithHooks::AfterUpdate { from, recipient, amount }
         );
         self.assert_emitted_single(contract, expected);
     }

--- a/packages/token/src/tests/erc721/test_erc721.cairo
+++ b/packages/token/src/tests/erc721/test_erc721.cairo
@@ -1403,7 +1403,6 @@ fn test_update_calls_before_update_hook() {
     let mut spy = spy_events();
     let contract_address = test_address();
 
-    start_cheat_caller_address(contract_address, OWNER());
     state.update(RECIPIENT(), TOKEN_ID, OWNER());
 
     spy.assert_event_before_update(contract_address, RECIPIENT(), TOKEN_ID, OWNER());
@@ -1416,7 +1415,6 @@ fn test_update_calls_after_update_hook() {
     let mut spy = spy_events();
     let contract_address = test_address();
 
-    start_cheat_caller_address(contract_address, OWNER());
     state.update(RECIPIENT(), TOKEN_ID, OWNER());
 
     spy.assert_event_after_update(contract_address, RECIPIENT(), TOKEN_ID, OWNER())

--- a/packages/token/src/tests/erc721/test_erc721.cairo
+++ b/packages/token/src/tests/erc721/test_erc721.cairo
@@ -5,7 +5,7 @@ use crate::erc721::ERC721Component;
 use crate::erc721;
 use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
 use openzeppelin_test_common::erc721::ERC721SpyHelpers;
-use openzeppelin_test_common::mocks::erc721::{DualCaseERC721Mock, DualCaseERC721MockWithHooks};
+use openzeppelin_test_common::mocks::erc721::{DualCaseERC721Mock, ERC721MockWithHooks};
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::{
     DATA, ZERO, OWNER, CALLER, RECIPIENT, SPENDER, OPERATOR, OTHER, NAME, SYMBOL, TOKEN_ID,
@@ -21,8 +21,7 @@ use starknet::storage::StorageMapReadAccess;
 //
 
 type ComponentState = ERC721Component::ComponentState<DualCaseERC721Mock::ContractState>;
-type ComponentStateWithHooks =
-    ERC721Component::ComponentState<DualCaseERC721MockWithHooks::ContractState>;
+type ComponentStateWithHooks = ERC721Component::ComponentState<ERC721MockWithHooks::ContractState>;
 
 fn CONTRACT_STATE() -> DualCaseERC721Mock::ContractState {
     DualCaseERC721Mock::contract_state_for_testing()
@@ -1465,8 +1464,8 @@ impl ERC721HooksSpyHelpersImpl of ERC721HooksSpyHelpers {
         token_id: u256,
         auth: ContractAddress
     ) {
-        let expected = DualCaseERC721MockWithHooks::Event::BeforeUpdate(
-            DualCaseERC721MockWithHooks::BeforeUpdate { to, token_id, auth }
+        let expected = ERC721MockWithHooks::Event::BeforeUpdate(
+            ERC721MockWithHooks::BeforeUpdate { to, token_id, auth }
         );
         self.assert_emitted_single(contract, expected);
     }
@@ -1478,8 +1477,8 @@ impl ERC721HooksSpyHelpersImpl of ERC721HooksSpyHelpers {
         token_id: u256,
         auth: ContractAddress
     ) {
-        let expected = DualCaseERC721MockWithHooks::Event::AfterUpdate(
-            DualCaseERC721MockWithHooks::AfterUpdate { to, token_id, auth }
+        let expected = ERC721MockWithHooks::Event::AfterUpdate(
+            ERC721MockWithHooks::AfterUpdate { to, token_id, auth }
         );
         self.assert_emitted_single(contract, expected);
     }

--- a/packages/token/src/tests/erc721/test_erc721.cairo
+++ b/packages/token/src/tests/erc721/test_erc721.cairo
@@ -5,7 +5,7 @@ use crate::erc721::ERC721Component;
 use crate::erc721;
 use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
 use openzeppelin_test_common::erc721::ERC721SpyHelpers;
-use openzeppelin_test_common::mocks::erc721::{DualCaseERC721Mock, ERC721MockWithHooks};
+use openzeppelin_test_common::mocks::erc721::{DualCaseERC721Mock, SnakeERC721MockWithHooks};
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::{
     DATA, ZERO, OWNER, CALLER, RECIPIENT, SPENDER, OPERATOR, OTHER, NAME, SYMBOL, TOKEN_ID,
@@ -21,7 +21,8 @@ use starknet::storage::StorageMapReadAccess;
 //
 
 type ComponentState = ERC721Component::ComponentState<DualCaseERC721Mock::ContractState>;
-type ComponentStateWithHooks = ERC721Component::ComponentState<ERC721MockWithHooks::ContractState>;
+type ComponentStateWithHooks =
+    ERC721Component::ComponentState<SnakeERC721MockWithHooks::ContractState>;
 
 fn CONTRACT_STATE() -> DualCaseERC721Mock::ContractState {
     DualCaseERC721Mock::contract_state_for_testing()
@@ -1462,8 +1463,8 @@ impl ERC721HooksSpyHelpersImpl of ERC721HooksSpyHelpers {
         token_id: u256,
         auth: ContractAddress
     ) {
-        let expected = ERC721MockWithHooks::Event::BeforeUpdate(
-            ERC721MockWithHooks::BeforeUpdate { to, token_id, auth }
+        let expected = SnakeERC721MockWithHooks::Event::BeforeUpdate(
+            SnakeERC721MockWithHooks::BeforeUpdate { to, token_id, auth }
         );
         self.assert_emitted_single(contract, expected);
     }
@@ -1475,8 +1476,8 @@ impl ERC721HooksSpyHelpersImpl of ERC721HooksSpyHelpers {
         token_id: u256,
         auth: ContractAddress
     ) {
-        let expected = ERC721MockWithHooks::Event::AfterUpdate(
-            ERC721MockWithHooks::AfterUpdate { to, token_id, auth }
+        let expected = SnakeERC721MockWithHooks::Event::AfterUpdate(
+            SnakeERC721MockWithHooks::AfterUpdate { to, token_id, auth }
         );
         self.assert_emitted_single(contract, expected);
     }


### PR DESCRIPTION
Fixes #1062 

- Checking that the hooks are called is a bit tricky, the best way to do it is emitting an event from a new mock that also lets you validate that they are called with the right parameters.
- I didn't embed camelCase implementations for the new mock since I don't think there's a any reason to support it on the hooks tests.

#### PR Checklist

- [x] Tests
