### PR TITLE
Fix typos in `README.md` and `CHANGELOG.md` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,7 +337,7 @@ with new external functions (#1173)
 
 ### Removed
 
-- Non standard increase_allowance and decrease_allowance functions in ERC20 contract (#881)
+- Non-standard increase_allowance and decrease_allowance functions in ERC20 contract (#881)
 
 ## 0.8.1 (2024-01-23)
 

--- a/packages/access/README.md
+++ b/packages/access/README.md
@@ -5,7 +5,7 @@
 This crate provides ways to restrict who can access the functions of a contract or when they can do it.
 
 - `Ownable` is a simple mechanism with a single "owner" role that can be assigned to a single contract (usually an
-account). This mechanism can be useful in simple scenarios, but fine grained access needs are likely to outgrow it.
+account). This mechanism can be useful in simple scenarios, but fine-grained access needs are likely to outgrow it.
 
 - `AccessControl` provides a general role based access control mechanism. Multiple hierarchical roles can be created
 and assigned each to multiple accounts.


### PR DESCRIPTION
This pull request addresses minor typos in the `README.md` and `CHANGELOG.md` files. It corrects the usage of the term "Non standard" to "Non-standard" and "fine grained" to "fine-grained" to maintain consistency and improve clarity. These changes ensure proper formatting according to standard grammar rules.

#### PR Checklist:
- [ ] Tests
- [ ] Documentation
- [ ] Added entry to CHANGELOG.md
- [ ] Tried the feature on a public network
