### PR TITLE
Fuzz tests for StorePacking

### DIFF
--- a/packages/account/Scarb.toml
+++ b/packages/account/Scarb.toml
@@ -32,6 +32,9 @@ snforge_std.workspace = true
 openzeppelin_testing = { path = "../testing" }
 openzeppelin_test_common = { path = "../test_common" }
 
+[features]
+fuzzing = []
+
 [lib]
 
 [[target.starknet-contract]]

--- a/packages/governance/Scarb.toml
+++ b/packages/governance/Scarb.toml
@@ -35,6 +35,9 @@ snforge_std.workspace = true
 openzeppelin_testing = { path = "../testing" }
 openzeppelin_test_common = { path = "../test_common" }
 
+[features]
+fuzzing = []
+
 [lib]
 
 [[target.starknet-contract]]

--- a/packages/governance/src/multisig/multisig.cairo
+++ b/packages/governance/src/multisig/multisig.cairo
@@ -16,7 +16,7 @@
 #[starknet::component]
 pub mod MultisigComponent {
     use core::hash::{HashStateExTrait, HashStateTrait};
-    use core::num::traits::Zero;
+    use core::num::traits::{Bounded, Zero};
     use core::panic_with_felt252;
     use core::pedersen::PedersenTrait;
     use crate::multisig::interface::{IMultisig, TransactionID, TransactionState};
@@ -128,6 +128,7 @@ pub mod MultisigComponent {
         pub const ZERO_ADDRESS_SIGNER: felt252 = 'Multisig: zero address signer';
         pub const ZERO_QUORUM: felt252 = 'Multisig: quorum cannot be 0';
         pub const QUORUM_TOO_HIGH: felt252 = 'Multisig: quorum > signers';
+        pub const TOO_MANY_SIGNERS: felt252 = 'Multisig: too many signers';
     }
 
     //
@@ -569,6 +570,8 @@ pub mod MultisigComponent {
 
                     signers_count += 1;
                 };
+
+                assert(signers_count != Bounded::MAX, Errors::TOO_MANY_SIGNERS);
                 self.Multisig_signers_info.write(SignersInfo { quorum, signers_count });
             }
             self._change_quorum(new_quorum);

--- a/packages/governance/src/tests.cairo
+++ b/packages/governance/src/tests.cairo
@@ -1,4 +1,6 @@
 mod governor;
+#[cfg(feature: 'fuzzing')]
+mod test_fuzz_packing;
 mod test_multisig;
 mod test_timelock;
 mod test_utils;

--- a/packages/governance/src/tests/test_fuzz_packing.cairo
+++ b/packages/governance/src/tests/test_fuzz_packing.cairo
@@ -1,0 +1,53 @@
+use core::num::traits::Bounded;
+use crate::governor::ProposalCore;
+use crate::multisig::storage_utils::{SignersInfo, TxInfo};
+use starknet::storage_access::StorePacking;
+
+#[test]
+fn test_pack_unpack_tx_info(is_executed_val: u8, submitted_block: u64) {
+    let is_executed = is_executed_val % 2 == 0;
+    let packed_value = StorePacking::pack(TxInfo { is_executed, submitted_block });
+    let unpacked_tx_info: TxInfo = StorePacking::unpack(packed_value);
+
+    assert_eq!(unpacked_tx_info.is_executed, is_executed);
+    assert_eq!(unpacked_tx_info.submitted_block, submitted_block);
+}
+
+#[test]
+fn test_pack_unpack_signers_info(quorum: u32, signers_count: u32) {
+    // Packing works incorrectly when the number of signers
+    // equals max u32 value (0xffffffff or 4_294_967_295).
+    if signers_count == Bounded::MAX {
+        return;
+    };
+    let packed_value = StorePacking::pack(SignersInfo { quorum, signers_count });
+    let unpacked_signers_info: SignersInfo = StorePacking::unpack(packed_value);
+
+    assert_eq!(unpacked_signers_info.quorum, quorum);
+    assert_eq!(unpacked_signers_info.signers_count, signers_count);
+}
+
+#[test]
+fn test_pack_unpack_proposal_core(
+    proposer_val: felt252,
+    vote_start: u64,
+    vote_duration: u64,
+    executed_val: u8,
+    canceled_val: u8,
+    eta_seconds: u64,
+) {
+    let proposer = match proposer_val.try_into() {
+        Option::Some(proposer) => proposer,
+        Option::None => { return; },
+    };
+    let executed = executed_val % 2 == 0;
+    let canceled = canceled_val % 2 == 0;
+    let initial_proposal_core = ProposalCore {
+        proposer, vote_start, vote_duration, executed, canceled, eta_seconds,
+    };
+
+    let packed_value = StorePacking::pack(initial_proposal_core);
+    let unpacked_proposal_core: ProposalCore = StorePacking::unpack(packed_value);
+
+    assert!(unpacked_proposal_core == initial_proposal_core);
+}


### PR DESCRIPTION
- Adds fuzz test cases for StorePacking logic of various structs: `TxInfo`, `SignersInfo` and `ProposalCore` in governance package, and `Secp256k1Point` and `Secp256r1Point` in account package
- Addresses issue of `SignersInfo` store packing: if number of signers is equal max `u32` value (0xffffffff or 4_294_967_295), it leads to unpacked `quorum` value be higher than the expected value by 1