### PR TITLE
Fix broken Components chapter link

### DIFF
--- a/docs/modules/ROOT/pages/components.adoc
+++ b/docs/modules/ROOT/pages/components.adoc
@@ -3,7 +3,7 @@
 The following documentation provides reasoning and examples on how to use Contracts for Cairo components.
 
 :shamans-post: https://community.starknet.io/t/cairo-components/101136#components-1[Starknet Shamans post]
-:cairo-book: https://book.cairo-lang.org/ch99-01-05-00-components.html[Cairo book]
+:cairo-book: https://book.cairo-lang.org/ch103-02-00-composability-and-components.html[Cairo book]
 
 Starknet components are separate modules that contain storage, events, and implementations that can be integrated into a contract.
 Components themselves cannot be declared or deployed.


### PR DESCRIPTION
Hey team—noticed a dead link, replaced it with a working URL.

 https://book.cairo-lang.org/ch99-01-05-00-components.html - old link
 https://book.cairo-lang.org/ch103-02-00-composability-and-components.html - new link

- [x] Tests
- [x] Documentation
- [ ] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
