### PR TITLE
docs: fix broken and outdated links in documentation

### DIFF
--- a/docs/modules/ROOT/pages/access.adoc
+++ b/docs/modules/ROOT/pages/access.adoc
@@ -1,5 +1,5 @@
 :ownable-cairo: xref:api/access.adoc#OwnableComponent[OwnableComponent]
-:sn_keccak: https://docs.starknet.io/documentation/architecture_and_concepts/Cryptography/hash-functions/#starknet_keccak[sn_keccak]
+:sn_keccak: https://docs.starknet.io/architecture-and-concepts/cryptography/#starknet_keccak[sn_keccak]
 
 = Access
 

--- a/docs/modules/ROOT/pages/accounts.adoc
+++ b/docs/modules/ROOT/pages/accounts.adoc
@@ -10,7 +10,7 @@ concept on Starknet.
 Instead, the network features native account abstraction and signature validation happens at the contract level.
 
 For a general overview of account abstraction, see
-https://docs.starknet.io/documentation/architecture_and_concepts/Accounts/introduction/[Starknet's documentation].
+https://docs.starknet.io/architecture-and-concepts/accounts/introduction/[Starknet's documentation].
 A more detailed discussion on the topic can be found in
 https://community.starknet.io/t/starknet-account-abstraction-model-part-1/781[Starknet Shaman's forum].
 
@@ -81,7 +81,7 @@ The Starknet protocol uses a few entrypoints for abstracting the accounts. We al
 as part of the ISRC6 interface, and both are required for enabling accounts to be used for executing transactions. The rest are optional:
 
 1. `\\__validate__` verifies the validity of the transaction to be executed. This is usually used to validate signatures,
-but the entrypoint implementation can be customized to feature any validation mechanism https://docs.starknet.io/documentation/architecture_and_concepts/Accounts/validate_and_execute/#validate_limitations[with some limitations].
+but the entrypoint implementation can be customized to feature any validation mechanism https://docs.starknet.io/architecture-and-concepts/accounts/account-functions/#limitations_of_validation[with some limitations].
 
 2. `\\__execute__` executes the transaction if the validation is successful.
 
@@ -94,7 +94,7 @@ NOTE: Although these entrypoints are available to the protocol for its regular t
 
 == Starknet Account
 
-:stark-curve: https://docs.starknet.io/documentation/architecture_and_concepts/Cryptography/stark-curve
+:stark-curve: https://docs.starknet.io/architecture-and-concepts/cryptography/#stark-curve
 :account-component: xref:/api/account.adoc#AccountComponent[AccountComponent]
 :src5-component: xref:/api/introspection.adoc#SRC5Component[SRC5Component]
 

--- a/docs/modules/ROOT/pages/api/account.adoc
+++ b/docs/modules/ROOT/pages/api/account.adoc
@@ -71,7 +71,7 @@ Returns the short string `'VALID'` if valid, otherwise it reverts.
 
 :OwnerAdded: xref:AccountComponent-OwnerAdded[OwnerAdded]
 :OwnerRemoved: xref:AccountComponent-OwnerRemoved[OwnerRemoved]
-:starknet-curve: https://docs.starknet.io/documentation/architecture_and_concepts/Cryptography/stark-curve/[Starknet curve]
+:starknet-curve: https://docs.starknet.io/architecture-and-concepts/cryptography/#stark-curve[Starknet curve]
 
 ```cairo
 use openzeppelin_account::AccountComponent;
@@ -181,7 +181,7 @@ See xref:ISRC6-is_valid_signature[ISRC6::is_valid_signature].
 [[AccountComponent-__validate_declare__]]
 ==== `[.contract-item-name]#++__validate_declare__++#++(self: @ContractState, class_hash: felt252) → felt252++` [.item-kind]#external#
 
-Validates a https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#declare-transaction[`Declare` transaction].
+Validates a https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#declare-transaction[`Declare` transaction].
 
 Returns the short string `'VALID'` if valid, otherwise it reverts.
 
@@ -189,7 +189,7 @@ Returns the short string `'VALID'` if valid, otherwise it reverts.
 [[AccountComponent-__validate_deploy__]]
 ==== `[.contract-item-name]#++__validate_deploy__++#++(self: @ContractState, class_hash: felt252, contract_address_salt: felt252, public_key: felt252) → felt252++` [.item-kind]#external#
 
-Validates a https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#deploy_account_transaction[`DeployAccount` transaction].
+Validates a https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#deploy_account_transaction[`DeployAccount` transaction].
 See xref:/guides/deployment.adoc[Counterfactual Deployments].
 
 Returns the short string `'VALID'` if valid, otherwise it reverts.
@@ -433,7 +433,7 @@ See xref:ISRC6-is_valid_signature[ISRC6::is_valid_signature].
 [[EthAccountComponent-__validate_declare__]]
 ==== `[.contract-item-name]#++__validate_declare__++#++(self: @ContractState, class_hash: felt252) → felt252++` [.item-kind]#external#
 
