### PR TITLE
Update erc1155.adoc

### DIFF
--- a/docs/modules/ROOT/pages/erc1155.adoc
+++ b/docs/modules/ROOT/pages/erc1155.adoc
@@ -3,7 +3,7 @@
 
 = ERC1155
 
-The ERC1155 multi token standard is a specification for {fungibility-agnostic} token contracts.
+The ERC1155 multi-token standard is a specification for {fungibility-agnostic} token contracts.
 The ERC1155 library implements an approximation of {eip-1155} in Cairo for StarkNet.
 
 == Multi Token Standard
@@ -181,7 +181,7 @@ tokens, this yields execution to the receiver which can result in a xref:securit
 :on_erc1155_batch_received: xref:/api/erc1155.adoc#IERC1155Receiver-on_erc1155_batch_received[on_erc1155_batch_received]
 :computing-interface-id: xref:introspection.adoc#computing_the_interface_id[Computing the interface ID]
 
-In order to be sure a non-account contract can safely accept ERC1155 tokens, said contract must implement the `IERC1155Receiver` interface.
+In order to be sure a non-account contract can safely accept ERC1155 tokens, the contract must implement the `IERC1155Receiver` interface.
 The recipient contract must also implement the {src5} interface which supports interface introspection.
 
 === IERC1155Receiver


### PR DESCRIPTION
Description:
This PR includes minor but important fixes to the ERC1155 documentation to improve consistency and professionalism:

1. Changed "multi token standard" to "multi-token standard" to follow proper hyphenation rules for compound modifiers
2. Replaced outdated formal "said contract" with "the contract" in the "Receiving tokens" section for better readability

Files changed:
- docs/modules/ROOT/pages/erc1155.adoc

The changes maintain technical accuracy while improving the documentation's clarity and consistency with modern technical writing standards.
