### PR TITLE
docs: fix message type hash in snip12 guide #1273

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump scarb to v2.9.2 (#1239)
 
+### Fixed
+
+- Fixed message type hash in SNIP12 doc (#1274)
+
 ## 0.20.0 (2024-12-06)
 
 ### Added

--- a/docs/modules/ROOT/pages/guides/snip12.adoc
+++ b/docs/modules/ROOT/pages/guides/snip12.adoc
@@ -101,8 +101,9 @@ In this case it can be computed as follows:
 
 [,cairo]
 ----
+// Since there's no u64 type in SNIP-12, we use u128 for `expiry` in the type hash generation.
 let message_type_hash = selector!(
-    "\"Message\"(\"recipient\":\"ContractAddress\",\"amount\":\"u256\",\"nonce\":\"felt\",\"expiry\":\"u64\")\"u256\"(\"low\":\"felt\",\"high\":\"felt\")"
+    "\"Message\"(\"recipient\":\"ContractAddress\",\"amount\":\"u256\",\"nonce\":\"felt\",\"expiry\":\"u128\")\"u256\"(\"low\":\"u128\",\"high\":\"u128\")"
 );
 ----
 
@@ -110,7 +111,7 @@ which is the same as:
 
 [,cairo]
 ----
-let message_type_hash = 0x120ae1bdaf7c1e48349da94bb8dad27351ca115d6605ce345aee02d68d99ec1;
+let message_type_hash = 0x28bf13f11bba405c77ce010d2781c5903cbed100f01f72fcff1664f98343eb6;
 ----
 
 NOTE: In practice it's better to compute the type hash off-chain and hardcode it in the contract, since it is a constant value.
@@ -128,7 +129,7 @@ use openzeppelin_utils::snip12::StructHash;
 use starknet::ContractAddress;
 
 const MESSAGE_TYPE_HASH: felt252 =
-    0x120ae1bdaf7c1e48349da94bb8dad27351ca115d6605ce345aee02d68d99ec1;
+    0x28bf13f11bba405c77ce010d2781c5903cbed100f01f72fcff1664f98343eb6;
 
 #[derive(Copy, Drop, Hash)]
 struct Message {
@@ -194,7 +195,7 @@ use openzeppelin_utils::snip12::{SNIP12Metadata, StructHash, OffchainMessageHash
 use starknet::ContractAddress;
 
 const MESSAGE_TYPE_HASH: felt252 =
-    0x120ae1bdaf7c1e48349da94bb8dad27351ca115d6605ce345aee02d68d99ec1;
+    0x28bf13f11bba405c77ce010d2781c5903cbed100f01f72fcff1664f98343eb6;
 
 #[derive(Copy, Drop, Hash)]
 struct Message {
@@ -248,7 +249,7 @@ use openzeppelin_utils::snip12::{SNIP12Metadata, StructHash, OffchainMessageHash
 use starknet::ContractAddress;
 
 const MESSAGE_TYPE_HASH: felt252 =
-    0x120ae1bdaf7c1e48349da94bb8dad27351ca115d6605ce345aee02d68d99ec1;
+    0x28bf13f11bba405c77ce010d2781c5903cbed100f01f72fcff1664f98343eb6;
 
 #[derive(Copy, Drop, Hash)]
 struct Message {


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #1273

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

This PR updates the SNIP-12 documentation guide with a corrected message type hash value. Here are the key changes:
1. Typed Message Update:
    * Changed the typed message in the selector from
      *  `"expiry\":\"u64\"` to `"expiry\":\"u128\"` and,
      * `"u256"("low":"felt","high":"felt")` to `"u256"("low":"u128","high":"u128")` 
    * Added a clarifying comment explaining that since SNIP-12 doesn't support u64, u128 is used for the expiry field instead.

2. Hash Value Update:
    * The message type hash constant was updated throughout the document from: `0x120ae1bdaf7c1e48349da94bb8dad27351ca115d6605ce345aee02d68d99ec1` to: `0x28bf13f11bba405c77ce010d2781c5903cbed100f01f72fcff1664f98343eb6`

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [x] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
