### PR TITLE
Allow custom total assets logic in ERC4626

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -189,15 +189,15 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:3525e4502541043571678531fced28f753746cb59a8aa79811811218abef6c05"
+checksum = "sha256:8630dcf3fa4df36a3d45e6a2d053cf84c548ab154e829fece99373ae5852921c"
 
 [[package]]
 name = "snforge_std"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:b8647adcd0f5c9631f88b5a523b2653a82f2349dde2af7213c75f1006fa3f71b"
+checksum = "sha256:981139c83359089540652c44f4a1a888c77409eedaa148377927cc63a604b67b"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -45,7 +45,7 @@ keywords = [
 [workspace.dependencies]
 assert_macros = "2.12.0"
 starknet = "2.12.0"
-snforge_std = "0.47.0"
+snforge_std = "0.48.0"
 
 [dependencies]
 starknet.workspace = true

--- a/packages/token/Scarb.toml
+++ b/packages/token/Scarb.toml
@@ -53,6 +53,7 @@ build-external-contracts = [
     "openzeppelin_test_common::mocks::account::DualCaseAccountMock",
     "openzeppelin_test_common::mocks::erc20::ERC20ReentrantMock",
     "openzeppelin_test_common::mocks::erc4626::ERC4626Mock",
+    "openzeppelin_test_common::mocks::erc4626::ERC4626TotalAssetsMock",
     "openzeppelin_test_common::mocks::erc4626::ERC4626OffsetMock",
     "openzeppelin_test_common::mocks::erc4626::ERC4626FeesMock",
     "openzeppelin_test_common::mocks::erc4626::ERC4626LimitsMock",

--- a/packages/token/src/erc20/extensions/erc4626.cairo
+++ b/packages/token/src/erc20/extensions/erc4626.cairo
@@ -1,5 +1,5 @@
 pub mod erc4626;
 pub use erc4626::{
     DefaultConfig, ERC4626Component, ERC4626DefaultLimits, ERC4626DefaultNoFees,
-    ERC4626HooksEmptyImpl,
+    ERC4626DefaultTotalAssets, ERC4626HooksEmptyImpl,
 };

--- a/packages/token/src/erc20/extensions/erc4626/erc4626.cairo
+++ b/packages/token/src/erc20/extensions/erc4626/erc4626.cairo
@@ -719,7 +719,9 @@ pub impl DefaultConfig of ERC4626Component::ImmutableConfig {
 mod Test {
     use openzeppelin_test_common::mocks::erc4626::ERC4626Mock;
     use super::ERC4626Component::InternalImpl;
-    use super::{ERC4626Component, ERC4626DefaultLimits, ERC4626DefaultNoFees};
+    use super::{
+        ERC4626Component, ERC4626DefaultLimits, ERC4626DefaultNoFees, ERC4626DefaultTotalAssets,
+    };
 
     type ComponentState = ERC4626Component::ComponentState<ERC4626Mock::ContractState>;
 


### PR DESCRIPTION
Extract total_assets implementation into ERC4626TotalAssetsTrait to enable contracts to implement their own asset calculation logic while providing a default implementation that maintains existing behavior.
