### PR TITLE
comment where "SCR5

### DIFF
--- a/packages/test_common/src/mocks/account.cairo
+++ b/packages/test_common/src/mocks/account.cairo
@@ -17,7 +17,7 @@ pub mod DualCaseAccountMock {
     impl DeployableImpl = AccountComponent::DeployableImpl<ContractState>;
     impl AccountInternalImpl = AccountComponent::InternalImpl<ContractState>;
 
-    // SCR5
+    // SRC5
     #[abi(embed_v0)]
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
@@ -59,7 +59,7 @@ pub mod SnakeAccountMock {
     impl PublicKeyImpl = AccountComponent::PublicKeyImpl<ContractState>;
     impl AccountInternalImpl = AccountComponent::InternalImpl<ContractState>;
 
-    // SCR5
+    // SRC5
     #[abi(embed_v0)]
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 

--- a/packages/test_common/src/mocks/src9.cairo
+++ b/packages/test_common/src/mocks/src9.cairo
@@ -22,7 +22,7 @@ pub mod SRC9AccountMock {
         SRC9Component::OutsideExecutionV2Impl<ContractState>;
     impl OutsideExecutionInternalImpl = SRC9Component::InternalImpl<ContractState>;
 
-    // SCR5
+    // SRC5
     #[abi(embed_v0)]
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 


### PR DESCRIPTION
This PR fixes a typo in the comment where "SCR5" is incorrectly written instead of "SRC5" (Starknet Request for Comments 5).

The comment contains a transposition error in the acronym. SRC5 is the correct abbreviation for "Starknet Request for Comments 5", which is the standard specification. This change ensures consistency with the official documentation and other references to this standard throughout the codebase.