### PR TITLE
Clean up and small refactors to the access module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ use crate::votes::VotesComponent::VotingUnitsTrait;
 - VestingComponent `release` function won't emit an event or attempt to transfer when the amount is zero (#1209)
 - Bump snforge_std to v0.33.0 (#1203)
 
+### Changed
+
+- The initializer in `OwnableComponent` now checks that `owner` is not the zero address (#1221)
+
 ## 0.19.0 (2024-11-08)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (Breaking)
 
+- The initializer in `OwnableComponent` now checks that `owner` is not the zero address (#1221)
 - Add `verifying_contract` member to the `Delegation` struct used in Votes `delegate_by_sig` (#1214)
 use crate::votes::VotesComponent::VotingUnitsTrait;
 - VotingUnitsTrait moved from `openzeppelin_governance::votes::votes` to `openzeppelin_governance::votes::VotesComponent` (#1214)
 - VestingComponent `release` function won't emit an event or attempt to transfer when the amount is zero (#1209)
 - Bump snforge_std to v0.33.0 (#1203)
-
-### Changed
-
-- The initializer in `OwnableComponent` now checks that `owner` is not the zero address (#1221)
 
 ## 0.19.0 (2024-11-08)
 

--- a/docs/modules/ROOT/pages/api/access.adoc
+++ b/docs/modules/ROOT/pages/api/access.adoc
@@ -156,7 +156,8 @@ Emits an xref:OwnableComponent-OwnershipTransferred[OwnershipTransferred] event.
 [[OwnableComponent-two-step-transfer_ownership]]
 ==== `[.contract-item-name]#++transfer_ownership++#++(ref self: ContractState, new_owner: ContractAddress)++` [.item-kind]#external#
 
-Starts the two step ownership transfer process, by setting the pending owner.
+Starts the two step ownership transfer process, by setting the pending owner. Setting `new_owner` to the zero address is allowed, this can be used to cancel an initiated ownership transfer.
+
 Can only be called by the current owner.
 
 Emits an xref:OwnableComponent-OwnershipTransferStarted[OwnershipTransferStarted] event.
@@ -209,7 +210,7 @@ See xref:OwnableComponent-two-step-renounce_ownership[renounce_ownership].
 [[OwnableComponent-initializer]]
 ==== `[.contract-item-name]#++initializer++#++(ref self: ContractState, owner: ContractAddress)++` [.item-kind]#internal#
 
-Initializes the contract and sets `owner` as the initial owner.
+Initializes the contract and sets `owner` as the initial owner. `owner` cannot be the zero address.
 
 Emits an xref:OwnableComponent-OwnershipTransferred[OwnershipTransferred] event.
 

--- a/docs/modules/ROOT/pages/api/access.adoc
+++ b/docs/modules/ROOT/pages/api/access.adoc
@@ -210,7 +210,11 @@ See xref:OwnableComponent-two-step-renounce_ownership[renounce_ownership].
 [[OwnableComponent-initializer]]
 ==== `[.contract-item-name]#++initializer++#++(ref self: ContractState, owner: ContractAddress)++` [.item-kind]#internal#
 
-Initializes the contract and sets `owner` as the initial owner. `owner` cannot be the zero address.
+Initializes the contract and sets `owner` as the initial owner.
+
+Requirements:
+
+- `owner` cannot be the zero address.
 
 Emits an xref:OwnableComponent-OwnershipTransferred[OwnershipTransferred] event.
 

--- a/packages/access/src/accesscontrol/accesscontrol.cairo
+++ b/packages/access/src/accesscontrol/accesscontrol.cairo
@@ -3,7 +3,7 @@
 
 /// # AccessControl Component
 ///
-/// Contract component that enables role-based access control mechanisms. This is a lightweight
+/// The AccessControl component enables role-based access control mechanisms. This is a lightweight
 /// implementation that doesn't support on-chain enumeration of role members, though role membership
 /// can be tracked off-chain through contract events.
 ///

--- a/packages/access/src/accesscontrol/accesscontrol.cairo
+++ b/packages/access/src/accesscontrol/accesscontrol.cairo
@@ -43,7 +43,7 @@ pub mod AccessControlComponent {
     /// Emitted when `account` is granted `role`.
     ///
     /// `sender` is the account that originated the contract call, an account with the admin role
-    /// or the zero address if `grant_role` is called from the constructor.
+    /// or the deployer address if `grant_role` is called from the constructor.
     #[derive(Drop, PartialEq, starknet::Event)]
     pub struct RoleGranted {
         pub role: felt252,

--- a/packages/access/src/accesscontrol/accesscontrol.cairo
+++ b/packages/access/src/accesscontrol/accesscontrol.cairo
@@ -66,7 +66,7 @@ pub mod AccessControlComponent {
     /// Emitted when `new_admin_role` is set as `role`'s admin role, replacing `previous_admin_role`
     ///
     /// `DEFAULT_ADMIN_ROLE` is the starting admin for all roles, despite
-    /// {RoleAdminChanged} not being emitted signaling this.
+    /// `RoleAdminChanged` not being emitted signaling this.
     #[derive(Drop, PartialEq, starknet::Event)]
     pub struct RoleAdminChanged {
         pub role: felt252,

--- a/packages/access/src/accesscontrol/accesscontrol.cairo
+++ b/packages/access/src/accesscontrol/accesscontrol.cairo
@@ -3,8 +3,19 @@
 
 /// # AccessControl Component
 ///
-/// The AccessControl component allows contracts to implement role-based access control mechanisms.
-/// Roles are referred to by their `felt252` identifier.
+/// Contract component that enables role-based access control mechanisms. This is a lightweight
+/// implementation that doesn't support on-chain enumeration of role members, though role membership
+/// can be tracked off-chain through contract events.
+///
+/// Roles can be granted and revoked dynamically via `grant_role` and `revoke_role`. Each role
+/// has an associated admin role that controls who can grant and revoke it. By default, all roles
+/// use `DEFAULT_ADMIN_ROLE` as their admin role.
+/// Accounts can also renounce roles they have been granted by using `renounce_role`.
+///
+/// More complex role hierarchies can be created using `set_role_admin`.
+///
+/// WARNING: The `DEFAULT_ADMIN_ROLE` is its own admin, meaning it can grant and revoke itself.
+/// Extra precautions should be taken to secure accounts with this role.
 #[starknet::component]
 pub mod AccessControlComponent {
     use crate::accesscontrol::interface;
@@ -31,8 +42,8 @@ pub mod AccessControlComponent {
 
     /// Emitted when `account` is granted `role`.
     ///
-    /// `sender` is the account that originated the contract call, an admin role
-    /// bearer (except if `_grant_role` is called during initialization from the constructor).
+    /// `sender` is the account that originated the contract call, an account with the admin role
+    /// or the zero address if `grant_role` is called from the constructor.
     #[derive(Drop, PartialEq, starknet::Event)]
     pub struct RoleGranted {
         pub role: felt252,
@@ -40,7 +51,7 @@ pub mod AccessControlComponent {
         pub sender: ContractAddress
     }
 
-    /// Emitted when `account` is revoked `role`.
+    /// Emitted when `role` is revoked for `account`.
     ///
     /// `sender` is the account that originated the contract call:
     ///   - If using `revoke_role`, it is the admin role bearer.
@@ -89,7 +100,7 @@ pub mod AccessControlComponent {
 
         /// Grants `role` to `account`.
         ///
-        /// If `account` had not been already granted `role`, emits a `RoleGranted` event.
+        /// If `account` has not been already granted `role`, emits a `RoleGranted` event.
         ///
         /// Requirements:
         ///
@@ -104,7 +115,7 @@ pub mod AccessControlComponent {
 
         /// Revokes `role` from `account`.
         ///
-        /// If `account` had been granted `role`, emits a `RoleRevoked` event.
+        /// If `account` has been granted `role`, emits a `RoleRevoked` event.
         ///
         /// Requirements:
         ///
@@ -132,7 +143,7 @@ pub mod AccessControlComponent {
         fn renounce_role(
             ref self: ComponentState<TContractState>, role: felt252, account: ContractAddress
         ) {
-            let caller: ContractAddress = get_caller_address();
+            let caller = get_caller_address();
             assert(caller == account, Errors::INVALID_CALLER);
             self._revoke_role(role, account);
         }

--- a/packages/access/src/ownable/ownable.cairo
+++ b/packages/access/src/ownable/ownable.cairo
@@ -50,8 +50,7 @@ pub mod OwnableComponent {
 
     /// Emitted when `transfer_ownership` is called on a contract that implements `IOwnableTwoStep`.
     /// `previous_owner` is the address of the current owner.
-    /// `new_owner` is the address of the new owner. It will be the zero address if the ownership
-    /// is being renounced.
+    /// `new_owner` is the address of the pending owner.
     #[derive(Drop, PartialEq, starknet::Event)]
     pub struct OwnershipTransferStarted {
         #[key]

--- a/packages/access/src/ownable/ownable.cairo
+++ b/packages/access/src/ownable/ownable.cairo
@@ -133,7 +133,7 @@ pub mod OwnableComponent {
 
         /// Starts the two-step ownership transfer process by setting the pending owner.
         ///
-        /// Setting `newOwner` to the zero address is allowed; this can be used to cancel an
+        /// Setting `new_owner` to the zero address is allowed; this can be used to cancel an
         /// initiated ownership transfer.
         /// Requirements:
         ///

--- a/packages/access/src/ownable/ownable.cairo
+++ b/packages/access/src/ownable/ownable.cairo
@@ -36,10 +36,7 @@ pub mod OwnableComponent {
     }
 
     /// Emitted when `new_owner` is set as owner of the contract.
-    /// `previous_owner` is the address of the previous owner. It will be the zero address if
-    /// the ownership is transferred from the constructor.
-    /// `new_owner` is the address of the new owner. It will be the zero address if the ownership
-    /// is renounced.
+    /// `new_owner` can be set to zero only if the ownership is renounced.
     #[derive(Drop, PartialEq, starknet::Event)]
     pub struct OwnershipTransferred {
         #[key]

--- a/packages/access/src/ownable/ownable.cairo
+++ b/packages/access/src/ownable/ownable.cairo
@@ -136,6 +136,8 @@ pub mod OwnableComponent {
 
         /// Starts the two-step ownership transfer process by setting the pending owner.
         ///
+        /// Setting `newOwner` to the zero address is allowed; this can be used to cancel an
+        /// initiated ownership transfer.
         /// Requirements:
         ///
         /// - The caller is the contract owner.
@@ -278,8 +280,13 @@ pub mod OwnableComponent {
     > of InternalTrait<TContractState> {
         /// Sets the contract's initial owner.
         ///
+        /// Requirements:
+        ///
+        /// - `owner` is not the zero address.
+        ///
         /// This function should be called at construction time.
         fn initializer(ref self: ComponentState<TContractState>, owner: ContractAddress) {
+            assert(!owner.is_zero(), Errors::ZERO_ADDRESS_OWNER);
             self._transfer_ownership(owner);
         }
 

--- a/packages/access/src/ownable/ownable.cairo
+++ b/packages/access/src/ownable/ownable.cairo
@@ -63,7 +63,6 @@ pub mod OwnableComponent {
     pub mod Errors {
         pub const NOT_OWNER: felt252 = 'Caller is not the owner';
         pub const NOT_PENDING_OWNER: felt252 = 'Caller is not the pending owner';
-        pub const ZERO_ADDRESS_CALLER: felt252 = 'Caller is the zero address';
         pub const ZERO_ADDRESS_OWNER: felt252 = 'New owner is the zero address';
     }
 

--- a/packages/access/src/tests/test_accesscontrol.cairo
+++ b/packages/access/src/tests/test_accesscontrol.cairo
@@ -81,7 +81,7 @@ fn test_assert_only_role() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is missing role',))]
+#[should_panic(expected: 'Caller is missing role')]
 fn test_assert_only_role_unauthorized() {
     let state = setup();
     start_cheat_caller_address(test_address(), OTHER());
@@ -89,7 +89,7 @@ fn test_assert_only_role_unauthorized() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is missing role',))]
+#[should_panic(expected: 'Caller is missing role')]
 fn test_assert_only_role_unauthorized_when_authorized_for_another_role() {
     let mut state = setup();
     state.grant_role(ROLE, AUTHORIZED());
@@ -151,7 +151,7 @@ fn test_grantRole_multiple_times_for_granted_role() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is missing role',))]
+#[should_panic(expected: 'Caller is missing role')]
 fn test_grant_role_unauthorized() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), AUTHORIZED());
@@ -159,7 +159,7 @@ fn test_grant_role_unauthorized() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is missing role',))]
+#[should_panic(expected: 'Caller is missing role')]
 fn test_grantRole_unauthorized() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), AUTHORIZED());
@@ -245,7 +245,7 @@ fn test_revokeRole_multiple_times_for_granted_role() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is missing role',))]
+#[should_panic(expected: 'Caller is missing role')]
 fn test_revoke_role_unauthorized() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), OTHER());
@@ -253,7 +253,7 @@ fn test_revoke_role_unauthorized() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is missing role',))]
+#[should_panic(expected: 'Caller is missing role')]
 fn test_revokeRole_unauthorized() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), OTHER());
@@ -345,7 +345,7 @@ fn test_renounceRole_multiple_times_for_granted_role() {
 }
 
 #[test]
-#[should_panic(expected: ('Can only renounce role for self',))]
+#[should_panic(expected: 'Can only renounce role for self')]
 fn test_renounce_role_unauthorized() {
     let mut state = setup();
     let contract_address = test_address();
@@ -357,7 +357,7 @@ fn test_renounce_role_unauthorized() {
 }
 
 #[test]
-#[should_panic(expected: ('Can only renounce role for self',))]
+#[should_panic(expected: 'Can only renounce role for self')]
 fn test_renounceRole_unauthorized() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), ADMIN());
@@ -423,7 +423,7 @@ fn test_new_admin_can_revoke_roles() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is missing role',))]
+#[should_panic(expected: 'Caller is missing role')]
 fn test_previous_admin_cannot_grant_roles() {
     let mut state = setup();
     state.set_role_admin(ROLE, OTHER_ROLE);
@@ -432,7 +432,7 @@ fn test_previous_admin_cannot_grant_roles() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is missing role',))]
+#[should_panic(expected: 'Caller is missing role')]
 fn test_previous_admin_cannot_revoke_roles() {
     let mut state = setup();
     state.set_role_admin(ROLE, OTHER_ROLE);

--- a/packages/access/src/tests/test_ownable.cairo
+++ b/packages/access/src/tests/test_ownable.cairo
@@ -45,7 +45,7 @@ fn test_initializer_owner() {
 }
 
 #[test]
-#[should_panic(expected: ('New owner is the zero address',))]
+#[should_panic(expected: 'New owner is the zero address')]
 fn test_initializer_zero_owner() {
     let mut state = COMPONENT_STATE();
     state.initializer(ZERO());
@@ -63,7 +63,7 @@ fn test_assert_only_owner() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner',))]
+#[should_panic(expected: 'Caller is not the owner')]
 fn test_assert_only_owner_when_not_owner() {
     let state = setup();
     start_cheat_caller_address(test_address(), OTHER());
@@ -117,7 +117,7 @@ fn test_transfer_ownership() {
 }
 
 #[test]
-#[should_panic(expected: ('New owner is the zero address',))]
+#[should_panic(expected: 'New owner is the zero address')]
 fn test_transfer_ownership_to_zero() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), OWNER());
@@ -125,7 +125,7 @@ fn test_transfer_ownership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner',))]
+#[should_panic(expected: 'Caller is not the owner')]
 fn test_transfer_ownership_from_nonowner() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), OTHER());
@@ -145,7 +145,7 @@ fn test_transferOwnership() {
 }
 
 #[test]
-#[should_panic(expected: ('New owner is the zero address',))]
+#[should_panic(expected: 'New owner is the zero address')]
 fn test_transferOwnership_to_zero() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), OWNER());
@@ -153,7 +153,7 @@ fn test_transferOwnership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner',))]
+#[should_panic(expected: 'Caller is not the owner')]
 fn test_transferOwnership_from_nonowner() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), OTHER());
@@ -177,7 +177,7 @@ fn test_renounce_ownership() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner',))]
+#[should_panic(expected: 'Caller is not the owner')]
 fn test_renounce_ownership_from_nonowner() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), OTHER());
@@ -197,7 +197,7 @@ fn test_renounceOwnership() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner',))]
+#[should_panic(expected: 'Caller is not the owner')]
 fn test_renounceOwnership_from_nonowner() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), OTHER());

--- a/packages/access/src/tests/test_ownable.cairo
+++ b/packages/access/src/tests/test_ownable.cairo
@@ -63,13 +63,6 @@ fn test_assert_only_owner_when_not_owner() {
     state.assert_only_owner();
 }
 
-#[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_assert_only_owner_when_caller_zero() {
-    let state = setup();
-    state.assert_only_owner();
-}
-
 //
 // _transfer_ownership
 //
@@ -125,13 +118,6 @@ fn test_transfer_ownership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_transfer_ownership_from_zero() {
-    let mut state = setup();
-    state.transfer_ownership(OTHER());
-}
-
-#[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_transfer_ownership_from_nonowner() {
     let mut state = setup();
@@ -160,13 +146,6 @@ fn test_transferOwnership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_transferOwnership_from_zero() {
-    let mut state = setup();
-    state.transferOwnership(OTHER());
-}
-
-#[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_transferOwnership_from_nonowner() {
     let mut state = setup();
@@ -191,13 +170,6 @@ fn test_renounce_ownership() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_renounce_ownership_from_zero_address() {
-    let mut state = setup();
-    state.renounce_ownership();
-}
-
-#[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_renounce_ownership_from_nonowner() {
     let mut state = setup();
@@ -215,13 +187,6 @@ fn test_renounceOwnership() {
 
     spy.assert_only_event_ownership_transferred(contract_address, OWNER(), ZERO());
     assert!(state.owner().is_zero());
-}
-
-#[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_renounceOwnership_from_zero_address() {
-    let mut state = setup();
-    state.renounceOwnership();
 }
 
 #[test]

--- a/packages/access/src/tests/test_ownable.cairo
+++ b/packages/access/src/tests/test_ownable.cairo
@@ -44,6 +44,13 @@ fn test_initializer_owner() {
     assert_eq!(new_owner, OWNER());
 }
 
+#[test]
+#[should_panic(expected: ('New owner is the zero address',))]
+fn test_initializer_zero_owner() {
+    let mut state = COMPONENT_STATE();
+    state.initializer(ZERO());
+}
+
 //
 // assert_only_owner
 //

--- a/packages/access/src/tests/test_ownable_twostep.cairo
+++ b/packages/access/src/tests/test_ownable_twostep.cairo
@@ -97,13 +97,6 @@ fn test_transfer_ownership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_transfer_ownership_from_zero() {
-    let mut state = setup();
-    state.transfer_ownership(OTHER());
-}
-
-#[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_transfer_ownership_from_nonowner() {
     let mut state = setup();
@@ -142,13 +135,6 @@ fn test_transferOwnership_to_zero() {
     spy.assert_event_ownership_transfer_started(contract_address, OWNER(), ZERO());
     assert_eq!(state.owner(), OWNER());
     assert!(state.pendingOwner().is_zero());
-}
-
-#[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_transferOwnership_from_zero() {
-    let mut state = setup();
-    state.transferOwnership(OTHER());
 }
 
 #[test]
@@ -245,13 +231,6 @@ fn test_renounce_ownership_resets_pending_owner() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_renounce_ownership_from_zero_address() {
-    let mut state = setup();
-    state.renounce_ownership();
-}
-
-#[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_renounce_ownership_from_nonowner() {
     let mut state = setup();
@@ -270,13 +249,6 @@ fn test_renounceOwnership() {
     spy.assert_only_event_ownership_transferred(contract_address, OWNER(), ZERO());
 
     assert!(state.owner().is_zero());
-}
-
-#[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_renounceOwnership_from_zero_address() {
-    let mut state = setup();
-    state.renounceOwnership();
 }
 
 #[test]

--- a/packages/access/src/tests/test_ownable_twostep.cairo
+++ b/packages/access/src/tests/test_ownable_twostep.cairo
@@ -97,7 +97,7 @@ fn test_transfer_ownership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner',))]
+#[should_panic(expected: 'Caller is not the owner')]
 fn test_transfer_ownership_from_nonowner() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), OTHER());
@@ -138,7 +138,7 @@ fn test_transferOwnership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner',))]
+#[should_panic(expected: 'Caller is not the owner')]
 fn test_transferOwnership_from_nonowner() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), OTHER());
@@ -165,7 +165,7 @@ fn test_accept_ownership() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the pending owner',))]
+#[should_panic(expected: 'Caller is not the pending owner')]
 fn test_accept_ownership_from_nonpending() {
     let mut state = setup();
     state.Ownable_pending_owner.write(NEW_OWNER());
@@ -189,7 +189,7 @@ fn test_acceptOwnership() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the pending owner',))]
+#[should_panic(expected: 'Caller is not the pending owner')]
 fn test_acceptOwnership_from_nonpending() {
     let mut state = setup();
     state.Ownable_pending_owner.write(NEW_OWNER());
@@ -231,7 +231,7 @@ fn test_renounce_ownership_resets_pending_owner() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner',))]
+#[should_panic(expected: 'Caller is not the owner')]
 fn test_renounce_ownership_from_nonowner() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), OTHER());
@@ -252,7 +252,7 @@ fn test_renounceOwnership() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner',))]
+#[should_panic(expected: 'Caller is not the owner')]
 fn test_renounceOwnership_from_nonowner() {
     let mut state = setup();
     start_cheat_caller_address(test_address(), OTHER());

--- a/packages/presets/src/tests/test_erc1155.cairo
+++ b/packages/presets/src/tests/test_erc1155.cairo
@@ -657,14 +657,6 @@ fn test_transfer_ownership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_transfer_ownership_from_zero() {
-    let (_, dispatcher, _) = setup_dispatcher();
-    start_cheat_caller_address(dispatcher.contract_address, ZERO());
-    dispatcher.transfer_ownership(OTHER());
-}
-
-#[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_transfer_ownership_from_nonowner() {
     let (_, dispatcher, _) = setup_dispatcher();
@@ -691,14 +683,6 @@ fn test_transferOwnership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_transferOwnership_from_zero() {
-    let (_, dispatcher, _) = setup_dispatcher();
-    start_cheat_caller_address(dispatcher.contract_address, ZERO());
-    dispatcher.transferOwnership(OTHER());
-}
-
-#[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_transferOwnership_from_nonowner() {
     let (_, dispatcher, _) = setup_dispatcher();
@@ -721,14 +705,6 @@ fn test_renounce_ownership() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_renounce_ownership_from_zero_address() {
-    let (_, dispatcher, _) = setup_dispatcher();
-    start_cheat_caller_address(dispatcher.contract_address, ZERO());
-    dispatcher.renounce_ownership();
-}
-
-#[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_renounce_ownership_from_nonowner() {
     let (_, dispatcher, _) = setup_dispatcher();
@@ -744,14 +720,6 @@ fn test_renounceOwnership() {
 
     spy.assert_event_ownership_transferred(dispatcher.contract_address, owner, ZERO());
     assert!(dispatcher.owner().is_zero());
-}
-
-#[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_renounceOwnership_from_zero_address() {
-    let (_, dispatcher, _) = setup_dispatcher();
-    start_cheat_caller_address(dispatcher.contract_address, ZERO());
-    dispatcher.renounceOwnership();
 }
 
 #[test]

--- a/packages/presets/src/tests/test_erc20.cairo
+++ b/packages/presets/src/tests/test_erc20.cairo
@@ -329,14 +329,6 @@ fn test_transfer_ownership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_transfer_ownership_from_zero() {
-    let (_, mut dispatcher) = setup_dispatcher();
-    start_cheat_caller_address(dispatcher.contract_address, ZERO());
-    dispatcher.transfer_ownership(OTHER());
-}
-
-#[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_transfer_ownership_from_nonowner() {
     let (_, mut dispatcher) = setup_dispatcher();
@@ -363,14 +355,6 @@ fn test_transferOwnership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_transferOwnership_from_zero() {
-    let (_, mut dispatcher) = setup_dispatcher();
-    start_cheat_caller_address(dispatcher.contract_address, ZERO());
-    dispatcher.transferOwnership(OTHER());
-}
-
-#[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_transferOwnership_from_nonowner() {
     let (_, mut dispatcher) = setup_dispatcher();
@@ -393,14 +377,6 @@ fn test_renounce_ownership() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_renounce_ownership_from_zero_address() {
-    let (_, mut dispatcher) = setup_dispatcher();
-    start_cheat_caller_address(dispatcher.contract_address, ZERO());
-    dispatcher.renounce_ownership();
-}
-
-#[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_renounce_ownership_from_nonowner() {
     let (_, mut dispatcher) = setup_dispatcher();
@@ -416,14 +392,6 @@ fn test_renounceOwnership() {
 
     spy.assert_event_ownership_transferred(dispatcher.contract_address, OWNER(), ZERO());
     assert!(dispatcher.owner().is_zero());
-}
-
-#[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_renounceOwnership_from_zero_address() {
-    let (_, mut dispatcher) = setup_dispatcher();
-    start_cheat_caller_address(dispatcher.contract_address, ZERO());
-    dispatcher.renounceOwnership();
 }
 
 #[test]

--- a/packages/presets/src/tests/test_erc721.cairo
+++ b/packages/presets/src/tests/test_erc721.cairo
@@ -757,14 +757,6 @@ fn test_transfer_ownership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_transfer_ownership_from_zero() {
-    let (_, mut dispatcher) = setup_dispatcher();
-    start_cheat_caller_address(dispatcher.contract_address, ZERO());
-    dispatcher.transfer_ownership(OTHER());
-}
-
-#[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_transfer_ownership_from_nonowner() {
     let (_, mut dispatcher) = setup_dispatcher();
@@ -791,14 +783,6 @@ fn test_transferOwnership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_transferOwnership_from_zero() {
-    let (_, mut dispatcher) = setup_dispatcher();
-    start_cheat_caller_address(dispatcher.contract_address, ZERO());
-    dispatcher.transferOwnership(OTHER());
-}
-
-#[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_transferOwnership_from_nonowner() {
     let (_, mut dispatcher) = setup_dispatcher();
@@ -821,14 +805,6 @@ fn test_renounce_ownership() {
 }
 
 #[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_renounce_ownership_from_zero_address() {
-    let (_, mut dispatcher) = setup_dispatcher();
-    start_cheat_caller_address(dispatcher.contract_address, ZERO());
-    dispatcher.renounce_ownership();
-}
-
-#[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_renounce_ownership_from_nonowner() {
     let (_, mut dispatcher) = setup_dispatcher();
