### PR TITLE
Refactor remove_prefix_from_names function for improved readability

### DIFF
--- a/scripts/get_hashes_page.py
+++ b/scripts/get_hashes_page.py
@@ -48,7 +48,7 @@ https://crates.io/crates/cairo-lang-compiler/{cmp_version}[cairo {cmp_version}]
 
 def remove_prefix_from_names(contracts):
     for contract in contracts:
-        contract.update([("name", remove_prefix(contract['name'], 'openzeppelin_presets_'))])
+        contract['name'] = remove_prefix(contract['name'], 'openzeppelin_presets_')
     return contracts
 
 


### PR DESCRIPTION
### Description:

This PR refactors the `remove_prefix_from_names` function to improve code readability. Specifically, it replaces the usage of `update` with direct dictionary key assignment. 

#### Original code:
```python
def remove_prefix_from_names(contracts):
    for contract in contracts:
        contract.update([("name", remove_prefix(contract['name'], 'openzeppelin_presets_'))])
    return contracts
```

#### Refactored code:
```python
def remove_prefix_from_names(contracts):
    for contract in contracts:
        contract['name'] = remove_prefix(contract['name'], 'openzeppelin_presets_')
    return contracts
```

### Reason for the change:
- The use of direct assignment (`contract['name'] = ...`) is more intuitive and widely understood in Python. It simplifies the code and makes it clearer, especially for developers who might be unfamiliar with the `update` method.
- This is a minor improvement in terms of code style, but it contributes to better readability and maintainability.

Let me know if there are any questions or additional changes needed.