### PR TITLE
chore: fix 404 link udc.adoc

### DIFF
--- a/docs/modules/ROOT/pages/udc.adoc
+++ b/docs/modules/ROOT/pages/udc.adoc
@@ -5,7 +5,7 @@
 :udc-proposal: link:https://community.starknet.io/t/universal-deployer-contract-proposal/1864[Universal Deployer Contract proposal]
 :deploy_contract: xref:/api/udc.adoc#UniversalDeployer-deploy_contract[deploy_contract]
 :contract-deployed: xref:/api/udc.adoc#IUniversalDeployer-ContractDeployed[ContractDeployed]
-:previous-udc-api: https://docs.starknet.io/architecture-and-concepts/accounts/universal-deployer/
+:previous-udc-api: https://docs.starknet.io/architecture-and-concepts/accounts/#using-the-universal-deployer-contract
 
 The Universal Deployer Contract (UDC) is a singleton smart contract that wraps the {deploy-syscall} to expose it to any contract that doesn't implement it, such as account contracts. You can think of it as a standardized generic factory for Starknet contracts.
 


### PR DESCRIPTION
Fixes a broken documentation link to the "Universal Deployer Contract" section in StarkNet docs

https://docs.starknet.io/architecture-and-concepts/accounts/universal-deployer/ - 404 link
https://docs.starknet.io/architecture-and-concepts/accounts/#using-the-universal-deployer-contract - new link

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [ ] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
