### PR TITLE
Replace broken OpenZeppelin reference

### DIFF
--- a/packages/governance/src/votes/votes.cairo
+++ b/packages/governance/src/votes/votes.cairo
@@ -20,7 +20,7 @@
 /// purpose, as shown in the following ERC20 example:
 ///
 /// See [the documentation]
-/// (https://docs.openzeppelin.com/contracts-cairo/1.0.0/governance/votes#usage)
+/// (https://docs.openzeppelin.com/contracts-cairo/2.0.0-alpha.1/governance/votes#usage)
 /// for examples and more details.
 #[starknet::component]
 pub mod VotesComponent {


### PR DESCRIPTION
Replace the broken link to OpenZeppelin Cairo governance documentation (2.0.0-alpha.1) with the working link to the current stable version (1.0.0) that contains equivalent content in the votes/usage section.

#### PR Checklist

- [ ] Tests
- [x] Documentation
- [ ] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