-Validates a https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/Blocks/transactions/#declare-transaction[`Declare` transaction].
+Validates a https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#declare-transaction[`Declare` transaction].
 
 Returns the short string `'VALID'` if valid, otherwise it reverts.
 
@@ -441,7 +441,7 @@ Returns the short string `'VALID'` if valid, otherwise it reverts.
 [[EthAccountComponent-__validate_deploy__]]
 ==== `[.contract-item-name]#++__validate_deploy__++#++(self: @ContractState, class_hash: felt252, contract_address_salt: felt252, public_key: EthPublicKey) → felt252++` [.item-kind]#external#
 
-Validates a https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/Blocks/transactions/#deploy_account_transaction[`DeployAccount` transaction].
+Validates a https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#deploy_account_transaction[`DeployAccount` transaction].
 See xref:/guides/deployment.adoc[Counterfactual Deployments].
 
 Returns the short string `'VALID'` if valid, otherwise it reverts.

--- a/docs/modules/ROOT/pages/api/upgrades.adoc
+++ b/docs/modules/ROOT/pages/api/upgrades.adoc
@@ -1,5 +1,5 @@
 :github-icon: pass:[<svg class="icon"><use href="#github-icon"/></svg>]
-:class_hash: https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/class-hash/[class hash]
+:class_hash: https://docs.starknet.io/architecture-and-concepts/smart-contracts/class-hash/[class hash]
 
 = Upgrades
 

--- a/docs/modules/ROOT/pages/api/utilities.adoc
+++ b/docs/modules/ROOT/pages/api/utilities.adoc
@@ -1,6 +1,6 @@
 = Utilities
 
-:deploy_syscall: link:https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/system-calls-cairo1/#deploy[deploy_syscall]
+:deploy_syscall: link:https://docs.starknet.io/architecture-and-concepts/smart-contracts/system-calls-cairo1/#deploy[deploy_syscall]
 
 This crate provides miscellaneous components and libraries containing utility functions to handle common tasks.
 

--- a/docs/modules/ROOT/pages/presets.adoc
+++ b/docs/modules/ROOT/pages/presets.adoc
@@ -5,7 +5,7 @@
 :eth-account-upgradeable: xref:/api/account.adoc#EthAccountUpgradeable[EthAccountUpgradeable]
 :udc: xref:/api/udc.adoc#UniversalDeployer[UniversalDeployer]
 :vesting-wallet: xref:/api/finance.adoc#VestingWallet[VestingWallet]
-:sierra-class-hashes: https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/class-hash[Sierra class hashes]
+:sierra-class-hashes: https://docs.starknet.io/architecture-and-concepts/smart-contracts/class-hash/[Sierra class hashes]
 :starkli: https://book.starkli.rs/introduction[starkli]
 :wizard: https://wizard.openzeppelin.com[Wizard for Cairo]
 

--- a/docs/modules/ROOT/pages/udc.adoc
+++ b/docs/modules/ROOT/pages/udc.adoc
@@ -1,6 +1,6 @@
 = Universal Deployer Contract
 
-:deploy-syscall: link:https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/system-calls-cairo1/#deploy[deploy syscall]
+:deploy-syscall: link:https://docs.starknet.io/architecture-and-concepts/smart-contracts/system-calls-cairo1/#deploy[deploy syscall]
 :deployer-interface: link:https://community.starknet.io/t/snip-deployer-contract-interface/2772[Standard Deployer Interface]
 :udc-proposal: link:https://community.starknet.io/t/universal-deployer-contract-proposal/1864[Universal Deployer Contract proposal]
 :deploy_contract: xref:/api/udc.adoc#UniversalDeployer-deploy_contract[deploy_contract]
