### PR TITLE
preposition fix and grammatical improvement 

### DIFF
--- a/packages/merkle_tree/src/merkle_proof.cairo
+++ b/packages/merkle_tree/src/merkle_proof.cairo
@@ -132,7 +132,7 @@ pub fn process_multi_proof<impl Hasher: CommutativeHasher>(
     let root = if proof_flags_len > 0 {
         hashes.at(proof_flags_len - 1)
     } else if leaves_len > 0 {
-        // If `proof_flags_len` is zero, and `leaves_len` is greater then zero,
+        // If `proof_flags_len` is zero, and `leaves_len` is greater than zero,
         // then `leaves_len` can only be 1, because of the proof validity check.
         leaves.at(0)
     } else {

--- a/packages/security/src/initializable.cairo
+++ b/packages/security/src/initializable.cairo
@@ -34,7 +34,7 @@ pub mod InitializableComponent {
     pub impl InternalImpl<
         TContractState, +HasComponent<TContractState>,
     > of InternalTrait<TContractState> {
-        /// Ensures the calling function can only be called once.
+        /// Ensures that the calling function can only be called once.
         ///
         /// Requirements:
         ///


### PR DESCRIPTION
This PR fixes grammatical errors in comments:

- In merkle_proof.cairo, the comment now correctly reads "greater than zero" instead of "greater then zero."

- In initializable.cairo, the comment has been updated to "Ensures that the calling function can only be called once." which improves the clarity.
