### PR TITLE
Release openzeppelin_testing `v6.7.0`

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_testing"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "snforge_std",
 ]

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -190,15 +190,15 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.58.1"
+version = "0.59.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:c3ce76f0159e7752e6322966f4022f36b801128cc02a9835ceb5f89696ca5dca"
+checksum = "sha256:871fba677c03b66a1bf40815dac0ab1b385eb1b9be6e6c3cf2ad9788eeb2b6bb"
 
 [[package]]
 name = "snforge_std"
-version = "0.58.1"
+version = "0.59.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:4310803d74ef0c4f76ceba75e88d5c2621ff8b3490cfe5250ed7321de976474d"
+checksum = "sha256:3620924fa08bd2d740b2b5b01ef86c8dab3d4b9c2206387c8dbdc8d2ec15133e"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -45,7 +45,7 @@ keywords = [
 [workspace.dependencies]
 assert_macros = "2.15.1"
 starknet = "2.15.1"
-snforge_std = "0.58.1"
+snforge_std = "0.59.0"
 
 [dependencies]
 starknet.workspace = true

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.7.0 (2026-04-21)
+
+- Bump snforge to v0.59.0 (#1673)
+
 ## 6.6.0 (2026-04-01)
 
 - Bump snforge to v0.58.1 (#1666)

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -13,7 +13,7 @@ separate dependency in the Scarb.toml file:
 
 ```cairo
 [dev-dependencies]
-openzeppelin_testing = "6.6.0"
+openzeppelin_testing = "6.7.0"
 ```
 
 Then it can be imported into tests:
@@ -24,5 +24,5 @@ use openzeppelin_testing;
 
 ### API documentation
 
-- [Index](https://github.com/OpenZeppelin/cairo-contracts/blob/openzeppelin_testing-v6.6.0/packages/testing/docs/openzeppelin_testing.md)
-- [Summary](https://github.com/OpenZeppelin/cairo-contracts/blob/openzeppelin_testing-v6.6.0/packages/testing/docs/SUMMARY.md)
+- [Index](https://github.com/OpenZeppelin/cairo-contracts/blob/openzeppelin_testing-v6.7.0/packages/testing/docs/openzeppelin_testing.md)
+- [Summary](https://github.com/OpenZeppelin/cairo-contracts/blob/openzeppelin_testing-v6.7.0/packages/testing/docs/SUMMARY.md)

--- a/packages/testing/Scarb.toml
+++ b/packages/testing/Scarb.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openzeppelin_testing"
-version = "6.6.0"
+version = "6.7.0"
 readme = "README.md"
 keywords = [
     "openzeppelin",
@@ -13,7 +13,7 @@ cairo-version.workspace = true
 scarb-version.workspace = true
 authors.workspace = true
 description.workspace = true
-documentation = "https://github.com/openzeppelin/cairo-contracts/blob/openzeppelin_testing-v6.6.0/packages/testing/docs/openzeppelin_testing.md"
+documentation = "https://github.com/openzeppelin/cairo-contracts/blob/openzeppelin_testing-v6.7.0/packages/testing/docs/openzeppelin_testing.md"
 repository.workspace = true
 license-file.workspace = true
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the testing library version to 6.7.0
  * Bumped snforge standard library dependency to version 0.59.0

* **Documentation**
  * Updated README to reflect new version 6.7.0
  * Updated API documentation links to latest release references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->