### PR TITLE
feature: add assert_valid_signature utility function

### DIFF
--- a/packages/account/src/extensions/src9/src9.cairo
+++ b/packages/account/src/extensions/src9/src9.cairo
@@ -13,6 +13,7 @@ pub mod SRC9Component {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin_utils::cryptography::snip12::{OffchainMessageHash, SNIP12Metadata};
+    use starknet::ContractAddress;
     use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess};
     use crate::extensions::src9::snip12_utils::OutsideExecutionStructHash;
     use crate::extensions::src9::{OutsideExecution, interface};
@@ -102,18 +103,10 @@ pub mod SRC9Component {
             let this = starknet::get_contract_address();
             let outside_tx_hash = outside_execution.get_message_hash(this);
 
-            // Make this component agnostic to the account implementation, as long
-            // as the contract implements the SRC6 interface.
-            let is_valid_signature_felt = ISRC6Dispatcher { contract_address: this }
-                .is_valid_signature(outside_tx_hash, signature.into());
+            // 5. Validate signature
+            self.assert_valid_signature(this, outside_tx_hash, signature);
 
-            // Check either 'VALID' or true for backwards compatibility.
-            let is_valid_signature = is_valid_signature_felt == starknet::VALIDATED
-                || is_valid_signature_felt == 1;
-
-            assert(is_valid_signature, Errors::INVALID_SIGNATURE);
-
-            // 5. Execute the calls
+            // 6. Execute the calls
             execute_calls(outside_execution.calls)
         }
 
@@ -140,6 +133,27 @@ pub mod SRC9Component {
         fn initializer(ref self: ComponentState<TContractState>) {
             let mut src5_component = get_dep_component_mut!(ref self, SRC5);
             src5_component.register_interface(interface::ISRC9_V2_ID);
+        }
+
+        /// Validates that a signature is valid for a given hash and account.
+        /// Checks if the signature is valid according to SRC6 standard.
+        /// Supports both the VALIDATED constant and the legacy "1" boolean value.
+        ///
+        /// Revert if the signature is invalid for the given hash and account
+        fn assert_valid_signature(
+            self: @ComponentState<TContractState>,
+            account: ContractAddress,
+            hash: felt252,
+            signature: Span<felt252>,
+        ) {
+            let is_valid_signature_felt = ISRC6Dispatcher { contract_address: account }
+                .is_valid_signature(hash, signature.into());
+
+            // Check either 'VALID' or true for backwards compatibility
+            let is_valid_signature = is_valid_signature_felt == starknet::VALIDATED
+                || is_valid_signature_felt == 1;
+
+            assert(is_valid_signature, Errors::INVALID_SIGNATURE);
         }
     }
 }

--- a/packages/governance/src/governor/governor.cairo
+++ b/packages/governance/src/governor/governor.cairo
@@ -633,14 +633,8 @@ pub mod GovernorComponent {
             let vote = Vote { verifying_contract, nonce, proposal_id, support, voter };
             let hash = vote.get_message_hash(voter);
 
-            let is_valid_signature_felt = ISRC6Dispatcher { contract_address: voter }
-                .is_valid_signature(hash, signature.into());
-
-            // 3. Check either 'VALID' or true for backwards compatibility
-            let is_valid_signature = is_valid_signature_felt == starknet::VALIDATED
-                || is_valid_signature_felt == 1;
-
-            assert(is_valid_signature, Errors::INVALID_SIGNATURE);
+            // 3. Validate signature
+            self.assert_valid_signature(voter, hash, signature);
 
             // 4. Cast vote
             self._cast_vote(proposal_id, voter, support, "", Immutable::DEFAULT_PARAMS())
@@ -679,14 +673,8 @@ pub mod GovernorComponent {
             };
             let hash = vote.get_message_hash(voter);
 
-            let is_valid_signature_felt = ISRC6Dispatcher { contract_address: voter }
-                .is_valid_signature(hash, signature.into());
-
-            // 3. Check either 'VALID' or true for backwards compatibility
-            let is_valid_signature = is_valid_signature_felt == starknet::VALIDATED
-                || is_valid_signature_felt == 1;
-
-            assert(is_valid_signature, Errors::INVALID_SIGNATURE);
+            // 3.Validate signature
+            self.assert_valid_signature(voter, hash, signature);
 
             // 4. Cast vote
             self._cast_vote(proposal_id, voter, support, reason, params)
@@ -840,6 +828,28 @@ pub mod GovernorComponent {
         fn assert_only_governance(self: @ComponentState<TContractState>) {
             let executor = self.executor();
             assert(executor == starknet::get_caller_address(), Errors::EXECUTOR_ONLY);
+        }
+
+
+        /// Validates that a signature is valid for a given hash and account.
+        /// Checks if the signature is valid according to SRC6 standard.
+        /// Supports both the VALIDATED constant and the legacy "1" boolean value.
+        ///
+        /// Revert if the signature is invalid for the given hash and account
+        fn assert_valid_signature(
+            self: @ComponentState<TContractState>,
+            account: ContractAddress,
+            hash: felt252,
+            signature: Span<felt252>,
+        ) {
+            let is_valid_signature_felt = ISRC6Dispatcher { contract_address: account }
+                .is_valid_signature(hash, signature.into());
+
+            // Check either 'VALID' or true for backwards compatibility
+            let is_valid_signature = is_valid_signature_felt == starknet::VALIDATED
+                || is_valid_signature_felt == 1;
+
+            assert(is_valid_signature, Errors::INVALID_SIGNATURE);
         }
 
         /// Validates that the proposal is in one of the expected states.


### PR DESCRIPTION
##Fixes [#1223]

## Overview
Adding an internal utility function `assert_valid_signature` to reduce code duplication in signature validation logic.

## Changes

```rust
// Before
let is_valid_signature_felt = ISRC6Dispatcher { contract_address: voter }
            .is_valid_signature(hash, signature.into());

// Check either 'VALID' or true for backwards compatibility
let is_valid_signature = is_valid_signature_felt == starknet::VALIDATED
            || is_valid_signature_felt == 1;

assert(is_valid_signature, Errors::INVALID_SIGNATURE);

// After
self.assert_valid_signature(account, hash, signature);
```

* Added new utility function `assert_valid_signature` to the `InternalTrait` implementation
* Updated external function to use the new utility function
* Maintains compatibility with both `starknet::VALIDATED` and legacy `1` values
* Ran full test suite and formatting checks:
   * ✅ `snforge test` - All tests passing
   * ✅ `scarb fmt -w --check` - Code formatting verified