@@ -844,14 +820,6 @@ fn test_renounceOwnership() {
 
     spy.assert_event_ownership_transferred(dispatcher.contract_address, OWNER(), ZERO());
     assert!(dispatcher.owner().is_zero());
-}
-
-#[test]
-#[should_panic(expected: ('Caller is the zero address',))]
-fn test_renounceOwnership_from_zero_address() {
-    let (_, mut dispatcher) = setup_dispatcher();
-    start_cheat_caller_address(dispatcher.contract_address, ZERO());
-    dispatcher.renounceOwnership();
 }
 
 #[test]

--- a/packages/presets/src/tests/test_vesting.cairo
+++ b/packages/presets/src/tests/test_vesting.cairo
@@ -247,14 +247,6 @@ fn test_transfer_ownership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: 'Caller is the zero address')]
-fn test_transfer_ownership_from_zero() {
-    let (vesting, _) = setup(TEST_DATA());
-    start_cheat_caller_address(vesting.contract_address, ZERO());
-    vesting.transfer_ownership(OTHER());
-}
-
-#[test]
 #[should_panic(expected: 'Caller is not the owner')]
 fn test_transfer_ownership_from_nonowner() {
     let (vesting, _) = setup(TEST_DATA());
@@ -282,14 +274,6 @@ fn test_transferOwnership_to_zero() {
 }
 
 #[test]
-#[should_panic(expected: 'Caller is the zero address')]
-fn test_transferOwnership_from_zero() {
-    let (vesting, _) = setup(TEST_DATA());
-    start_cheat_caller_address(vesting.contract_address, ZERO());
-    vesting.transferOwnership(OTHER());
-}
-
-#[test]
 #[should_panic(expected: 'Caller is not the owner')]
 fn test_transferOwnership_from_nonowner() {
     let (vesting, _) = setup(TEST_DATA());
@@ -313,14 +297,6 @@ fn test_renounce_ownership() {
 }
 
 #[test]
-#[should_panic(expected: 'Caller is the zero address')]
-fn test_renounce_ownership_from_zero_address() {
-    let (vesting, _) = setup(TEST_DATA());
-    start_cheat_caller_address(vesting.contract_address, ZERO());
-    vesting.renounce_ownership();
-}
-
-#[test]
 #[should_panic(expected: 'Caller is not the owner')]
 fn test_renounce_ownership_from_nonowner() {
     let (vesting, _) = setup(TEST_DATA());
@@ -337,14 +313,6 @@ fn test_renounceOwnership() {
 
     spy.assert_event_ownership_transferred(vesting.contract_address, OWNER(), ZERO());
     assert!(vesting.owner().is_zero());
-}
-
-#[test]
-#[should_panic(expected: 'Caller is the zero address')]
-fn test_renounceOwnership_from_zero_address() {
-    let (vesting, _) = setup(TEST_DATA());
-    start_cheat_caller_address(vesting.contract_address, ZERO());
-    vesting.renounceOwnership();
 }
 
 #[test]

--- a/packages/security/src/initializable.cairo
+++ b/packages/security/src/initializable.cairo
@@ -24,7 +24,7 @@ pub mod InitializableComponent {
     impl Initializable<
         TContractState, +HasComponent<TContractState>
     > of IInitializable<ComponentState<TContractState>> {
-        /// Returns true if the using contract executed `initialize`.
+        /// Returns whether the contract has been initialized.
         fn is_initialized(self: @ComponentState<TContractState>) -> bool {
             self.Initializable_initialized.read()
         }

--- a/packages/security/src/tests/test_initializable.cairo
+++ b/packages/security/src/tests/test_initializable.cairo
@@ -17,7 +17,7 @@ fn test_initialize() {
 }
 
 #[test]
-#[should_panic(expected: ('Initializable: is initialized',))]
+#[should_panic(expected: 'Initializable: is initialized')]
 fn test_initialize_when_initialized() {
     let mut state = COMPONENT_STATE();
     state.initialize();

--- a/packages/security/src/tests/test_pausable.cairo
+++ b/packages/security/src/tests/test_pausable.cairo
@@ -42,7 +42,7 @@ fn test_assert_paused_when_paused() {
 }
 
 #[test]
-#[should_panic(expected: ('Pausable: not paused',))]
+#[should_panic(expected: 'Pausable: not paused')]
 fn test_assert_paused_when_not_paused() {
     let state = COMPONENT_STATE();
     state.assert_paused();
@@ -53,7 +53,7 @@ fn test_assert_paused_when_not_paused() {
 //
 
 #[test]
-#[should_panic(expected: ('Pausable: paused',))]
+#[should_panic(expected: 'Pausable: paused')]
 fn test_assert_not_paused_when_paused() {
     let mut state = COMPONENT_STATE();
     state.pause();
@@ -84,7 +84,7 @@ fn test_pause_when_unpaused() {
 }
 
 #[test]
-#[should_panic(expected: ('Pausable: paused',))]
+#[should_panic(expected: 'Pausable: paused')]
 fn test_pause_when_paused() {
     let mut state = COMPONENT_STATE();
     state.pause();
@@ -111,7 +111,7 @@ fn test_unpause_when_paused() {
 }
 
 #[test]
-#[should_panic(expected: ('Pausable: not paused',))]
+#[should_panic(expected: 'Pausable: not paused')]
 fn test_unpause_when_unpaused() {
     let mut state = COMPONENT_STATE();
     assert!(!state.is_paused());

--- a/packages/security/src/tests/test_reentrancyguard.cairo
+++ b/packages/security/src/tests/test_reentrancyguard.cairo
@@ -36,7 +36,7 @@ fn test_reentrancy_guard_start() {
 }
 
 #[test]
-#[should_panic(expected: ('ReentrancyGuard: reentrant call',))]
+#[should_panic(expected: 'ReentrancyGuard: reentrant call')]
 fn test_reentrancy_guard_start_when_started() {
     let mut state = COMPONENT_STATE();
 
@@ -64,7 +64,7 @@ fn test_reentrancy_guard_end() {
 //
 
 #[test]
-#[should_panic(expected: ('ReentrancyGuard: reentrant call',))]
+#[should_panic(expected: 'ReentrancyGuard: reentrant call')]
 fn test_remote_callback() {
     let contract = deploy_mock();
 
@@ -76,14 +76,14 @@ fn test_remote_callback() {
 }
 
 #[test]
-#[should_panic(expected: ('ReentrancyGuard: reentrant call',))]
+#[should_panic(expected: 'ReentrancyGuard: reentrant call')]
 fn test_local_recursion() {
     let contract = deploy_mock();
     contract.count_local_recursive(10);
 }
 
 #[test]
-#[should_panic(expected: ('ReentrancyGuard: reentrant call',))]
+#[should_panic(expected: 'ReentrancyGuard: reentrant call')]
 fn test_external_recursion() {
     let contract = deploy_mock();
     contract.count_external_recursive(10);


### PR DESCRIPTION
- Add comments where missing
- Small refactors
- Remove a check in Ownable that verifies that sender is the zero address
- Add a check to Ownable initializer that the owner is not being set to the zero address

- [x] Tests
- [x] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
