### PR TITLE
ci: bump actions/checkout to v6

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -9,7 +9,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Add problem matchers
         run: echo "::add-matcher::.github/actionlint-matcher.json"
       - uses: docker://rhysd/actionlint:latest

--- a/.github/workflows/benchmark-diff-comment.yml
+++ b/.github/workflows/benchmark-diff-comment.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # 1. Check out the PR branch so we can build and benchmark it
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       # 2. Extract the required Scarb version from Scarb.toml and save to env
       - name: Extract scarb version

--- a/.github/workflows/benchmark-diff-pr.yml
+++ b/.github/workflows/benchmark-diff-pr.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # 1. Check out the repository at the merge commit
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       # 2. Use Rust cache (speeds up builds in repeated runs)
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Extract current versions
       run: |

--- a/.github/workflows/prepare-testing-release.yml
+++ b/.github/workflows/prepare-testing-release.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Extract current version
       working-directory: ./packages/testing

--- a/.github/workflows/test-macros.yml
+++ b/.github/workflows/test-macros.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint and test macros
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint and test Cairo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Extract scarb version
         run: |

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check for typos
         uses: crate-ci/typos@626c4bedb751ce0b7f03262ca97ddda9a076ae1c


### PR DESCRIPTION
Bumps to v6 for Node.js 24 support. Requires runner v2.329.0+.

https://github.com/actions/checkout/releases/tag/v6.0.0