### PR TITLE
Fix broken link to macros documentation

### DIFF
--- a/packages/macros/README.md
+++ b/packages/macros/README.md
@@ -1,6 +1,6 @@
 ## Macros
 
-> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/2.0.0-alpha.0/macros](https://docs.openzeppelin.com/contracts-cairo/2.0.0-alpha.0/macros)
+> **NOTE:** This document is better viewed at [https://docs.openzeppelin.com/contracts-cairo/2.0.0-alpha.0/macros](https://docs.openzeppelin.com/contracts-cairo/2.0.0-alpha.0/api/macros)
 
 This crate provides a collection of macros that streamline and simplify development with the OpenZeppelin library.
 


### PR DESCRIPTION

Old link:
https://docs.openzeppelin.com/contracts-cairo/2.0.0-alpha.0/macros
This URL leads to a 404 Not Found page.

New link:
https://docs.openzeppelin.com/contracts-cairo/2.0.0-alpha.0/api/macros
This URL correctly links to the macros section in the documentation.