### PR TITLE
Fix version and link in `audits/`

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -34,6 +34,7 @@ jobs:
         find . -type f -not -path '*/\.*' -not -path './CHANGELOG.md' -not -path './docs/package-lock.json' \
           -not -path './RELEASING.md' \
           -not -path './packages/testing/*' \
+          -not -path './audits/*' \
           -exec sed -i "s/$ESCAPED_CURRENT_VERSION/$NEW_VERSION/g" {} +
 
     - name: Setup scarb

--- a/audits/README.md
+++ b/audits/README.md
@@ -2,5 +2,5 @@
 
 | Date         | Version | Commit                                                                    | Auditor | Scope                                  | Links                      |
 | ------------ | ------- | ------------------------------------------------------------------------- | ------- | -------------------------------------- | -------------------------- |
-| January 2025 | v2.0.0-alpha.0  | [`3fdef27`](https://github.com/OpenZeppelin/cairo-contracts/tree/3fdef27) | Zellic  | Everything except `governance` package | [🔗](./2025-01-v2.0.0-alpha.0.pdf) |
-| January 2025 | v2.0.0-alpha.0  | [`79391c6`](https://github.com/OpenZeppelin/cairo-contracts/tree/79391c6) | Zellic  | `governance` package                   | [🔗](./2025-01-v2.0.0-alpha.0.pdf) |
+| January 2025 | v1.0.0  | [`3fdef27`](https://github.com/OpenZeppelin/cairo-contracts/tree/3fdef27) | Zellic  | Everything except `governance` package | [🔗](./2025-01-v1.0.0.pdf) |
+| January 2025 | v1.0.0  | [`79391c6`](https://github.com/OpenZeppelin/cairo-contracts/tree/79391c6) | Zellic  | `governance` package                   | [🔗](./2025-01-v1.0.0.pdf) |


### PR DESCRIPTION
This PR fixes the `audits/` version and link (back to v1). This PR also ignores the `audits/` dir in the CI version bump :)