### PR TITLE
deleted double space interface.cairo

### DIFF
--- a/packages/governance/src/governor/interface.cairo
+++ b/packages/governance/src/governor/interface.cairo
@@ -48,7 +48,7 @@ pub trait IGovernor<TState> {
     /// - `quorum=bravo` means that only For votes are counted towards quorum.
     /// - `quorum=for,abstain` means that both For and Abstain votes are counted towards quorum.
     ///
-    /// If a counting module makes use of encoded `params`, it should  include this under a `params`
+    /// If a counting module makes use of encoded `params`, it should include this under a `params`
     /// key with a unique name that describes the behavior. For example:
     ///
     /// - `params=fractional` might refer to a scheme where votes are divided fractionally between


### PR DESCRIPTION
packages/governance/src/governor/interface.cairo
should__include 