### PR TITLE
More ERC-4626 hooks

### DIFF
--- a/docs/modules/ROOT/pages/api/erc20.adoc
+++ b/docs/modules/ROOT/pages/api/erc20.adoc
@@ -937,6 +937,8 @@ The component leverages traits to configure fees, limits, and decimals.
 [.sub-index#ERC4626Component-ERC4626HooksTrait]
 .ERC4626HooksTrait
 * xref:#ERC4626Component-before_withdraw[`++before_withdraw(self, assets, shares)++`]
+* xref:#ERC4626Component-after_withdraw[`++after_withdraw(self, assets, shares)++`]
+* xref:#ERC4626Component-before_deposit[`++before_deposit(self, assets, shares)++`]
 * xref:#ERC4626Component-after_deposit[`++after_deposit(self, assets, shares)++`]
 --
 
@@ -1128,6 +1130,22 @@ See the {mock-ex}.
 Hooks into xref:#ERC4626Component-_withdraw[_withdraw].
 
 Executes logic before burning shares and transferring assets.
+
+[.contract-item]
+[[ERC4626Component-after_withdraw]]
+==== `[.contract-item-name]#++after_withdraw++#++(ref self: ContractState, assets: u256, shares: u256)++` [.item-kind]#hook#
+
+Hooks into xref:#ERC4626Component-_withdraw[_withdraw].
+
+Executes logic after burning shares and transferring assets.
+
+[.contract-item]
+[[ERC4626Component-before_deposit]]
+==== `[.contract-item-name]#++before_deposit++#++(ref self: ContractState, assets: u256, shares: u256)++` [.item-kind]#hook#
+
+Hooks into xref:#ERC4626Component-_deposit[_deposit].
+
+Executes logic before transferring assets and minting shares.
 
 [.contract-item]
 [[ERC4626Component-after_deposit]]

--- a/packages/testing/docs/SUMMARY.md
+++ b/packages/testing/docs/SUMMARY.md
@@ -212,6 +212,8 @@
 
   - [events::EventSpyExt](./openzeppelin_testing-events-EventSpyExt.md)
 
+  - [EventSpyQueueDebug](./openzeppelin_testing-events-EventSpyQueueDebug.md)
+
   - [SerializedSigning](./openzeppelin_testing-signing-SerializedSigning.md)
 
 - [Impls](./impls.md)
@@ -219,6 +221,8 @@
   - [AsAddressImpl](./openzeppelin_testing-constants-AsAddressImpl.md)
 
   - [EventSpyQueueImpl](./openzeppelin_testing-events-EventSpyQueueImpl.md)
+
+  - [EventSpyQueueDebugImpl](./openzeppelin_testing-events-EventSpyQueueDebugImpl.md)
 
   - [StarkSerializedSigning](./openzeppelin_testing-signing-StarkSerializedSigning.md)
 

--- a/packages/testing/docs/impls.md
+++ b/packages/testing/docs/impls.md
@@ -4,6 +4,8 @@
 
 - [EventSpyQueueImpl](./openzeppelin_testing-events-EventSpyQueueImpl.md)
 
+- [EventSpyQueueDebugImpl](./openzeppelin_testing-events-EventSpyQueueDebugImpl.md)
+
 - [StarkSerializedSigning](./openzeppelin_testing-signing-StarkSerializedSigning.md)
 
 - [Secp256k1SerializedSigning](./openzeppelin_testing-signing-Secp256k1SerializedSigning.md)

--- a/packages/testing/docs/openzeppelin_testing-events-EventSpyQueueDebug.md
+++ b/packages/testing/docs/openzeppelin_testing-events-EventSpyQueueDebug.md
@@ -1,0 +1,26 @@
+# EventSpyQueueDebug
+
+Fully qualified path: `openzeppelin_testing::events::EventSpyQueueDebug`
+
+<pre><code class="language-rust">pub trait EventSpyQueueDebug</code></pre>
+
+## Trait functions
+
+### print_all_events
+
+Prints out all events remaining on the queue.
+
+Fully qualified path: `openzeppelin_testing::events::EventSpyQueueDebug::print_all_events`
+
+<pre><code class="language-rust">fn print_all_events(ref self: EventSpyQueue)</code></pre>
+
+
+### print_events_from
+
+Prints out events on the queue emitted from the given address.
+
+Fully qualified path: `openzeppelin_testing::events::EventSpyQueueDebug::print_events_from`
+
+<pre><code class="language-rust">fn print_events_from(ref self: EventSpyQueue, from_address: ContractAddress)</code></pre>
+
+

--- a/packages/testing/docs/openzeppelin_testing-events-EventSpyQueueDebugImpl.md
+++ b/packages/testing/docs/openzeppelin_testing-events-EventSpyQueueDebugImpl.md
@@ -1,0 +1,26 @@
+# EventSpyQueueDebugImpl
+
+Fully qualified path: `openzeppelin_testing::events::EventSpyQueueDebugImpl`
+
+<pre><code class="language-rust">pub impl EventSpyQueueDebugImpl of EventSpyQueueDebug</code></pre>
+
+## Impl functions
+
+### print_all_events
+
+Prints out all events remaining on the queue.
+
+Fully qualified path: `openzeppelin_testing::events::EventSpyQueueDebugImpl::print_all_events`
+
+<pre><code class="language-rust">fn print_all_events(ref self: EventSpyQueue)</code></pre>
+
+
+### print_events_from
+
+Prints out events on the queue emitted from the given address.
+
+Fully qualified path: `openzeppelin_testing::events::EventSpyQueueDebugImpl::print_events_from`
+
+<pre><code class="language-rust">fn print_events_from(ref self: EventSpyQueue, from_address: ContractAddress)</code></pre>
+
+

--- a/packages/testing/docs/openzeppelin_testing-events.md
+++ b/packages/testing/docs/openzeppelin_testing-events.md
@@ -14,7 +14,11 @@ Fully qualified path: `openzeppelin_testing::events`
 
 - [EventSpyExt](./openzeppelin_testing-events-EventSpyExt.md)
 
+- [EventSpyQueueDebug](./openzeppelin_testing-events-EventSpyQueueDebug.md)
+
 ## Impls
 
 - [EventSpyQueueImpl](./openzeppelin_testing-events-EventSpyQueueImpl.md)
+
+- [EventSpyQueueDebugImpl](./openzeppelin_testing-events-EventSpyQueueDebugImpl.md)
 

--- a/packages/testing/docs/traits.md
+++ b/packages/testing/docs/traits.md
@@ -12,5 +12,7 @@
 
 - [events::EventSpyExt](./openzeppelin_testing-events-EventSpyExt.md)
 
+- [EventSpyQueueDebug](./openzeppelin_testing-events-EventSpyQueueDebug.md)
+
 - [SerializedSigning](./openzeppelin_testing-signing-SerializedSigning.md)
 

--- a/packages/testing/src/events.cairo
+++ b/packages/testing/src/events.cairo
@@ -1,5 +1,6 @@
+use core::fmt::{Debug, Error, Formatter};
 use snforge_std::cheatcodes::events::Events;
-use snforge_std::{EventSpy, EventSpyTrait, EventsFilterTrait};
+use snforge_std::{Event, EventSpy, EventSpyTrait, EventsFilterTrait};
 use starknet::ContractAddress;
 
 /// A wrapper around the `EventSpy` structure to allow treating the events as a queue.
@@ -86,6 +87,71 @@ pub impl EventSpyQueueImpl of EventSpyExt {
     fn count_events_from(ref self: EventSpyQueue, from_address: ContractAddress) -> u32 {
         let events = self.get_events().emitted_by(from_address).events;
         events.len()
+    }
+}
+
+#[generate_trait]
+pub impl EventSpyDebugImpl of EventSpyDebug {
+    fn print_all_events(ref self: EventSpyQueue) {
+        let events = AllEventsInfo { events: self.get_events().events };
+        print!("{:?}", events);
+    }
+
+    fn print_events_from(ref self: EventSpyQueue, from_address: ContractAddress) {
+        let events = ContractEventsInfo { from_address, events: self.get_events().events };
+        print!("{:?}", events);
+    }
+}
+
+#[derive(Drop)]
+struct AllEventsInfo {
+    events: Array<(ContractAddress, Event)>,
+}
+
+impl DebugAllEventsInfo of Debug<AllEventsInfo> {
+    fn fmt(self: @AllEventsInfo, ref f: Formatter) -> Result<(), Error> {
+        let AllEventsInfo { events } = self;
+        writeln!(f, "Total of {} events emitted:", events.len())?;
+        let mut index = 0;
+        for (from_address, event) in events {
+            writeln!(f, "-----")?;
+            writeln!(f, "[{}]:", index)?;
+            writeln!(f, "From {:?}", *from_address)?;
+            DebugEvent::fmt(event, ref f)?;
+            // writeln!(f, "{:?}", event)?;
+            index += 1;
+        }
+        writeln!(f, "-----")
+    }
+}
+
+#[derive(Drop)]
+struct ContractEventsInfo {
+    from_address: ContractAddress,
+    events: Array<(ContractAddress, Event)>,
+}
+
+impl DebugContractEventsInfo of Debug<ContractEventsInfo> {
+    fn fmt(self: @ContractEventsInfo, ref f: Formatter) -> Result<(), Error> {
+        let ContractEventsInfo { from_address, events } = self;
+        writeln!(f, "Total of {} events emitted from {:?}:", events.len(), *from_address)?;
+        let mut index = 0;
+        for (_, event) in events {
+            writeln!(f, "-----")?;
+            writeln!(f, "[{}]:", index)?;
+            DebugEvent::fmt(event, ref f)?;
+            // writeln!(f, "{:?}", event)?;
+            index += 1;
+        }
+        writeln!(f, "-----")
+    }
+}
+
+impl DebugEvent of Debug<Event> {
+    fn fmt(self: @Event, ref f: Formatter) -> Result<(), Error> {
+        let Event { keys, data } = self.clone();
+        writeln!(f, "Keys: {:?}", keys)?;
+        writeln!(f, "Data: {:?}", data)
     }
 }
 

--- a/packages/testing/src/events.cairo
+++ b/packages/testing/src/events.cairo
@@ -92,11 +92,13 @@ pub impl EventSpyQueueImpl of EventSpyExt {
 
 #[generate_trait]
 pub impl EventSpyQueueDebugImpl of EventSpyQueueDebug {
+    /// Prints out all events remaining on the queue.
     fn print_all_events(ref self: EventSpyQueue) {
         let events = AllEventsInfo { events: self.get_events().events };
         print!("{:?}", events);
     }
 
+    /// Prints out events on the queue emitted from the given address.
     fn print_events_from(ref self: EventSpyQueue, from_address: ContractAddress) {
         let events = ContractEventsInfo {
             from_address, events: self.get_events().emitted_by(from_address).events,

--- a/packages/testing/src/events.cairo
+++ b/packages/testing/src/events.cairo
@@ -98,7 +98,9 @@ pub impl EventSpyDebugImpl of EventSpyDebug {
     }
 
     fn print_events_from(ref self: EventSpyQueue, from_address: ContractAddress) {
-        let events = ContractEventsInfo { from_address, events: self.get_events().events };
+        let events = ContractEventsInfo {
+            from_address, events: self.get_events().emitted_by(from_address).events,
+        };
         print!("{:?}", events);
     }
 }

--- a/packages/testing/src/events.cairo
+++ b/packages/testing/src/events.cairo
@@ -91,7 +91,7 @@ pub impl EventSpyQueueImpl of EventSpyExt {
 }
 
 #[generate_trait]
-pub impl EventSpyDebugImpl of EventSpyDebug {
+pub impl EventSpyQueueDebugImpl of EventSpyQueueDebug {
     fn print_all_events(ref self: EventSpyQueue) {
         let events = AllEventsInfo { events: self.get_events().events };
         print!("{:?}", events);
@@ -120,7 +120,6 @@ impl DebugAllEventsInfo of Debug<AllEventsInfo> {
             writeln!(f, "[{}]:", index)?;
             writeln!(f, "From {:?}", *from_address)?;
             DebugEvent::fmt(event, ref f)?;
-            // writeln!(f, "{:?}", event)?;
             index += 1;
         }
         writeln!(f, "-----")
@@ -142,7 +141,6 @@ impl DebugContractEventsInfo of Debug<ContractEventsInfo> {
             writeln!(f, "-----")?;
             writeln!(f, "[{}]:", index)?;
             DebugEvent::fmt(event, ref f)?;
-            // writeln!(f, "{:?}", event)?;
             index += 1;
         }
         writeln!(f, "-----")

--- a/packages/token/Scarb.toml
+++ b/packages/token/Scarb.toml
@@ -55,6 +55,7 @@ build-external-contracts = [
     "openzeppelin_test_common::mocks::erc4626::ERC4626OffsetMock",
     "openzeppelin_test_common::mocks::erc4626::ERC4626FeesMock",
     "openzeppelin_test_common::mocks::erc4626::ERC4626LimitsMock",
+    "openzeppelin_test_common::mocks::erc4626::ERC4626MockWithHooks",
     "openzeppelin_test_common::mocks::erc721::DualCaseERC721ReceiverMock",
     "openzeppelin_test_common::mocks::erc1155::DualCaseERC1155ReceiverMock",
     "openzeppelin_test_common::mocks::non_implementing::NonImplementingMock",

--- a/packages/token/src/erc20/extensions/erc4626/erc4626.cairo
+++ b/packages/token/src/erc20/extensions/erc4626/erc4626.cairo
@@ -222,6 +222,12 @@ pub mod ERC4626Component {
         /// Hooks into `InternalImpl::_withdraw`.
         /// Executes logic before burning shares and transferring assets.
         fn before_withdraw(ref self: ComponentState<TContractState>, assets: u256, shares: u256) {}
+        /// Hooks into `InternalImpl::_withdraw`.
+        /// Executes logic after burning shares and transferring assets.
+        fn after_withdraw(ref self: ComponentState<TContractState>, assets: u256, shares: u256) {}
+        /// Hooks into `InternalImpl::_deposit`.
+        /// Executes logic before transferring assets and minting shares.
+        fn before_deposit(ref self: ComponentState<TContractState>, assets: u256, shares: u256) {}
         /// Hooks into `InternalImpl::_deposit`.
         /// Executes logic after transferring assets and minting shares.
         fn after_deposit(ref self: ComponentState<TContractState>, assets: u256, shares: u256) {}
@@ -567,6 +573,9 @@ pub mod ERC4626Component {
             assets: u256,
             shares: u256,
         ) {
+            // Before deposit hook
+            Hooks::before_deposit(ref self, assets, shares);
+
             // Transfer assets first
             let this = starknet::get_contract_address();
             let asset_dispatcher = IERC20Dispatcher { contract_address: self.ERC4626_asset.read() };
@@ -618,6 +627,9 @@ pub mod ERC4626Component {
             assert(asset_dispatcher.transfer(receiver, assets), Errors::TOKEN_TRANSFER_FAILED);
 
             self.emit(Withdraw { sender: caller, receiver, owner, assets, shares });
+
+            // After withdraw hook
+            Hooks::after_withdraw(ref self, assets, shares);
         }
 
         /// Internal conversion function (from assets to shares) with support for `rounding`

--- a/packages/token/src/tests/erc4626/test_erc4626.cairo
+++ b/packages/token/src/tests/erc4626/test_erc4626.cairo
@@ -3,7 +3,9 @@ use openzeppelin_test_common::erc20::ERC20SpyHelpers;
 use openzeppelin_test_common::mocks::erc20::{
     IERC20ReentrantDispatcher, IERC20ReentrantDispatcherTrait, Type,
 };
-use openzeppelin_test_common::mocks::erc4626::{ERC4626LimitsMock, ERC4626Mock};
+use openzeppelin_test_common::mocks::erc4626::{
+    ERC4626LimitsMock, ERC4626Mock, ERC4626MockWithHooks,
+};
 use openzeppelin_testing as utils;
 use openzeppelin_testing::constants::{ALICE, BOB, NAME, OTHER, RECIPIENT, SPENDER, SYMBOL, ZERO};
 use openzeppelin_testing::{AsAddressTrait, EventSpyExt, EventSpyQueue as EventSpy, spy_events};
@@ -162,6 +164,20 @@ fn deploy_vault_limits(asset_address: ContractAddress) -> ERC4626ABIDispatcher {
     vault_calldata.append_serde(HOLDER);
 
     let contract_address = utils::declare_and_deploy("ERC4626LimitsMock", vault_calldata);
+    ERC4626ABIDispatcher { contract_address }
+}
+
+fn deploy_vault_with_hooks(asset_address: ContractAddress) -> ERC4626ABIDispatcher {
+    let no_shares = 0_u256;
+
+    let mut vault_calldata: Array<felt252> = array![];
+    vault_calldata.append_serde(VAULT_NAME());
+    vault_calldata.append_serde(VAULT_SYMBOL());
+    vault_calldata.append_serde(asset_address);
+    vault_calldata.append_serde(no_shares);
+    vault_calldata.append_serde(HOLDER);
+
+    let contract_address = utils::declare_and_deploy("ERC4626MockWithHooks", vault_calldata);
     ERC4626ABIDispatcher { contract_address }
 }
 
@@ -1604,6 +1620,82 @@ fn test_multiple_txs_part_2() {
 }
 
 //
+// Vault implementing all hooks
+//
+
+fn setup_vault_with_hooks() -> (IERC20ReentrantDispatcher, ERC4626ABIDispatcher) {
+    let mut asset = deploy_asset();
+    let mut vault = deploy_vault_with_hooks(asset.contract_address);
+
+    // Mint assets to HOLDER and approve vault
+    asset.unsafe_mint(HOLDER, Bounded::MAX / 2); // 50% of max
+    cheat_caller_address(asset.contract_address, HOLDER, CheatSpan::TargetCalls(1));
+    asset.approve(vault.contract_address, Bounded::MAX);
+
+    (asset, vault)
+}
+
+#[test]
+fn test_hooks_called_when_deposit() {
+    let (_, vault) = setup_vault_with_hooks();
+    let assets = parse_token(1);
+
+    // Deposit
+    let mut spy = spy_events();
+    cheat_caller_address(vault.contract_address, HOLDER, CheatSpan::TargetCalls(1));
+    let shares = vault.deposit(assets, RECIPIENT);
+
+    // Check hooks called
+    spy.assert_event_before_deposit(vault.contract_address, assets, shares);
+    spy.assert_event_after_deposit(vault.contract_address, assets, shares);
+}
+
+#[test]
+fn test_hooks_called_when_mint() {
+    let (_, vault) = setup_vault_with_hooks();
+    let shares = parse_share_offset(1);
+
+    // Mint
+    let mut spy = spy_events();
+    cheat_caller_address(vault.contract_address, HOLDER, CheatSpan::TargetCalls(1));
+    let assets = vault.mint(shares, RECIPIENT);
+
+    // Check hooks called
+    spy.assert_event_before_deposit(vault.contract_address, assets, shares);
+    spy.assert_event_after_deposit(vault.contract_address, assets, shares);
+}
+
+#[test]
+fn test_hooks_called_when_withdraw() {
+    let (_, vault) = setup_vault_with_hooks();
+    let assets = 0;
+
+    // Withdraw
+    let mut spy = spy_events();
+    cheat_caller_address(vault.contract_address, HOLDER, CheatSpan::TargetCalls(1));
+    let shares = vault.withdraw(assets, RECIPIENT, HOLDER);
+
+    // Check hooks called
+    spy.assert_event_before_withdraw(vault.contract_address, assets, shares);
+    spy.assert_event_after_withdraw(vault.contract_address, assets, shares);
+}
+
+#[test]
+fn test_hooks_called_when_redeem() {
+    let (_, vault) = setup_vault_with_hooks();
+    let shares = 0;
+
+    // Redeem
+    let mut spy = spy_events();
+    cheat_caller_address(vault.contract_address, HOLDER, CheatSpan::TargetCalls(1));
+    let assets = vault.redeem(shares, RECIPIENT, HOLDER);
+
+    // Check hooks called
+    spy.assert_event_before_withdraw(vault.contract_address, assets, shares);
+    spy.assert_event_after_withdraw(vault.contract_address, assets, shares);
+}
+
+//
 // Assertions/Helpers
 //
 
@@ -1673,5 +1765,44 @@ pub impl ERC4626SpyHelpersImpl of ERC4626SpyHelpers {
     ) {
         self.assert_event_withdraw(contract, sender, receiver, owner, assets, shares);
         self.assert_no_events_left_from(contract);
+    }
+}
+
+#[generate_trait]
+impl ERC4626HooksSpyHelpersImpl of ERC4626HooksSpyHelpers {
+    fn assert_event_before_deposit(
+        ref self: EventSpy, contract: ContractAddress, assets: u256, shares: u256,
+    ) {
+        let expected = ERC4626MockWithHooks::Event::BeforeDeposit(
+            ERC4626MockWithHooks::BeforeDeposit { assets, shares },
+        );
+        self.assert_emitted_single(contract, expected);
+    }
+
+    fn assert_event_after_deposit(
+        ref self: EventSpy, contract: ContractAddress, assets: u256, shares: u256,
+    ) {
+        let expected = ERC4626MockWithHooks::Event::AfterDeposit(
+            ERC4626MockWithHooks::AfterDeposit { assets, shares },
+        );
+        self.assert_emitted_single(contract, expected);
+    }
+
+    fn assert_event_before_withdraw(
+        ref self: EventSpy, contract: ContractAddress, assets: u256, shares: u256,
+    ) {
+        let expected = ERC4626MockWithHooks::Event::BeforeWithdraw(
+            ERC4626MockWithHooks::BeforeWithdraw { assets, shares },
+        );
+        self.assert_emitted_single(contract, expected);
+    }
+
+    fn assert_event_after_withdraw(
+        ref self: EventSpy, contract: ContractAddress, assets: u256, shares: u256,
+    ) {
+        let expected = ERC4626MockWithHooks::Event::AfterWithdraw(
+            ERC4626MockWithHooks::AfterWithdraw { assets, shares },
+        );
+        self.assert_emitted_single(contract, expected);
     }
 }


### PR DESCRIPTION
### Fixes [#1445](https://github.com/OpenZeppelin/cairo-contracts/issues/1445)
---
### Apart from that, introduces 2 test utils functions to make debugging events more friendly:
1. `spy.print_all_events()`
2. `spy.print_events_from(from_address)`

An example of the ouput:
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/7b3757e3-94cb-4c3f-b86c-b89448364396" />