### PR TITLE
fix common.cairo

### DIFF
--- a/packages/testing/src/common.cairo
+++ b/packages/testing/src/common.cairo
@@ -32,7 +32,7 @@ pub fn to_base_16_string(value: felt252) -> ByteArray {
 /// Converts a `felt252` to a `base16` (hexadecimal) string without padding, but including the `0x`
 /// prefix.
 /// We need this because Starknet Foundry has a way of representing addresses and selectors that
-/// does not include 0's after `Ox`.
+/// does not include 0's after `0x`.
 pub fn to_base_16_string_no_padding(value: felt252) -> ByteArray {
     let string = value.format_as_byte_array(16);
     format!("0x{}", string)


### PR DESCRIPTION
`Ox` - `0x` -----> fix сhanged a letter to a digit