### PR TITLE
correction link README.md

### DIFF
--- a/packages/account/README.md
+++ b/packages/account/README.md
@@ -5,7 +5,7 @@
 This crate provides components to implement account contracts that can be used for interacting with the network.
 
 - `Account` validates transactions from signatures over the
-[STARK Curve](https://docs.starknet.io/architecture-and-concepts/cryptography/stark-curve/).
+[STARK Curve](https://docs.starknet.io/architecture-and-concepts/cryptography/#the_stark_curve).
 
 - `EthAccount` validates transactions from signatures over the
 [Secp256k1 curve](https://en.bitcoin.it/wiki/Secp256k1).


### PR DESCRIPTION
docs: use canonical anchor link for STARK curve section

**Description**
- `.../cryptography/stark-curve/` → `.../cryptography/#the_stark_curve`