### PR TITLE
Fix/update license paths

### DIFF
--- a/packages/access/src/accesscontrol/accesscontrol.cairo
+++ b/packages/access/src/accesscontrol/accesscontrol.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (access/accesscontrol/accesscontrol.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (access/src/accesscontrol/accesscontrol.cairo)
 
 /// # AccessControl Component
 ///

--- a/packages/access/src/accesscontrol/interface.cairo
+++ b/packages/access/src/accesscontrol/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (access/accesscontrol/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (access/src/accesscontrol/interface.cairo)
 
 use starknet::ContractAddress;
 

--- a/packages/access/src/ownable/interface.cairo
+++ b/packages/access/src/ownable/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (access/ownable/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (access/src/ownable/interface.cairo)
 
 use starknet::ContractAddress;
 

--- a/packages/access/src/ownable/ownable.cairo
+++ b/packages/access/src/ownable/ownable.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (access/ownable/ownable.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (access/src/ownable/ownable.cairo)
 
 /// # Ownable Component
 ///

--- a/packages/account/src/account.cairo
+++ b/packages/account/src/account.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (account/account.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (account/src/account.cairo)
 
 /// # Account Component
 ///

--- a/packages/account/src/eth_account.cairo
+++ b/packages/account/src/eth_account.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (account/eth_account.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (account/src/eth_account.cairo)
 
 /// # EthAccount Component
 ///

--- a/packages/account/src/extensions/src9/interface.cairo
+++ b/packages/account/src/extensions/src9/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (account/extensions/src9/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (account/src/src/extensions/src9/interface.cairo)
 
 use starknet::ContractAddress;
 use starknet::account::Call;

--- a/packages/account/src/extensions/src9/interface.cairo
+++ b/packages/account/src/extensions/src9/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (account/src/src/extensions/src9/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (account/src/extensions/src9/interface.cairo)
 
 use starknet::ContractAddress;
 use starknet::account::Call;

--- a/packages/account/src/extensions/src9/snip12_utils.cairo
+++ b/packages/account/src/extensions/src9/snip12_utils.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (account/extensions/src9/snip12_utils.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (account/src/extensions/src9/snip12_utils.cairo)
 
 use core::hash::{HashStateExTrait, HashStateTrait};
 use core::poseidon::{PoseidonTrait, poseidon_hash_span};

--- a/packages/account/src/extensions/src9/src9.cairo
+++ b/packages/account/src/extensions/src9/src9.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (account/extensions/src9/src9.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (account/src/extensions/src9/src9.cairo)
 
 /// # SRC9 Component (Outside Execution)
 ///

--- a/packages/account/src/interface.cairo
+++ b/packages/account/src/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (account/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (account/src/interface.cairo)
 
 use starknet::account::Call;
 

--- a/packages/account/src/utils.cairo
+++ b/packages/account/src/utils.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (account/utils.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (account/src/utils.cairo)
 
 pub mod secp256_point;
 pub mod signature;

--- a/packages/account/src/utils/secp256_point.cairo
+++ b/packages/account/src/utils/secp256_point.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (account/utils/secp256_point.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (account/src/utils/secp256_point.cairo)
 
 use core::fmt::{Error, Formatter};
 use starknet::SyscallResultTrait;

--- a/packages/account/src/utils/signature.cairo
+++ b/packages/account/src/utils/signature.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (account/utils/signature.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (account/src/utils/signature.cairo)
 
 use core::ecdsa::check_ecdsa_signature;
 use crate::interface::{EthPublicKey, P256PublicKey};

--- a/packages/finance/src/vesting/interface.cairo
+++ b/packages/finance/src/vesting/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (finance/vesting/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (finance/src/vesting/interface.cairo)
 
 use starknet::ContractAddress;
 

--- a/packages/finance/src/vesting/vesting.cairo
+++ b/packages/finance/src/vesting/vesting.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (finance/vesting/vesting.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (finance/src/vesting/vesting.cairo)
 
 use starknet::ContractAddress;
 

--- a/packages/governance/src/governor/extensions/governor_core_execution.cairo
+++ b/packages/governance/src/governor/extensions/governor_core_execution.cairo
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governor/extensions/governor_core_execution.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0
+// (governance/src/governor/extensions/governor_core_execution.cairo)
 
 /// # GovernorCoreExecution Component
 ///

--- a/packages/governance/src/governor/extensions/governor_core_execution.cairo
+++ b/packages/governance/src/governor/extensions/governor_core_execution.cairo
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0
-// (governance/governor/extensions/governor_core_execution.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governor/extensions/governor_core_execution.cairo)
 
 /// # GovernorCoreExecution Component
 ///

--- a/packages/governance/src/governor/extensions/governor_counting_simple.cairo
+++ b/packages/governance/src/governor/extensions/governor_counting_simple.cairo
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governor/extensions/governor_counting_simple.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0
+// (governance/src/governor/extensions/governor_counting_simple.cairo)
 
 /// # GovernorCountingSimple Component
 ///

--- a/packages/governance/src/governor/extensions/governor_counting_simple.cairo
+++ b/packages/governance/src/governor/extensions/governor_counting_simple.cairo
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0
-// (governance/governor/extensions/governor_counting_simple.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governor/extensions/governor_counting_simple.cairo)
 
 /// # GovernorCountingSimple Component
 ///

--- a/packages/governance/src/governor/extensions/governor_settings.cairo
+++ b/packages/governance/src/governor/extensions/governor_settings.cairo
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governor/extensions/governor_settings.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0
+// (governance/src/governor/extensions/governor_settings.cairo)
 
 /// # GovernorSettings Component
 ///

--- a/packages/governance/src/governor/extensions/governor_settings.cairo
+++ b/packages/governance/src/governor/extensions/governor_settings.cairo
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0
-// (governance/governor/extensions/governor_settings.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governor/extensions/governor_settings.cairo)
 
 /// # GovernorSettings Component
 ///

--- a/packages/governance/src/governor/extensions/governor_timelock_execution.cairo
+++ b/packages/governance/src/governor/extensions/governor_timelock_execution.cairo
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0
-// (governance/governor/extensions/governor_core_execution.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governor/extensions/governor_core_execution.cairo)
 
 /// # GovernorTimelockExecution Component
 ///

--- a/packages/governance/src/governor/extensions/governor_timelock_execution.cairo
+++ b/packages/governance/src/governor/extensions/governor_timelock_execution.cairo
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governor/extensions/governor_core_execution.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0
+// (governance/src/governor/extensions/governor_core_execution.cairo)
 
 /// # GovernorTimelockExecution Component
 ///

--- a/packages/governance/src/governor/extensions/governor_votes.cairo
+++ b/packages/governance/src/governor/extensions/governor_votes.cairo
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts for Cairo v0.20.0
-// (governance/src/governance/governor/extensions/governor_votes.cairo)
+// (governance/src/governor/extensions/governor_votes.cairo)
 
 /// # GovernorVotes Component
 ///

--- a/packages/governance/src/governor/extensions/governor_votes.cairo
+++ b/packages/governance/src/governor/extensions/governor_votes.cairo
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0
-// (governance/governor/extensions/governor_votes.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governance/governor/extensions/governor_votes.cairo)
 
 /// # GovernorVotes Component
 ///

--- a/packages/governance/src/governor/extensions/governor_votes.cairo
+++ b/packages/governance/src/governor/extensions/governor_votes.cairo
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governance/governor/extensions/governor_votes.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0
+// (governance/src/governance/governor/extensions/governor_votes.cairo)
 
 /// # GovernorVotes Component
 ///

--- a/packages/governance/src/governor/extensions/governor_votes_quorum_fraction.cairo
+++ b/packages/governance/src/governor/extensions/governor_votes_quorum_fraction.cairo
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0
-// (governance/governor/extensions/governor_votes_quorum_fraction.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governance/governor/extensions/governor_votes_quorum_fraction.cairo)
 
 /// # GovernorVotesQuorumFraction Component
 ///

--- a/packages/governance/src/governor/extensions/governor_votes_quorum_fraction.cairo
+++ b/packages/governance/src/governor/extensions/governor_votes_quorum_fraction.cairo
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts for Cairo v0.20.0
-// (governance/src/governance/governor/extensions/governor_votes_quorum_fraction.cairo)
+// (governance/src/governor/extensions/governor_votes_quorum_fraction.cairo)
 
 /// # GovernorVotesQuorumFraction Component
 ///

--- a/packages/governance/src/governor/extensions/governor_votes_quorum_fraction.cairo
+++ b/packages/governance/src/governor/extensions/governor_votes_quorum_fraction.cairo
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governance/governor/extensions/governor_votes_quorum_fraction.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0
+// (governance/src/governance/governor/extensions/governor_votes_quorum_fraction.cairo)
 
 /// # GovernorVotesQuorumFraction Component
 ///

--- a/packages/governance/src/governor/extensions/interface.cairo
+++ b/packages/governance/src/governor/extensions/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/governor/extensions/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governor/extensions/interface.cairo)
 
 use starknet::ContractAddress;
 

--- a/packages/governance/src/governor/governor.cairo
+++ b/packages/governance/src/governor/governor.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/governor/governor.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governor/governor.cairo)
 
 /// # Governor Component
 ///

--- a/packages/governance/src/governor/interface.cairo
+++ b/packages/governance/src/governor/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/governor/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governor/interface.cairo)
 
 use starknet::ContractAddress;
 use starknet::account::Call;

--- a/packages/governance/src/governor/proposal_core.cairo
+++ b/packages/governance/src/governor/proposal_core.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/governor/proposal_core.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governor/proposal_core.cairo)
 
 use core::traits::DivRem;
 use starknet::ContractAddress;

--- a/packages/governance/src/governor/vote.cairo
+++ b/packages/governance/src/governor/vote.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/governor/vote.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/governor/vote.cairo)
 
 use core::hash::{HashStateExTrait, HashStateTrait};
 use core::poseidon::PoseidonTrait;

--- a/packages/governance/src/multisig/interface.cairo
+++ b/packages/governance/src/multisig/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/multisig/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/multisig/interface.cairo)
 
 use starknet::ContractAddress;
 use starknet::account::Call;

--- a/packages/governance/src/multisig/multisig.cairo
+++ b/packages/governance/src/multisig/multisig.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/multisig/multisig.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/multisig/multisig.cairo)
 
 /// # Multisig Component
 ///

--- a/packages/governance/src/multisig/storage_utils.cairo
+++ b/packages/governance/src/multisig/storage_utils.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/multisig/storage_utils.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/multisig/storage_utils.cairo)
 
 use core::integer::u128_safe_divmod;
 use starknet::storage_access::StorePacking;

--- a/packages/governance/src/timelock/interface.cairo
+++ b/packages/governance/src/timelock/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/timelock/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/timelock/interface.cairo)
 
 use starknet::ContractAddress;
 use starknet::account::Call;

--- a/packages/governance/src/timelock/timelock_controller.cairo
+++ b/packages/governance/src/timelock/timelock_controller.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/timelock/timelock_controller.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/timelock/timelock_controller.cairo)
 
 /// # TimelockController Component
 ///

--- a/packages/governance/src/utils/call_impls.cairo
+++ b/packages/governance/src/utils/call_impls.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/utils/call_impls.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/utils/call_impls.cairo)
 
 use core::hash::{Hash, HashStateExTrait, HashStateTrait};
 use starknet::account::Call;

--- a/packages/governance/src/votes/delegation.cairo
+++ b/packages/governance/src/votes/delegation.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/votes/delegation.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/votes/delegation.cairo)
 
 use core::hash::{HashStateExTrait, HashStateTrait};
 use core::poseidon::PoseidonTrait;

--- a/packages/governance/src/votes/interface.cairo
+++ b/packages/governance/src/votes/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/votes/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/votes/interface.cairo)
 
 use starknet::ContractAddress;
 

--- a/packages/governance/src/votes/votes.cairo
+++ b/packages/governance/src/votes/votes.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (governance/votes/votes.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (governance/src/votes/votes.cairo)
 
 /// # Votes Component
 ///

--- a/packages/introspection/src/interface.cairo
+++ b/packages/introspection/src/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (introspection/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (introspection/src/interface.cairo)
 
 pub const ISRC5_ID: felt252 = 0x3f918d17e5ee77373b56385708f855659a07f75997f365cf87748628532a055;
 

--- a/packages/introspection/src/src5.cairo
+++ b/packages/introspection/src/src5.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (introspection/src5.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (introspection/src/src5.cairo)
 
 /// # SRC5 Component
 ///

--- a/packages/merkle_tree/src/hashes.cairo
+++ b/packages/merkle_tree/src/hashes.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (merkle_tree/hashes.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (merkle_tree/src/hashes.cairo)
 
 use core::hash::HashStateTrait;
 use core::pedersen::PedersenTrait;

--- a/packages/merkle_tree/src/merkle_proof.cairo
+++ b/packages/merkle_tree/src/merkle_proof.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (merkle_tree/merkle_proof.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (merkle_tree/src/merkle_proof.cairo)
 
 /// These functions deal with verification of Merkle Tree proofs.
 ///

--- a/packages/presets/src/account.cairo
+++ b/packages/presets/src/account.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (presets/account.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (presets/src/account.cairo)
 
 /// # Account Preset
 ///

--- a/packages/presets/src/erc1155.cairo
+++ b/packages/presets/src/erc1155.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (presets/erc1155.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (presets/src/erc1155.cairo)
 
 /// # ERC1155Upgradeable Preset
 ///

--- a/packages/presets/src/erc20.cairo
+++ b/packages/presets/src/erc20.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (presets/erc20.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (presets/src/erc20.cairo)
 
 /// # ERC20 Preset
 ///

--- a/packages/presets/src/erc721.cairo
+++ b/packages/presets/src/erc721.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (presets/erc721.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (presets/src/erc721.cairo)
 
 /// # ERC721 Preset
 ///

--- a/packages/presets/src/eth_account.cairo
+++ b/packages/presets/src/eth_account.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (presets/eth_account.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (presets/src/eth_account.cairo)
 
 /// # EthAccount Preset
 ///

--- a/packages/presets/src/universal_deployer.cairo
+++ b/packages/presets/src/universal_deployer.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (presets/universal_deployer.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (presets/src/universal_deployer.cairo)
 
 /// # UniversalDeployerContract Preset
 ///

--- a/packages/presets/src/vesting.cairo
+++ b/packages/presets/src/vesting.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (presets/vesting.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (presets/src/vesting.cairo)
 
 #[starknet::contract]
 pub mod VestingWallet {

--- a/packages/security/src/initializable.cairo
+++ b/packages/security/src/initializable.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (security/initializable.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (security/src/initializable.cairo)
 
 /// # Initializable Component
 ///

--- a/packages/security/src/interface.cairo
+++ b/packages/security/src/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (security/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (security/src/interface.cairo)
 
 #[starknet::interface]
 pub trait IInitializable<TState> {

--- a/packages/security/src/pausable.cairo
+++ b/packages/security/src/pausable.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (security/pausable.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (security/src/pausable.cairo)
 
 /// # Pausable Component
 ///

--- a/packages/security/src/reentrancyguard.cairo
+++ b/packages/security/src/reentrancyguard.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (security/reentrancyguard.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (security/src/reentrancyguard.cairo)
 
 /// # ReentrancyGuard Component
 ///

--- a/packages/token/src/common/erc2981/erc2981.cairo
+++ b/packages/token/src/common/erc2981/erc2981.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (token/common/erc2981/erc2981.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (token/src/common/erc2981/erc2981.cairo)
 
 /// # ERC2981 Component
 ///

--- a/packages/token/src/common/erc2981/interface.cairo
+++ b/packages/token/src/common/erc2981/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (token/common/erc2981/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (token/src/common/erc2981/interface.cairo)
 
 use starknet::ContractAddress;
 

--- a/packages/token/src/erc1155/erc1155.cairo
+++ b/packages/token/src/erc1155/erc1155.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (token/erc1155/erc1155.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (token/src/erc1155/erc1155.cairo)
 
 /// # ERC1155 Component
 ///

--- a/packages/token/src/erc1155/erc1155_receiver.cairo
+++ b/packages/token/src/erc1155/erc1155_receiver.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (token/erc1155/erc1155_receiver.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (token/src/erc1155/erc1155_receiver.cairo)
 
 /// # ERC1155Receiver Component
 ///

--- a/packages/token/src/erc1155/interface.cairo
+++ b/packages/token/src/erc1155/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (token/erc1155/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (token/src/erc1155/interface.cairo)
 
 use starknet::ContractAddress;
 

--- a/packages/token/src/erc20/erc20.cairo
+++ b/packages/token/src/erc20/erc20.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (token/erc20/erc20.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (token/src/erc20/erc20.cairo)
 
 /// # ERC20 Component
 ///

--- a/packages/token/src/erc20/extensions/erc4626/erc4626.cairo
+++ b/packages/token/src/erc20/extensions/erc4626/erc4626.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0-rc.0 (token/erc20/extensions/erc4626/erc4626.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0-rc.0 (token/src/erc20/extensions/erc4626/erc4626.cairo)
 
 /// # ERC4626 Component
 ///

--- a/packages/token/src/erc20/extensions/erc4626/erc4626.cairo
+++ b/packages/token/src/erc20/extensions/erc4626/erc4626.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0-rc.0 (token/src/erc20/extensions/erc4626/erc4626.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (token/src/erc20/extensions/erc4626/erc4626.cairo)
 
 /// # ERC4626 Component
 ///

--- a/packages/token/src/erc20/extensions/erc4626/interface.cairo
+++ b/packages/token/src/erc20/extensions/erc4626/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0-rc.0
+// OpenZeppelin Contracts for Cairo v0.20.0
 // (token/src/erc20/extensions/erc4626/interface.cairo)
 
 use starknet::ContractAddress;

--- a/packages/token/src/erc20/extensions/erc4626/interface.cairo
+++ b/packages/token/src/erc20/extensions/erc4626/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0-rc.0 (token/erc20/extensions/erc4626/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0-rc.0 (token/src/erc20/extensions/erc4626/interface.cairo)
 
 use starknet::ContractAddress;
 

--- a/packages/token/src/erc20/extensions/erc4626/interface.cairo
+++ b/packages/token/src/erc20/extensions/erc4626/interface.cairo
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0-rc.0 (token/src/erc20/extensions/erc4626/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0-rc.0
+// (token/src/erc20/extensions/erc4626/interface.cairo)
 
 use starknet::ContractAddress;
 

--- a/packages/token/src/erc20/interface.cairo
+++ b/packages/token/src/erc20/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (token/erc20/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (token/src/erc20/interface.cairo)
 
 use starknet::ContractAddress;
 

--- a/packages/token/src/erc20/snip12_utils/permit.cairo
+++ b/packages/token/src/erc20/snip12_utils/permit.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (token/erc20/snip12_utils/permit.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (token/src/erc20/snip12_utils/permit.cairo)
 
 use core::hash::{HashStateExTrait, HashStateTrait};
 use core::poseidon::PoseidonTrait;

--- a/packages/token/src/erc721/erc721.cairo
+++ b/packages/token/src/erc721/erc721.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (token/erc721/erc721.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (token/src/erc721/erc721.cairo)
 
 /// # ERC721 Component
 ///

--- a/packages/token/src/erc721/erc721_receiver.cairo
+++ b/packages/token/src/erc721/erc721_receiver.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (token/erc721/erc721_receiver.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (token/src/erc721/erc721_receiver.cairo)
 
 /// # ERC721Receiver Component
 ///

--- a/packages/token/src/erc721/interface.cairo
+++ b/packages/token/src/erc721/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (token/erc721/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (token/src/erc721/interface.cairo)
 
 use starknet::ContractAddress;
 

--- a/packages/upgrades/src/interface.cairo
+++ b/packages/upgrades/src/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (upgrades/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (upgrades/src/interface.cairo)
 
 use starknet::ClassHash;
 

--- a/packages/upgrades/src/upgradeable.cairo
+++ b/packages/upgrades/src/upgradeable.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (upgrades/upgradeable.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (upgrades/src/upgradeable.cairo)
 
 /// # Upgradeable Component
 ///

--- a/packages/utils/src/bytearray.cairo
+++ b/packages/utils/src/bytearray.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (utils/bytearray.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (utils/src/bytearray.cairo)
 
 use core::byte_array::ByteArrayTrait;
 use core::hash::{HashStateExTrait, HashStateTrait};

--- a/packages/utils/src/cryptography/interface.cairo
+++ b/packages/utils/src/cryptography/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (utils/cryptography/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (utils/src/cryptography/interface.cairo)
 
 use starknet::ContractAddress;
 

--- a/packages/utils/src/cryptography/nonces.cairo
+++ b/packages/utils/src/cryptography/nonces.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (utils/cryptography/nonces.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (utils/src/cryptography/nonces.cairo)
 
 /// # Nonces Component
 ///

--- a/packages/utils/src/cryptography/snip12.cairo
+++ b/packages/utils/src/cryptography/snip12.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (utils/cryptography/snip12.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (utils/src/cryptography/snip12.cairo)
 
 use core::hash::{Hash, HashStateExTrait, HashStateTrait};
 use core::poseidon::{HashState, PoseidonTrait};

--- a/packages/utils/src/deployments.cairo
+++ b/packages/utils/src/deployments.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (utils/deployments.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (utils/src/deployments.cairo)
 
 pub mod interface;
 

--- a/packages/utils/src/deployments/interface.cairo
+++ b/packages/utils/src/deployments/interface.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (utils/deployments/interface.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (utils/src/deployments/interface.cairo)
 
 use starknet::{ClassHash, ContractAddress};
 

--- a/packages/utils/src/math.cairo
+++ b/packages/utils/src/math.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (utils/math.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (utils/src/math.cairo)
 
 use core::integer::u512_safe_div_rem_by_u256;
 use core::num::traits::WideMul;

--- a/packages/utils/src/serde.cairo
+++ b/packages/utils/src/serde.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (utils/serde.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (utils/src/serde.cairo)
 
 pub trait SerializedAppend<T> {
     fn append_serde(ref self: Array<felt252>, value: T);

--- a/packages/utils/src/structs/checkpoint.cairo
+++ b/packages/utils/src/structs/checkpoint.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.20.0 (utils/structs/checkpoint.cairo)
+// OpenZeppelin Contracts for Cairo v0.20.0 (utils/src/structs/checkpoint.cairo)
 
 use core::num::traits::Sqrt;
 use crate::math;


### PR DESCRIPTION
Fixes [#1106 ]

## Description

This PR updates the license header paths to include `src/` to match the new repository structure. For example:

```diff
- // OpenZeppelin Contracts for Cairo v0.20.0 (account/account.cairo)
+ // OpenZeppelin Contracts for Cairo v0.20.0 (account/src/account.cairo)
```

This is a straightforward documentation update to align license headers with the current repository structure. No functional changes are involved.