### PR TITLE
Update Markdown Syntax for URL in Header

### DIFF
--- a/scripts/get_hashes_page.py
+++ b/scripts/get_hashes_page.py
@@ -22,8 +22,7 @@ def main():
 
 def generate_doc_file(cmp_version, contracts):
     header = f"""// Version
-:class-hash-cairo-version: \
-https://crates.io/crates/cairo-lang-compiler/{cmp_version}[cairo {cmp_version}]
+:class-hash-cairo-version: https://crates.io/crates/cairo-lang-compiler/{cmp_version} [cairo {cmp_version}]
 """
     hashes = "// Class Hashes\n"
     contracts['contracts'] = remove_prefix_from_names(contracts['contracts'])


### PR DESCRIPTION
#### Problem  
The URL in the header for the class hash documentation is incorrectly formatted. The current syntax:  

```python
:class-hash-cairo-version: \
https://crates.io/crates/cairo-lang-compiler/{cmp_version}[cairo {cmp_version}]
```  

is not valid Markdown for embedding a link.  

#### Solution  
The link syntax has been updated to properly follow Markdown standards:  

```python
:class-hash-cairo-version: https://crates.io/crates/cairo-lang-compiler/{cmp_version} [cairo {cmp_version}]
```  

#### Importance  
- **Clarity**: Correctly formatted links ensure that users can click and access the intended documentation without confusion.  
- **Professionalism**: Proper formatting enhances the readability and usability of generated documentation.  
- **Functionality**: A malformed link can break automated tools that parse or render the documentation.  

This small change significantly improves the quality of the generated documentation and aligns it with standard practices.

#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
