### PR TITLE
fix: crash when comparing metrics with None values

### DIFF
--- a/scripts/benchmarking/benchmark_diff.py
+++ b/scripts/benchmarking/benchmark_diff.py
@@ -67,8 +67,8 @@ def color_name(name):
 def compare_subdicts(old, new, metric):
     all_files = set(old.keys()) | set(new.keys())
     for file in sorted(all_files):
-        old_val = old.get(file, {}).get(metric)
-        new_val = new.get(file, {}).get(metric)
+        old_val = (old.get(file) or {}).get(metric)
+        new_val = (new.get(file) or {}).get(metric)
         file_name = color_name(try_get_name(file))
         if old_val is None and new_val is not None:
             value = f"{GREEN}{metric} = {new_val}{RESET}"
@@ -113,8 +113,8 @@ def markdown_subtable(old, new, metric, show_unchanged=False):
     # Data rows
     for file in all_files:
         name = try_get_name(file)
-        old_val = old.get(file, {}).get(metric)
-        new_val = new.get(file, {}).get(metric)
+        old_val = (old.get(file) or {}).get(metric)
+        new_val = (new.get(file) or {}).get(metric)
 
         if old_val is None and new_val is not None:
             delta = f"+{new_val}"


### PR DESCRIPTION
updated `compare_subdicts` and `markdown_subtable` to safely handle cases where `old[file]` or `new[file]` might be `None`.
using `(old.get(file) or {}).get(metric)` and `(new.get(file) or {}).get(metric)` prevents `AttributeError` and ensures the comparison works reliably.


#### PR Checklist

- [x] Tests
- [ ] Documentation
- [ ] Added entry to CHANGELOG.md <!-- [learn how](https://keepachangelog.com/en/1.1.0/) -->
- [ ] Tried the feature on a public network <!-- Please share some tx link or proof to confirm proper behavior. -->
