### PR TITLE
Bump Scarb to `2.17.0`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,11 +50,13 @@ jobs:
       - name: Run tests
         run: snforge test --workspace --features fuzzing --fuzzer-runs 200
 
-      - name: Run tests and generate coverage report
-        run: snforge test --workspace --coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
-        with:
-          file: ./coverage.lcov
-          token: ${{ secrets.CODECOV_TOKEN }}
+      # TODO: Uncomment once a cairo-coverage version compatible with Scarb 2.17.0 is released.
+      # The latest cairo-coverage (0.6.0) does not support Scarb 2.17.0.
+      # - name: Run tests and generate coverage report
+      #   run: snforge test --workspace --coverage
+      #
+      # - name: Upload coverage to Codecov
+      #   uses: codecov/codecov-action@v6
+      #   with:
+      #     file: ./coverage.lcov
+      #     token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ERC-3156 standard interfaces and `ERC20FlashMintComponent` extension (#1608)
 
+## Changed
+
+- Bump scarb to v2.17.0 (#1672)
+
 ## 4.0.0-alpha.0 (2026-01-31)
 
 ### Added

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -27,8 +27,8 @@ edition.workspace = true
 [workspace.package]
 version = "4.0.0-alpha.0"
 edition = "2024_07"
-cairo-version = "2.15.0"
-scarb-version = "2.15.1"
+cairo-version = "2.17.0"
+scarb-version = "2.17.0"
 authors = ["OpenZeppelin Community <maintainers@openzeppelin.org>"]
 description = "OpenZeppelin Contracts written in Cairo for Starknet, a decentralized ZK Rollup"
 documentation = "https://docs.openzeppelin.com/contracts-cairo"
@@ -43,8 +43,8 @@ keywords = [
 ]
 
 [workspace.dependencies]
-assert_macros = "2.15.1"
-starknet = "2.15.1"
+assert_macros = "2.17.0"
+starknet = "2.17.0"
 snforge_std = "0.58.1"
 
 [dependencies]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cairo toolchain to version 2.17.0
  * Updated Scarb toolchain to version 2.17.0
  * Updated assert_macros and starknet dependencies to version 2.17.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->