### PR TITLE
Fix: Update OpenZeppelin Cairo contracts link

### DIFF
--- a/docs/modules/ROOT/pages/api/access.adoc
+++ b/docs/modules/ROOT/pages/api/access.adoc
@@ -1092,7 +1092,7 @@ Emitted when a {pending_default_admin_delay} is reset if its schedule didn't pas
 
 [.contract]
 [[AccessControlDefaultAdminRulesComponent]]
-=== `++AccessControlDefaultAdminRulesComponent++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v2.0.0/packages/access/src/accesscontrol/extensions/accesscontrol_default_admin_rules.cairo[{github-icon},role=heading-link]
+=== `++AccessControlDefaultAdminRulesComponent++` link:https://github.com/OpenZeppelin/cairo-contracts/blob/main/packages/access/src/accesscontrol/extensions/accesscontrol_default_admin_rules.cairo[{github-icon},role=heading-link]
 
 ```cairo
 use openzeppelin_access::accesscontrol::extensions::AccessControlDefaultAdminRulesComponent;


### PR DESCRIPTION
The original link to the AccessControlDefaultAdminRules contract was pointing to a non-existent branch (release-v2.0.0). Updated the link to reference the main branch which contains the current implementation of the contract.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
