### PR TITLE
Fix broken links

### DIFF
--- a/packages/macros/README.md
+++ b/packages/macros/README.md
@@ -1,9 +1,9 @@
 ## Macros
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/1.0.0/api/macros](https://docs.openzeppelin.com/contracts-cairo/1.0.0/api/macros)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/1.0.0/access]([https://docs.openzeppelin.com/contracts-cairo/1.0.0/access]
 
 This crate provides a collection of macros that streamline and simplify development with the OpenZeppelin library.
 
 ### Attribute macros
 
-- [`with_components(..)`](https://docs.openzeppelin.com/contracts-cairo/1.0.0/api/macros#with_components)
+- [`with_components(..)`](https://docs.openzeppelin.com/contracts-cairo/1.0.0/access#with_components)


### PR DESCRIPTION
I found that the link to https://docs.openzeppelin.com/contracts-cairo/1.0.0/api/macros was broken. I have replaced it with https://docs.openzeppelin.com/contracts-cairo/1.0.0/access, which contains the same relevant content.

If there is a more appropriate link, please let me know, and I will update it accordingly.