### PR TITLE
Fix macros linting

### DIFF
--- a/packages/macros/src/attribute/type_hash/definition.rs
+++ b/packages/macros/src/attribute/type_hash/definition.rs
@@ -115,8 +115,7 @@ fn parse_args(s: &str) -> Result<TypeHashArgs, Diagnostic> {
     let allowed_args_re = allowed_args.join("|");
 
     let re = Regex::new(&format!(
-        r#"^\(({}): ([\w"' ])+(?:, ({}): ([\w"' ])+)*\)$"#,
-        allowed_args_re, allowed_args_re
+        r#"^\(({allowed_args_re}): ([\w"' ])+(?:, ({allowed_args_re}): ([\w"' ])+)*\)$"#
     ))
     .unwrap();
 
@@ -131,7 +130,7 @@ fn parse_args(s: &str) -> Result<TypeHashArgs, Diagnostic> {
                 "name" => args.name = parse_string_arg(value)?,
                 "debug" => args.debug = value == "true",
                 // This should be unreachable as long as the regex is correct
-                _ => panic!("Invalid argument: {}", name),
+                _ => panic!("Invalid argument: {name}"),
             }
         }
         Ok(args)

--- a/packages/macros/src/attribute/type_hash/parser.rs
+++ b/packages/macros/src/attribute/type_hash/parser.rs
@@ -94,7 +94,7 @@ impl<'a> TypeHashParser<'a> {
             // Format the member depending on the type variant
             match self.plugin_type_info.type_variant {
                 TypeVariant::Struct => {
-                    encoded_type.push_str(&format!("\"{}\":\"{}\",", name, type_name))
+                    encoded_type.push_str(&format!("\"{name}\":\"{type_name}\","))
                 }
                 TypeVariant::Enum => {
                     encoded_type.push_str(&format!("\"{}\"({}),", name, maybe_tuple(&type_name)))
@@ -203,8 +203,7 @@ fn parse_snip12_args(s: &str) -> Result<Snip12Args, Diagnostic> {
     let allowed_args_re = allowed_args.join("|");
 
     let re = Regex::new(&format!(
-        r#"^\(({}): ([\w"'\(\),<> ])+(?:, ({}): ([\w"'\(\),<> ])+)*\)$"#,
-        allowed_args_re, allowed_args_re
+        r#"^\(({allowed_args_re}): ([\w"'\(\),<> ])+(?:, ({allowed_args_re}): ([\w"'\(\),<> ])+)*\)$"#
     ))
     .unwrap();
 
@@ -225,7 +224,7 @@ fn parse_snip12_args(s: &str) -> Result<Snip12Args, Diagnostic> {
                 "name" => args.name = parse_string_arg(value)?,
                 "kind" => args.kind = parse_string_arg(value)?,
                 // This should be unreachable as long as the regex is correct
-                _ => panic!("Invalid argument: {}", name),
+                _ => panic!("Invalid argument: {name}"),
             };
         }
         Ok(args)
@@ -261,6 +260,6 @@ fn maybe_tuple(s: &str) -> String {
             .collect::<Vec<_>>()
             .join(",")
     } else {
-        format!("\"{}\"", s)
+        format!("\"{s}\"")
     }
 }

--- a/packages/macros/src/attribute/type_hash/types.rs
+++ b/packages/macros/src/attribute/type_hash/types.rs
@@ -320,7 +320,7 @@ pub fn split_types(s: &str) -> Vec<&str> {
     let mut start = 0;
     let mut paren_count = 0;
 
-    for (i, c) in s.chars().enumerate() {
+    for (i, c) in s.char_indices() {
         match c {
             '(' => paren_count += 1,
             ')' => paren_count -= 1,

--- a/packages/macros/src/attribute/with_components/diagnostics.rs
+++ b/packages/macros/src/attribute/with_components/diagnostics.rs
@@ -11,9 +11,7 @@ pub mod errors {
     }
     /// Error when the module has no `#[starknet::contract]` attribute.
     pub fn NO_CONTRACT_ATTRIBUTE(contract_attribute: &str) -> String {
-        format!(
-            "Contract module must have the `#[{contract_attribute}]` attribute.\n"
-        )
+        format!("Contract module must have the `#[{contract_attribute}]` attribute.\n")
     }
 }
 

--- a/packages/macros/src/attribute/with_components/diagnostics.rs
+++ b/packages/macros/src/attribute/with_components/diagnostics.rs
@@ -7,13 +7,12 @@ pub mod errors {
 
     /// Error when the component is invalid.
     pub fn INVALID_COMPONENT(short_name: &str) -> String {
-        format!("{} is not in the list of allowed components.\n", short_name)
+        format!("{short_name} is not in the list of allowed components.\n")
     }
     /// Error when the module has no `#[starknet::contract]` attribute.
     pub fn NO_CONTRACT_ATTRIBUTE(contract_attribute: &str) -> String {
         format!(
-            "Contract module must have the `#[{}]` attribute.\n",
-            contract_attribute
+            "Contract module must have the `#[{contract_attribute}]` attribute.\n"
         )
     }
 }

--- a/packages/macros/src/attribute/with_components/parser.rs
+++ b/packages/macros/src/attribute/with_components/parser.rs
@@ -168,7 +168,7 @@ fn validate_contract_module(
                 .strip_suffix(&component.name)
                 .expect("Component path must end with the component name");
             let re = Regex::new(&format!(
-                r"use {component_parent_path}[{{\w, \n]*DefaultConfig[{{\w}}, \n]*;"  
+                r"use {component_parent_path}[{{\w, \n]*DefaultConfig[{{\w}}, \n]*;"
             ))
             .unwrap();
 

--- a/packages/macros/src/attribute/with_components/parser.rs
+++ b/packages/macros/src/attribute/with_components/parser.rs
@@ -168,8 +168,7 @@ fn validate_contract_module(
                 .strip_suffix(&component.name)
                 .expect("Component path must end with the component name");
             let re = Regex::new(&format!(
-                r"use {}[{{\w, \n]*DefaultConfig[{{\w}}, \n]*;",
-                component_parent_path
+                r"use {component_parent_path}[{{\w, \n]*DefaultConfig[{{\w}}, \n]*;"  
             ))
             .unwrap();
 
@@ -180,7 +179,7 @@ fn validate_contract_module(
                 if !immutable_config_implemented {
                     let warning = Diagnostic::warn(warnings::IMMUTABLE_CONFIG_MISSING(
                         component.short_name(),
-                        &format!("{}DefaultConfig", component_parent_path),
+                        &format!("{component_parent_path}DefaultConfig"),
                     ));
                     warnings.push(warning);
                 }

--- a/packages/macros/src/with_components.rs
+++ b/packages/macros/src/with_components.rs
@@ -224,7 +224,7 @@ fn validate_contract_module(
                 .path
                 .strip_suffix(&component.name)
                 .expect("Component path must end with the component name");
-            let default_config_path = format!("{}DefaultConfig", component_parent_path);
+            let default_config_path = format!("{component_parent_path}DefaultConfig");
             let default_config_used = code.contains(&default_config_path);
             if !default_config_used {
                 // Check if the ImmutableConfig is implemented


### PR DESCRIPTION
The latest version of `clippy` generated several warnings and 1 error that led to failing workflows.

## Changes:
- One issue with string indexing was fixed
- several `format!` function calls were updated to the recommended approach of using variables directly in the format string

<img width="873" alt="image" src="https://github.com/user-attachments/assets/1c32396c-15c6-4233-a5a6-5e0d06646e43" />