### PR TITLE
Add optional delay to AccessControl role grants

### DIFF
--- a/packages/access/src/accesscontrol.cairo
+++ b/packages/access/src/accesscontrol.cairo
@@ -1,6 +1,6 @@
 pub mod accesscontrol;
+pub mod account_role_info;
 pub mod interface;
 
 pub use accesscontrol::AccessControlComponent;
-
-pub const DEFAULT_ADMIN_ROLE: felt252 = 0;
+pub use accesscontrol::AccessControlComponent::DEFAULT_ADMIN_ROLE;

--- a/packages/access/src/accesscontrol/account_role_info.cairo
+++ b/packages/access/src/accesscontrol/account_role_info.cairo
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.20.0 (access/accesscontrol/account_role_info.cairo)
+
+use starknet::storage_access::StorePacking;
+
+/// Information about whether a role is active for an account or not.
+#[derive(Copy, Drop, Serde, PartialEq, Debug)]
+pub struct AccountRoleInfo {
+    pub effective_from: u64,
+    pub active: bool,
+}
+
+/// Packs an AccountRoleInfo into a single felt252.
+///
+/// The packing is done as follows:
+///
+/// 1. `effective_from` is stored at range [187,250] (0-indexed starting from the most
+///   significant bits).
+/// 2. `active` is stored at range [251, 251], following `effective_from`.
+impl AccountRoleInfoStorePacking of StorePacking<AccountRoleInfo, felt252> {
+    fn pack(value: AccountRoleInfo) -> felt252 {
+        let account_role_info = value;
+
+        // shift-left to reach the corresponding positions
+        let effective_from = account_role_info.effective_from.into() * 2;
+        let active = if account_role_info.active {
+            1
+        } else {
+            0
+        };
+
+        effective_from + active
+    }
+
+    fn unpack(value: felt252) -> AccountRoleInfo {
+        let value: u256 = value.into();
+        let effective_from = value / 2;
+        let active = value % 2 == 1;
+
+        AccountRoleInfo { effective_from: effective_from.try_into().unwrap(), active }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::num::traits::Bounded;
+    use super::{AccountRoleInfo, AccountRoleInfoStorePacking};
+
+    #[test]
+    fn test_pack_and_unpack() {
+        let account_role_info = AccountRoleInfo { effective_from: 100, active: true };
+        let packed = AccountRoleInfoStorePacking::pack(account_role_info);
+        let unpacked = AccountRoleInfoStorePacking::unpack(packed);
+        assert_eq!(account_role_info, unpacked);
+    }
+
+    #[test]
+    fn test_pack_and_unpack_big_values() {
+        let account_role_info = AccountRoleInfo { effective_from: Bounded::MAX, active: true };
+        let packed = AccountRoleInfoStorePacking::pack(account_role_info);
+        let unpacked = AccountRoleInfoStorePacking::unpack(packed);
+        assert_eq!(account_role_info, unpacked);
+    }
+}

--- a/packages/access/src/accesscontrol/interface.cairo
+++ b/packages/access/src/accesscontrol/interface.cairo
@@ -16,6 +16,11 @@ pub trait IAccessControl<TState> {
 }
 
 #[starknet::interface]
+pub trait IAccessControlWithDelay<TState> {
+    fn grant_role_with_delay(ref self: TState, role: felt252, account: ContractAddress, delay: u64);
+}
+
+#[starknet::interface]
 pub trait IAccessControlCamel<TState> {
     fn hasRole(self: @TState, role: felt252, account: ContractAddress) -> bool;
     fn getRoleAdmin(self: @TState, role: felt252) -> felt252;


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #1261  <!-- Fill in with issue number -->

This implementation is backward compatible. Contracts using the existing AccessControl component should be able to upgrade to this implementation without breaking the storage or the logic since they will have `effective_from` set as 0 by default for existing roles, and the `AccountRoleInfo` active member layout is compatible with the current boolean.

NOTE: This is a POC, so it lacks tests and documentation yet. MUST NOT be used as it is until is finished.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