@@ -33,7 +33,7 @@ pub trait IUniversalDeployer {
 
 == Deploying a contract with the UDC
 
-:declare: link:https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#declare-transaction[declare]
+:declare: link:https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#declare-transaction[declare]
 
 First, {declare} the target contract (if it's not already declared).
 Next, call the UDC's `deploy_contract` method.
@@ -106,10 +106,10 @@ let deployed_addr = udc.deploy_contract(class_hash, salt, true, calldata.span())
 
 == Version changes
 
-:pedersen: link:https://docs.starknet.io/documentation/architecture_and_concepts/Cryptography/hash-functions/#pedersen_hash[Pedersen]
-:poseidon: link:https://docs.starknet.io/documentation/architecture_and_concepts/Cryptography/hash-functions/#poseidon_hash[Poseidon]
+:pedersen: link:https://docs.starknet.io/architecture-and-concepts/cryptography/#pedersen_hash[Pedersen]
+:poseidon: link:https://docs.starknet.io/architecture-and-concepts/cryptography/#poseidon_hash[Poseidon]
 :origin-dependent-deployments: xref:origin_dependent[origin-dependent deployments]
-:previous-udc-api: https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/universal-deployer/[previous Universal Deployer API]
+:previous-udc-api: https://docs.starknet.io/architecture-and-concepts/accounts/universal-deployer/[previous Universal Deployer API]
 :contract-deployed-event: xref:/api/udc.adoc#IUniversalDeployer-ContractDeployed[ContractDeployed]
 
 NOTE: See the {previous-udc-api} for the initial spec.

--- a/docs/modules/ROOT/pages/upgrades.adoc
+++ b/docs/modules/ROOT/pages/upgrades.adoc
@@ -1,10 +1,10 @@
-:contract_classes: https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/contract-classes/[Contract Classes]
-:class_hash: https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/class-hash/[class hash]
-:replace_class_syscall: https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/system-calls-cairo1/#replace_class[replace_class]
+:contract_classes: https://docs.starknet.io/architecture-and-concepts/smart-contracts/contract-classes/[Contract Classes]
+:class_hash: https://docs.starknet.io/architecture-and-concepts/smart-contracts/class-hash/[class hash]
+:replace_class_syscall: https://docs.starknet.io/architecture-and-concepts/smart-contracts/system-calls-cairo1/#replace_class[replace_class]
 :upgradeable: https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.20.0/packages/upgrades/src/upgradeable.cairo[Upgradeable]
 :ownable: xref:access.adoc#ownership_and_ownable[Ownable]
 :i_upgradeable: xref:api/upgrades.adoc#IUpgradeable[IUpgradeable]
-:library_calls: https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/system-calls-cairo1/#library_call[library calls]
+:library_calls: https://docs.starknet.io/architecture-and-concepts/smart-contracts/system-calls-cairo1/#library_call[library calls]
 
 = Upgrades
 

--- a/packages/governance/src/governor/proposal_core.cairo
+++ b/packages/governance/src/governor/proposal_core.cairo
@@ -38,7 +38,7 @@ const _2_POW_54: felt252 = 0x40000000000000;
 ///
 /// NOTE: In the second felt252, the first four bits are skipped to avoid representation errors due
 /// to `felt252` max value being a bit less than a 252 bits number max value
-/// (https://docs.starknet.io/documentation/architecture_and_concepts/Cryptography/p-value/).
+/// (https://docs.starknet.io/architecture-and-concepts/cryptography/#stark-field).
 impl ProposalCoreStorePacking of StorePacking<ProposalCore, (felt252, felt252)> {
     fn pack(value: ProposalCore) -> (felt252, felt252) {
         let proposal = value;

--- a/packages/upgrades/src/upgradeable.cairo
+++ b/packages/upgrades/src/upgradeable.cairo
@@ -69,7 +69,7 @@ pub mod UpgradeableComponent {
             let this = starknet::get_contract_address();
             // `call_contract_syscall` is used in order to call `selector` from the new class.
             // See:
-            // https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/system-calls-cairo1/#replace_class
+            // https://docs.starknet.io/architecture-and-concepts/smart-contracts/system-calls-cairo1/#replace_class
             starknet::syscalls::call_contract_syscall(this, selector, calldata).unwrap_syscall()
         }
     }

--- a/packages/utils/src/deployments.cairo
+++ b/packages/utils/src/deployments.cairo
@@ -20,7 +20,7 @@ pub const CONTRACT_ADDRESS_PREFIX: felt252 = 'STARKNET_CONTRACT_ADDRESS';
 /// from zero).
 ///
 /// For more information, see
-/// https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/contract-address/
+/// https://docs.starknet.io/architecture-and-concepts/smart-contracts/contract-address/
 pub fn calculate_contract_address_from_deploy_syscall(
     salt: felt252,
     class_hash: ClassHash,

--- a/packages/utils/src/structs/checkpoint.cairo
+++ b/packages/utils/src/structs/checkpoint.cairo
@@ -177,7 +177,7 @@ const _128_BITS_MASK: u256 = 0xffffffffffffffffffffffffffffffff;
 ///
 /// NOTE: In this first felt, the first four bits are skipped to avoid representation errors due
 /// to `felt252` max value being a bit less than a 252 bits number max value
-/// (https://docs.starknet.io/documentation/architecture_and_concepts/Cryptography/p-value/).
+/// (https://docs.starknet.io/architecture-and-concepts/cryptography/#stark-field).
 impl CheckpointStorePacking of StorePacking<Checkpoint, (felt252, felt252)> {
     fn pack(value: Checkpoint) -> (felt252, felt252) {
         let checkpoint = value;


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

Hi! This PR fixes broken and outdated links in the documentation. The links now correctly point to the latest sections of the official Starknet documentation. Updated references in `adoc` and `cairo` files

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
