### PR TITLE
Fix missing -m flag in git commit command Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ As a contributor, you are expected to fork this repository, work on your own for
 
     ```sh
     git add src/file.cairo
-    git commit "Fix some bug short description #123"
+    git commit -m "Fix some bug short description #123"
     git push origin fix/some-bug-short-description-#123
     ```
 


### PR DESCRIPTION
**Description**:

This PR fixes an issue where the `git commit` command in the contributing guide was missing the necessary `-m` flag for the commit message. The original line:

```bash
git commit 'Fix some bug short description #123'
```

is incorrect because it does not include the `-m` flag, which is required to specify the commit message in Git.

The corrected command should be:

```bash
git commit -m "Fix some bug short description #123"
```

**Importance**:

Without the `-m` flag, the command will fail, and users will encounter an error when trying to commit changes. This fix ensures that the instructions are correct and that contributors can follow the guide without encountering problems during their workflow. Providing clear and accurate instructions is crucial for streamlining the contribution process and avoiding unnecessary confusion for new contributors.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
