### PR TITLE
Improve ERC-6909

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - ERC-3156 standard interfaces and `ERC20FlashMintComponent` extension (#1608)
+- `IERC6909MetadataAdmin` and `IERC6909ContentUriAdmin` interfaces to `openzeppelin_interfaces::token::erc6909`.
+- Embeddable Ownable, AccessControl, and AccessControlDefaultAdminRules admin impls for `ERC6909MetadataComponent` and `ERC6909ContentURIComponent`.
 
 ### Changed (Breaking)
 
 - Simplified `ERC6909MetadataComponent.initializer` to only register the SRC5 interface, matching the other ERC-6909 extensions.
+- Renamed `ERC6909MetadataComponent` internal setters to `_set_token_name`, `_set_token_symbol`, and `_set_token_decimals`.
+- Renamed `ERC6909ContentURIComponent` internal setters to `_set_contract_uri` and `_set_token_uri`.
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - ERC-3156 standard interfaces and `ERC20FlashMintComponent` extension (#1608)
-- `IERC6909MetadataAdmin` and `IERC6909ContentUriAdmin` interfaces to `openzeppelin_interfaces::token::erc6909`.
-- Embeddable Ownable, AccessControl, and AccessControlDefaultAdminRules admin impls for `ERC6909MetadataComponent` and `ERC6909ContentURIComponent`.
+- `IERC6909MetadataAdmin` and `IERC6909ContentUriAdmin` interfaces to `openzeppelin_interfaces::token::erc6909` (#1676)
+- Embeddable Ownable, AccessControl, and AccessControlDefaultAdminRules admin impls for `ERC6909MetadataComponent` and `ERC6909ContentURIComponent` (#1676)
 
 ### Changed (Breaking)
 
-- Simplified `ERC6909MetadataComponent.initializer` to only register the SRC5 interface, matching the other ERC-6909 extensions.
-- Renamed `ERC6909MetadataComponent` internal setters to `_set_token_name`, `_set_token_symbol`, and `_set_token_decimals`.
-- Renamed `ERC6909ContentURIComponent` internal setters to `_set_contract_uri` and `_set_token_uri`.
+- Simplified `ERC6909MetadataComponent.initializer` to only register the SRC5 interface, matching the other ERC-6909 extensions. (#1676)
+- Renamed `ERC6909MetadataComponent` internal setters to `_set_token_name`, `_set_token_symbol`, and `_set_token_decimals` (#1676)
+- Renamed `ERC6909ContentURIComponent` internal setters to `_set_contract_uri` and `_set_token_uri` (#1676)
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ERC-3156 standard interfaces and `ERC20FlashMintComponent` extension (#1608)
 
+### Changed (Breaking)
+
+- Simplified `ERC6909MetadataComponent.initializer` to only register the SRC5 interface, matching the other ERC-6909 extensions.
+
 ## Changed
 
 - Bump scarb to v2.17.0 (#1672)

--- a/packages/interfaces/src/token/erc6909.cairo
+++ b/packages/interfaces/src/token/erc6909.cairo
@@ -53,12 +53,21 @@ pub trait ERC6909ABI<TState> {
     fn symbol(self: @TState, id: u256) -> ByteArray;
     fn decimals(self: @TState, id: u256) -> u8;
 
+    // IERC6909MetadataAdmin
+    fn set_token_name(ref self: TState, id: u256, name: ByteArray);
+    fn set_token_symbol(ref self: TState, id: u256, symbol: ByteArray);
+    fn set_token_decimals(ref self: TState, id: u256, decimals: u8);
+
     // IERC6909TokenSupply
     fn total_supply(self: @TState, id: u256) -> u256;
 
     // IERC6909ContentUri
     fn contract_uri(self: @TState) -> ByteArray;
     fn token_uri(self: @TState, id: u256) -> ByteArray;
+
+    // IERC6909ContentUriAdmin
+    fn set_contract_uri(ref self: TState, contract_uri: ByteArray);
+    fn set_token_uri(ref self: TState, id: u256, token_uri: ByteArray);
 }
 
 //
@@ -70,6 +79,19 @@ pub trait IERC6909Metadata<TState> {
     fn name(self: @TState, id: u256) -> ByteArray;
     fn symbol(self: @TState, id: u256) -> ByteArray;
     fn decimals(self: @TState, id: u256) -> u8;
+}
+
+/// Interface providing external admin functions for managing the metadata of ERC6909 component.
+#[starknet::interface]
+pub trait IERC6909MetadataAdmin<TState> {
+    /// Sets the name for the token of type `id`.
+    fn set_token_name(ref self: TState, id: u256, name: ByteArray);
+
+    /// Sets the symbol for the token of type `id`.
+    fn set_token_symbol(ref self: TState, id: u256, symbol: ByteArray);
+
+    /// Sets the decimals for the token of type `id`.
+    fn set_token_decimals(ref self: TState, id: u256, decimals: u8);
 }
 
 //
@@ -89,4 +111,14 @@ pub trait IERC6909TokenSupply<TState> {
 pub trait IERC6909ContentUri<TState> {
     fn contract_uri(self: @TState) -> ByteArray;
     fn token_uri(self: @TState, id: u256) -> ByteArray;
+}
+
+/// Interface providing external admin functions for managing the content URIs of ERC6909 component.
+#[starknet::interface]
+pub trait IERC6909ContentUriAdmin<TState> {
+    /// Sets the contract-level URI.
+    fn set_contract_uri(ref self: TState, contract_uri: ByteArray);
+
+    /// Sets the URI for the token of type `id`.
+    fn set_token_uri(ref self: TState, id: u256, token_uri: ByteArray);
 }

--- a/packages/test_common/src/erc6909.cairo
+++ b/packages/test_common/src/erc6909.cairo
@@ -90,3 +90,74 @@ pub impl ERC6909SpyHelpersImpl of ERC6909SpyHelpers {
         self.assert_no_events_left_from(contract);
     }
 }
+
+#[generate_trait]
+pub impl ERC6909MetadataSpyHelpersImpl of ERC6909MetadataSpyHelpers {
+    fn assert_event_name_updated(
+        ref self: EventSpy, contract: ContractAddress, id: u256, new_name: ByteArray,
+    ) {
+        let expected = ExpectedEvent::new()
+            .key(selector!("ERC6909NameUpdated"))
+            .key(id)
+            .data(new_name);
+        self.assert_emitted_single(contract, expected);
+    }
+
+    fn assert_only_event_name_updated(
+        ref self: EventSpy, contract: ContractAddress, id: u256, new_name: ByteArray,
+    ) {
+        self.assert_event_name_updated(contract, id, new_name);
+        self.assert_no_events_left_from(contract);
+    }
+
+    fn assert_event_symbol_updated(
+        ref self: EventSpy, contract: ContractAddress, id: u256, new_symbol: ByteArray,
+    ) {
+        let expected = ExpectedEvent::new()
+            .key(selector!("ERC6909SymbolUpdated"))
+            .key(id)
+            .data(new_symbol);
+        self.assert_emitted_single(contract, expected);
+    }
+
+    fn assert_only_event_symbol_updated(
+        ref self: EventSpy, contract: ContractAddress, id: u256, new_symbol: ByteArray,
+    ) {
+        self.assert_event_symbol_updated(contract, id, new_symbol);
+        self.assert_no_events_left_from(contract);
+    }
+
+    fn assert_event_decimals_updated(
+        ref self: EventSpy, contract: ContractAddress, id: u256, new_decimals: u8,
+    ) {
+        let expected = ExpectedEvent::new()
+            .key(selector!("ERC6909DecimalsUpdated"))
+            .key(id)
+            .data(new_decimals);
+        self.assert_emitted_single(contract, expected);
+    }
+
+    fn assert_only_event_decimals_updated(
+        ref self: EventSpy, contract: ContractAddress, id: u256, new_decimals: u8,
+    ) {
+        self.assert_event_decimals_updated(contract, id, new_decimals);
+        self.assert_no_events_left_from(contract);
+    }
+}
+
+#[generate_trait]
+pub impl ERC6909ContentURISpyHelpersImpl of ERC6909ContentURISpyHelpers {
+    fn assert_only_event_contract_uri_updated(ref self: EventSpy, contract: ContractAddress) {
+        let expected = ExpectedEvent::new().key(selector!("ContractURIUpdated"));
+        self.assert_emitted_single(contract, expected);
+        self.assert_no_events_left_from(contract);
+    }
+
+    fn assert_only_event_uri(
+        ref self: EventSpy, contract: ContractAddress, value: ByteArray, id: u256,
+    ) {
+        let expected = ExpectedEvent::new().key(selector!("URI")).key(id).data(value);
+        self.assert_emitted_single(contract, expected);
+        self.assert_no_events_left_from(contract);
+    }
+}

--- a/packages/test_common/src/mocks/erc6909.cairo
+++ b/packages/test_common/src/mocks/erc6909.cairo
@@ -114,8 +114,111 @@ pub mod ERC6909ContentURIMock {
     ) {
         self.erc6909.initializer();
         self.erc6909_content_uri.initializer();
-        self.erc6909_content_uri.set_contract_uri(contract_uri);
+        self.erc6909_content_uri._set_contract_uri(contract_uri);
         self.erc6909.mint(recipient, id, amount);
+    }
+}
+
+#[starknet::contract]
+#[with_components(ERC6909, ERC6909ContentURI, SRC5, Ownable)]
+pub mod ERC6909ContentURIOwnableMock {
+    use openzeppelin_token::erc6909::ERC6909HooksEmptyImpl;
+    use starknet::ContractAddress;
+
+    #[abi(embed_v0)]
+    impl ERC6909Impl = ERC6909Component::ERC6909Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC6909ContentURIImpl =
+        ERC6909ContentURIComponent::ERC6909ContentURIImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC6909ContentURIAdminOwnableImpl =
+        ERC6909ContentURIComponent::ERC6909ContentURIAdminOwnableImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+
+    #[storage]
+    pub struct Storage {}
+
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        self.erc6909.initializer();
+        self.erc6909_content_uri.initializer();
+        self.ownable.initializer(owner);
+    }
+}
+
+#[starknet::contract]
+#[with_components(ERC6909, ERC6909ContentURI, SRC5, AccessControl)]
+pub mod ERC6909ContentURIAccessControlMock {
+    use openzeppelin_access::accesscontrol::DEFAULT_ADMIN_ROLE;
+    use openzeppelin_token::erc6909::ERC6909HooksEmptyImpl;
+    use openzeppelin_token::erc6909::extensions::erc6909_content_uri::ERC6909ContentURIComponent::CONTENT_URI_ADMIN_ROLE;
+    use starknet::ContractAddress;
+
+    #[abi(embed_v0)]
+    impl ERC6909Impl = ERC6909Component::ERC6909Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC6909ContentURIImpl =
+        ERC6909ContentURIComponent::ERC6909ContentURIImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC6909ContentURIAdminAccessControlImpl =
+        ERC6909ContentURIComponent::ERC6909ContentURIAdminAccessControlImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl AccessControlImpl =
+        AccessControlComponent::AccessControlImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+
+    #[storage]
+    pub struct Storage {}
+
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        self.erc6909.initializer();
+        self.erc6909_content_uri.initializer();
+        self.access_control.initializer();
+        self.access_control._grant_role(DEFAULT_ADMIN_ROLE, owner);
+        self.access_control._grant_role(CONTENT_URI_ADMIN_ROLE, owner);
+    }
+}
+
+#[starknet::contract]
+#[with_components(ERC6909, ERC6909ContentURI, SRC5, AccessControlDefaultAdminRules)]
+pub mod ERC6909ContentURIAccessControlDefaultAdminRulesMock {
+    use openzeppelin_access::accesscontrol::extensions::DefaultConfig as AccessControlDefaultAdminRulesDefaultConfig;
+    use openzeppelin_token::erc6909::ERC6909HooksEmptyImpl;
+    use openzeppelin_token::erc6909::extensions::erc6909_content_uri::ERC6909ContentURIComponent::CONTENT_URI_ADMIN_ROLE;
+    use starknet::ContractAddress;
+
+    #[abi(embed_v0)]
+    impl ERC6909Impl = ERC6909Component::ERC6909Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC6909ContentURIImpl =
+        ERC6909ContentURIComponent::ERC6909ContentURIImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC6909ContentURIAdminAccessControlDefaultAdminRulesImpl =
+        ERC6909ContentURIComponent::ERC6909ContentURIAdminAccessControlDefaultAdminRulesImpl<
+            ContractState,
+        >;
+    #[abi(embed_v0)]
+    impl AccessControlImpl =
+        AccessControlDefaultAdminRulesComponent::AccessControlImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+
+    pub const INITIAL_DELAY: u64 = 3600; // 1 hour
+
+    #[storage]
+    pub struct Storage {}
+
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        self.erc6909.initializer();
+        self.erc6909_content_uri.initializer();
+        self.access_control_dar.initializer(INITIAL_DELAY, owner);
+        self.access_control_dar._grant_role(CONTENT_URI_ADMIN_ROLE, owner);
     }
 }
 
@@ -148,10 +251,113 @@ pub mod ERC6909MetadataMock {
     ) {
         self.erc6909.initializer();
         self.erc6909_metadata.initializer();
-        self.erc6909_metadata.set_token_name(id, name);
-        self.erc6909_metadata.set_token_symbol(id, symbol);
-        self.erc6909_metadata.set_token_decimals(id, decimals);
+        self.erc6909_metadata._set_token_name(id, name);
+        self.erc6909_metadata._set_token_symbol(id, symbol);
+        self.erc6909_metadata._set_token_decimals(id, decimals);
         self.erc6909.mint(recipient, id, amount);
+    }
+}
+
+#[starknet::contract]
+#[with_components(ERC6909, ERC6909Metadata, SRC5, Ownable)]
+pub mod ERC6909MetadataOwnableMock {
+    use openzeppelin_token::erc6909::ERC6909HooksEmptyImpl;
+    use starknet::ContractAddress;
+
+    #[abi(embed_v0)]
+    impl ERC6909Impl = ERC6909Component::ERC6909Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC6909MetadataImpl =
+        ERC6909MetadataComponent::ERC6909MetadataImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC6909MetadataAdminOwnableImpl =
+        ERC6909MetadataComponent::ERC6909MetadataAdminOwnableImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+
+    #[storage]
+    pub struct Storage {}
+
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        self.erc6909.initializer();
+        self.erc6909_metadata.initializer();
+        self.ownable.initializer(owner);
+    }
+}
+
+#[starknet::contract]
+#[with_components(ERC6909, ERC6909Metadata, SRC5, AccessControl)]
+pub mod ERC6909MetadataAccessControlMock {
+    use openzeppelin_access::accesscontrol::DEFAULT_ADMIN_ROLE;
+    use openzeppelin_token::erc6909::ERC6909HooksEmptyImpl;
+    use openzeppelin_token::erc6909::extensions::erc6909_metadata::ERC6909MetadataComponent::METADATA_ADMIN_ROLE;
+    use starknet::ContractAddress;
+
+    #[abi(embed_v0)]
+    impl ERC6909Impl = ERC6909Component::ERC6909Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC6909MetadataImpl =
+        ERC6909MetadataComponent::ERC6909MetadataImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC6909MetadataAdminAccessControlImpl =
+        ERC6909MetadataComponent::ERC6909MetadataAdminAccessControlImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl AccessControlImpl =
+        AccessControlComponent::AccessControlImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+
+    #[storage]
+    pub struct Storage {}
+
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        self.erc6909.initializer();
+        self.erc6909_metadata.initializer();
+        self.access_control.initializer();
+        self.access_control._grant_role(DEFAULT_ADMIN_ROLE, owner);
+        self.access_control._grant_role(METADATA_ADMIN_ROLE, owner);
+    }
+}
+
+#[starknet::contract]
+#[with_components(ERC6909, ERC6909Metadata, SRC5, AccessControlDefaultAdminRules)]
+pub mod ERC6909MetadataAccessControlDefaultAdminRulesMock {
+    use openzeppelin_access::accesscontrol::extensions::DefaultConfig as AccessControlDefaultAdminRulesDefaultConfig;
+    use openzeppelin_token::erc6909::ERC6909HooksEmptyImpl;
+    use openzeppelin_token::erc6909::extensions::erc6909_metadata::ERC6909MetadataComponent::METADATA_ADMIN_ROLE;
+    use starknet::ContractAddress;
+
+    #[abi(embed_v0)]
+    impl ERC6909Impl = ERC6909Component::ERC6909Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC6909MetadataImpl =
+        ERC6909MetadataComponent::ERC6909MetadataImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC6909MetadataAdminAccessControlDefaultAdminRulesImpl =
+        ERC6909MetadataComponent::ERC6909MetadataAdminAccessControlDefaultAdminRulesImpl<
+            ContractState,
+        >;
+    #[abi(embed_v0)]
+    impl AccessControlImpl =
+        AccessControlDefaultAdminRulesComponent::AccessControlImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+
+    pub const INITIAL_DELAY: u64 = 3600; // 1 hour
+
+    #[storage]
+    pub struct Storage {}
+
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        self.erc6909.initializer();
+        self.erc6909_metadata.initializer();
+        self.access_control_dar.initializer(INITIAL_DELAY, owner);
+        self.access_control_dar._grant_role(METADATA_ADMIN_ROLE, owner);
     }
 }
 

--- a/packages/test_common/src/mocks/erc6909.cairo
+++ b/packages/test_common/src/mocks/erc6909.cairo
@@ -147,7 +147,10 @@ pub mod ERC6909MetadataMock {
         amount: u256,
     ) {
         self.erc6909.initializer();
-        self.erc6909_metadata.initializer(id, name, symbol, decimals);
+        self.erc6909_metadata.initializer();
+        self.erc6909_metadata.set_token_name(id, name);
+        self.erc6909_metadata.set_token_symbol(id, symbol);
+        self.erc6909_metadata.set_token_decimals(id, decimals);
         self.erc6909.mint(recipient, id, amount);
     }
 }

--- a/packages/token/src/erc6909/extensions/erc6909_content_uri.cairo
+++ b/packages/token/src/erc6909/extensions/erc6909_content_uri.cairo
@@ -10,6 +10,12 @@
 /// Use `set_contract_uri` and `set_token_uri` to set the URIs as needed.
 #[starknet::component]
 pub mod ERC6909ContentURIComponent {
+    use openzeppelin_access::accesscontrol::AccessControlComponent;
+    use openzeppelin_access::accesscontrol::AccessControlComponent::InternalTrait as AccessControlInternalTrait;
+    use openzeppelin_access::accesscontrol::extensions::AccessControlDefaultAdminRulesComponent;
+    use openzeppelin_access::accesscontrol::extensions::AccessControlDefaultAdminRulesComponent::InternalTrait as AccessControlDefaultAdminRulesInternalTrait;
+    use openzeppelin_access::ownable::OwnableComponent;
+    use openzeppelin_access::ownable::OwnableComponent::InternalTrait as OwnableInternalTrait;
     use openzeppelin_interfaces::erc6909 as interface;
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
@@ -18,6 +24,9 @@ pub mod ERC6909ContentURIComponent {
         Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
         StoragePointerWriteAccess,
     };
+
+    /// Role for the admin responsible for managing the contract and token URIs.
+    pub const CONTENT_URI_ADMIN_ROLE: felt252 = selector!("CONTENT_URI_ADMIN_ROLE");
 
     #[storage]
     pub struct Storage {
@@ -65,6 +74,129 @@ pub mod ERC6909ContentURIComponent {
     }
 
     //
+    // Ownable-based implementation of IERC6909ContentUriAdmin
+    //
+
+    #[embeddable_as(ERC6909ContentURIAdminOwnableImpl)]
+    impl ERC6909ContentURIAdminOwnable<
+        TContractState,
+        +HasComponent<TContractState>,
+        +ERC6909Component::HasComponent<TContractState>,
+        +SRC5Component::HasComponent<TContractState>,
+        impl Ownable: OwnableComponent::HasComponent<TContractState>,
+        +Drop<TContractState>,
+    > of interface::IERC6909ContentUriAdmin<ComponentState<TContractState>> {
+        /// Sets the contract-level URI.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller is the contract owner.
+        ///
+        /// Emits a `ContractURIUpdated` event.
+        fn set_contract_uri(ref self: ComponentState<TContractState>, contract_uri: ByteArray) {
+            get_dep_component!(@self, Ownable).assert_only_owner();
+            self._set_contract_uri(contract_uri)
+        }
+
+        /// Sets the URI for the token of type `id`.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller is the contract owner.
+        ///
+        /// Emits a `URI` event.
+        fn set_token_uri(
+            ref self: ComponentState<TContractState>, id: u256, token_uri: ByteArray,
+        ) {
+            get_dep_component!(@self, Ownable).assert_only_owner();
+            self._set_token_uri(id, token_uri)
+        }
+    }
+
+    //
+    // AccessControl-based implementation of IERC6909ContentUriAdmin
+    //
+
+    #[embeddable_as(ERC6909ContentURIAdminAccessControlImpl)]
+    impl ERC6909ContentURIAdminAccessControl<
+        TContractState,
+        +HasComponent<TContractState>,
+        +ERC6909Component::HasComponent<TContractState>,
+        +SRC5Component::HasComponent<TContractState>,
+        impl AccessControl: AccessControlComponent::HasComponent<TContractState>,
+        +Drop<TContractState>,
+    > of interface::IERC6909ContentUriAdmin<ComponentState<TContractState>> {
+        /// Sets the contract-level URI.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller must have `CONTENT_URI_ADMIN_ROLE` role.
+        ///
+        /// Emits a `ContractURIUpdated` event.
+        fn set_contract_uri(ref self: ComponentState<TContractState>, contract_uri: ByteArray) {
+            get_dep_component!(@self, AccessControl).assert_only_role(CONTENT_URI_ADMIN_ROLE);
+            self._set_contract_uri(contract_uri)
+        }
+
+        /// Sets the URI for the token of type `id`.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller must have `CONTENT_URI_ADMIN_ROLE` role.
+        ///
+        /// Emits a `URI` event.
+        fn set_token_uri(
+            ref self: ComponentState<TContractState>, id: u256, token_uri: ByteArray,
+        ) {
+            get_dep_component!(@self, AccessControl).assert_only_role(CONTENT_URI_ADMIN_ROLE);
+            self._set_token_uri(id, token_uri)
+        }
+    }
+
+    //
+    // AccessControlDefaultAdminRules-based implementation of IERC6909ContentUriAdmin
+    //
+
+    #[embeddable_as(ERC6909ContentURIAdminAccessControlDefaultAdminRulesImpl)]
+    impl ERC6909ContentURIAdminAccessControlDefaultAdminRules<
+        TContractState,
+        +HasComponent<TContractState>,
+        +ERC6909Component::HasComponent<TContractState>,
+        +AccessControlDefaultAdminRulesComponent::ImmutableConfig,
+        +SRC5Component::HasComponent<TContractState>,
+        impl AccessControlDAR: AccessControlDefaultAdminRulesComponent::HasComponent<
+            TContractState,
+        >,
+        +Drop<TContractState>,
+    > of interface::IERC6909ContentUriAdmin<ComponentState<TContractState>> {
+        /// Sets the contract-level URI.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller must have `CONTENT_URI_ADMIN_ROLE` role.
+        ///
+        /// Emits a `ContractURIUpdated` event.
+        fn set_contract_uri(ref self: ComponentState<TContractState>, contract_uri: ByteArray) {
+            get_dep_component!(@self, AccessControlDAR).assert_only_role(CONTENT_URI_ADMIN_ROLE);
+            self._set_contract_uri(contract_uri)
+        }
+
+        /// Sets the URI for the token of type `id`.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller must have `CONTENT_URI_ADMIN_ROLE` role.
+        ///
+        /// Emits a `URI` event.
+        fn set_token_uri(
+            ref self: ComponentState<TContractState>, id: u256, token_uri: ByteArray,
+        ) {
+            get_dep_component!(@self, AccessControlDAR).assert_only_role(CONTENT_URI_ADMIN_ROLE);
+            self._set_token_uri(id, token_uri)
+        }
+    }
+
+    //
     // Internal
     //
 
@@ -85,7 +217,7 @@ pub mod ERC6909ContentURIComponent {
         /// Sets the contract URI.
         ///
         /// Emits a `ContractURIUpdated` event.
-        fn set_contract_uri(ref self: ComponentState<TContractState>, contract_uri: ByteArray) {
+        fn _set_contract_uri(ref self: ComponentState<TContractState>, contract_uri: ByteArray) {
             self.ERC6909ContentURI_contract_uri.write(contract_uri);
             self.emit(ContractURIUpdated {});
         }
@@ -93,7 +225,9 @@ pub mod ERC6909ContentURIComponent {
         /// Sets the token URI for a given token ID.
         ///
         /// Emits a `URI` event.
-        fn set_token_uri(ref self: ComponentState<TContractState>, id: u256, token_uri: ByteArray) {
+        fn _set_token_uri(
+            ref self: ComponentState<TContractState>, id: u256, token_uri: ByteArray,
+        ) {
             self.ERC6909ContentURI_token_uris.write(id, token_uri.clone());
             self.emit(URI { value: token_uri, id });
         }

--- a/packages/token/src/erc6909/extensions/erc6909_content_uri.cairo
+++ b/packages/token/src/erc6909/extensions/erc6909_content_uri.cairo
@@ -105,9 +105,7 @@ pub mod ERC6909ContentURIComponent {
         /// - The caller is the contract owner.
         ///
         /// Emits a `URI` event.
-        fn set_token_uri(
-            ref self: ComponentState<TContractState>, id: u256, token_uri: ByteArray,
-        ) {
+        fn set_token_uri(ref self: ComponentState<TContractState>, id: u256, token_uri: ByteArray) {
             get_dep_component!(@self, Ownable).assert_only_owner();
             self._set_token_uri(id, token_uri)
         }
@@ -145,9 +143,7 @@ pub mod ERC6909ContentURIComponent {
         /// - The caller must have `CONTENT_URI_ADMIN_ROLE` role.
         ///
         /// Emits a `URI` event.
-        fn set_token_uri(
-            ref self: ComponentState<TContractState>, id: u256, token_uri: ByteArray,
-        ) {
+        fn set_token_uri(ref self: ComponentState<TContractState>, id: u256, token_uri: ByteArray) {
             get_dep_component!(@self, AccessControl).assert_only_role(CONTENT_URI_ADMIN_ROLE);
             self._set_token_uri(id, token_uri)
         }
@@ -188,9 +184,7 @@ pub mod ERC6909ContentURIComponent {
         /// - The caller must have `CONTENT_URI_ADMIN_ROLE` role.
         ///
         /// Emits a `URI` event.
-        fn set_token_uri(
-            ref self: ComponentState<TContractState>, id: u256, token_uri: ByteArray,
-        ) {
+        fn set_token_uri(ref self: ComponentState<TContractState>, id: u256, token_uri: ByteArray) {
             get_dep_component!(@self, AccessControlDAR).assert_only_role(CONTENT_URI_ADMIN_ROLE);
             self._set_token_uri(id, token_uri)
         }

--- a/packages/token/src/erc6909/extensions/erc6909_metadata.cairo
+++ b/packages/token/src/erc6909/extensions/erc6909_metadata.cairo
@@ -8,12 +8,9 @@
 /// individual token IDs. Unlike ERC20, ERC6909 supports multiple token types each with
 /// its own metadata.
 ///
-/// To use this component:
-///
-/// 1. Call `initializer` in your contract's constructor with the initial token metadata
-///    (id, name, symbol, decimals) to register the SRC5 interface and set up the first token.
-/// 2. For additional token IDs, use the individual setters `set_token_name`,
-///    `set_token_symbol`, and `set_token_decimals` to configure metadata.
+/// Call the `initializer` function in your contract's constructor to register the interface.
+/// Use `set_token_name`, `set_token_symbol`, and `set_token_decimals` to configure metadata
+/// per token ID as needed.
 #[starknet::component]
 pub mod ERC6909MetadataComponent {
     use openzeppelin_interfaces::erc6909 as interface;
@@ -98,18 +95,8 @@ pub mod ERC6909MetadataComponent {
         +Drop<TContractState>,
     > of InternalTrait<TContractState> {
         /// Initializes the contract by declaring support for the `IERC6909Metadata`
-        /// interface id and setting the initial token metadata.
-        fn initializer(
-            ref self: ComponentState<TContractState>,
-            id: u256,
-            name: ByteArray,
-            symbol: ByteArray,
-            decimals: u8,
-        ) {
-            self.set_token_name(id, name);
-            self.set_token_symbol(id, symbol);
-            self.set_token_decimals(id, decimals);
-
+        /// interface id.
+        fn initializer(ref self: ComponentState<TContractState>) {
             let mut src5_component = get_dep_component_mut!(ref self, SRC5);
             src5_component.register_interface(interface::IERC6909_METADATA_ID);
         }

--- a/packages/token/src/erc6909/extensions/erc6909_metadata.cairo
+++ b/packages/token/src/erc6909/extensions/erc6909_metadata.cairo
@@ -13,11 +13,20 @@
 /// per token ID as needed.
 #[starknet::component]
 pub mod ERC6909MetadataComponent {
+    use openzeppelin_access::accesscontrol::AccessControlComponent;
+    use openzeppelin_access::accesscontrol::AccessControlComponent::InternalTrait as AccessControlInternalTrait;
+    use openzeppelin_access::accesscontrol::extensions::AccessControlDefaultAdminRulesComponent;
+    use openzeppelin_access::accesscontrol::extensions::AccessControlDefaultAdminRulesComponent::InternalTrait as AccessControlDefaultAdminRulesInternalTrait;
+    use openzeppelin_access::ownable::OwnableComponent;
+    use openzeppelin_access::ownable::OwnableComponent::InternalTrait as OwnableInternalTrait;
     use openzeppelin_interfaces::erc6909 as interface;
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin_token::erc6909::ERC6909Component;
     use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess};
+
+    /// Role for the admin responsible for managing token metadata.
+    pub const METADATA_ADMIN_ROLE: felt252 = selector!("METADATA_ADMIN_ROLE");
 
     #[storage]
     pub struct Storage {
@@ -83,6 +92,159 @@ pub mod ERC6909MetadataComponent {
     }
 
     //
+    // Ownable-based implementation of IERC6909MetadataAdmin
+    //
+
+    #[embeddable_as(ERC6909MetadataAdminOwnableImpl)]
+    impl ERC6909MetadataAdminOwnable<
+        TContractState,
+        +HasComponent<TContractState>,
+        +ERC6909Component::HasComponent<TContractState>,
+        +SRC5Component::HasComponent<TContractState>,
+        impl Ownable: OwnableComponent::HasComponent<TContractState>,
+        +Drop<TContractState>,
+    > of interface::IERC6909MetadataAdmin<ComponentState<TContractState>> {
+        /// Sets the name for the token of type `id`.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller is the contract owner.
+        ///
+        /// Emits an `ERC6909NameUpdated` event.
+        fn set_token_name(ref self: ComponentState<TContractState>, id: u256, name: ByteArray) {
+            get_dep_component!(@self, Ownable).assert_only_owner();
+            self._set_token_name(id, name)
+        }
+
+        /// Sets the symbol for the token of type `id`.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller is the contract owner.
+        ///
+        /// Emits an `ERC6909SymbolUpdated` event.
+        fn set_token_symbol(ref self: ComponentState<TContractState>, id: u256, symbol: ByteArray) {
+            get_dep_component!(@self, Ownable).assert_only_owner();
+            self._set_token_symbol(id, symbol)
+        }
+
+        /// Sets the decimals for the token of type `id`.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller is the contract owner.
+        ///
+        /// Emits an `ERC6909DecimalsUpdated` event.
+        fn set_token_decimals(ref self: ComponentState<TContractState>, id: u256, decimals: u8) {
+            get_dep_component!(@self, Ownable).assert_only_owner();
+            self._set_token_decimals(id, decimals)
+        }
+    }
+
+    //
+    // AccessControl-based implementation of IERC6909MetadataAdmin
+    //
+
+    #[embeddable_as(ERC6909MetadataAdminAccessControlImpl)]
+    impl ERC6909MetadataAdminAccessControl<
+        TContractState,
+        +HasComponent<TContractState>,
+        +ERC6909Component::HasComponent<TContractState>,
+        +SRC5Component::HasComponent<TContractState>,
+        impl AccessControl: AccessControlComponent::HasComponent<TContractState>,
+        +Drop<TContractState>,
+    > of interface::IERC6909MetadataAdmin<ComponentState<TContractState>> {
+        /// Sets the name for the token of type `id`.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller must have `METADATA_ADMIN_ROLE` role.
+        ///
+        /// Emits an `ERC6909NameUpdated` event.
+        fn set_token_name(ref self: ComponentState<TContractState>, id: u256, name: ByteArray) {
+            get_dep_component!(@self, AccessControl).assert_only_role(METADATA_ADMIN_ROLE);
+            self._set_token_name(id, name)
+        }
+
+        /// Sets the symbol for the token of type `id`.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller must have `METADATA_ADMIN_ROLE` role.
+        ///
+        /// Emits an `ERC6909SymbolUpdated` event.
+        fn set_token_symbol(ref self: ComponentState<TContractState>, id: u256, symbol: ByteArray) {
+            get_dep_component!(@self, AccessControl).assert_only_role(METADATA_ADMIN_ROLE);
+            self._set_token_symbol(id, symbol)
+        }
+
+        /// Sets the decimals for the token of type `id`.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller must have `METADATA_ADMIN_ROLE` role.
+        ///
+        /// Emits an `ERC6909DecimalsUpdated` event.
+        fn set_token_decimals(ref self: ComponentState<TContractState>, id: u256, decimals: u8) {
+            get_dep_component!(@self, AccessControl).assert_only_role(METADATA_ADMIN_ROLE);
+            self._set_token_decimals(id, decimals)
+        }
+    }
+
+    //
+    // AccessControlDefaultAdminRules-based implementation of IERC6909MetadataAdmin
+    //
+
+    #[embeddable_as(ERC6909MetadataAdminAccessControlDefaultAdminRulesImpl)]
+    impl ERC6909MetadataAdminAccessControlDefaultAdminRules<
+        TContractState,
+        +HasComponent<TContractState>,
+        +ERC6909Component::HasComponent<TContractState>,
+        +AccessControlDefaultAdminRulesComponent::ImmutableConfig,
+        +SRC5Component::HasComponent<TContractState>,
+        impl AccessControlDAR: AccessControlDefaultAdminRulesComponent::HasComponent<
+            TContractState,
+        >,
+        +Drop<TContractState>,
+    > of interface::IERC6909MetadataAdmin<ComponentState<TContractState>> {
+        /// Sets the name for the token of type `id`.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller must have `METADATA_ADMIN_ROLE` role.
+        ///
+        /// Emits an `ERC6909NameUpdated` event.
+        fn set_token_name(ref self: ComponentState<TContractState>, id: u256, name: ByteArray) {
+            get_dep_component!(@self, AccessControlDAR).assert_only_role(METADATA_ADMIN_ROLE);
+            self._set_token_name(id, name)
+        }
+
+        /// Sets the symbol for the token of type `id`.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller must have `METADATA_ADMIN_ROLE` role.
+        ///
+        /// Emits an `ERC6909SymbolUpdated` event.
+        fn set_token_symbol(ref self: ComponentState<TContractState>, id: u256, symbol: ByteArray) {
+            get_dep_component!(@self, AccessControlDAR).assert_only_role(METADATA_ADMIN_ROLE);
+            self._set_token_symbol(id, symbol)
+        }
+
+        /// Sets the decimals for the token of type `id`.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller must have `METADATA_ADMIN_ROLE` role.
+        ///
+        /// Emits an `ERC6909DecimalsUpdated` event.
+        fn set_token_decimals(ref self: ComponentState<TContractState>, id: u256, decimals: u8) {
+            get_dep_component!(@self, AccessControlDAR).assert_only_role(METADATA_ADMIN_ROLE);
+            self._set_token_decimals(id, decimals)
+        }
+    }
+
+    //
     // Internal
     //
 
@@ -102,19 +264,21 @@ pub mod ERC6909MetadataComponent {
         }
 
         /// Sets the token name.
-        fn set_token_name(ref self: ComponentState<TContractState>, id: u256, name: ByteArray) {
+        fn _set_token_name(ref self: ComponentState<TContractState>, id: u256, name: ByteArray) {
             self.ERC6909Metadata_name.write(id, name.clone());
             self.emit(ERC6909NameUpdated { id, new_name: name })
         }
 
         /// Sets the token symbol.
-        fn set_token_symbol(ref self: ComponentState<TContractState>, id: u256, symbol: ByteArray) {
+        fn _set_token_symbol(
+            ref self: ComponentState<TContractState>, id: u256, symbol: ByteArray,
+        ) {
             self.ERC6909Metadata_symbol.write(id, symbol.clone());
             self.emit(ERC6909SymbolUpdated { id, new_symbol: symbol });
         }
 
         /// Sets the token decimals.
-        fn set_token_decimals(ref self: ComponentState<TContractState>, id: u256, decimals: u8) {
+        fn _set_token_decimals(ref self: ComponentState<TContractState>, id: u256, decimals: u8) {
             self.ERC6909Metadata_decimals.write(id, decimals);
             self.emit(ERC6909DecimalsUpdated { id, new_decimals: decimals })
         }

--- a/packages/token/src/tests/erc6909.cairo
+++ b/packages/token/src/tests/erc6909.cairo
@@ -1,4 +1,10 @@
 mod test_erc6909;
 mod test_erc6909_content_uri;
+mod test_erc6909_content_uri_accesscontrol;
+mod test_erc6909_content_uri_accesscontrol_default_admin_rules;
+mod test_erc6909_content_uri_ownable;
 mod test_erc6909_metadata;
+mod test_erc6909_metadata_accesscontrol;
+mod test_erc6909_metadata_accesscontrol_default_admin_rules;
+mod test_erc6909_metadata_ownable;
 mod test_erc6909_token_supply;

--- a/packages/token/src/tests/erc6909/test_erc6909_content_uri.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_content_uri.cairo
@@ -59,7 +59,7 @@ fn test_set_contract_uri() {
     state.initializer();
 
     let mut spy = spy_events();
-    state.set_contract_uri(CONTRACT_URI());
+    state._set_contract_uri(CONTRACT_URI());
 
     spy.assert_only_event_contract_uri_updated(contract_address);
     assert_eq!(state.contract_uri(), CONTRACT_URI());
@@ -70,7 +70,7 @@ fn test_set_contract_uri_empty() {
     let mut state = COMPONENT_STATE();
 
     state.initializer();
-    state.set_contract_uri("");
+    state._set_contract_uri("");
 
     let empty: ByteArray = "";
     assert_eq!(state.contract_uri(), empty);
@@ -91,7 +91,7 @@ fn test_set_token_uri() {
     state.initializer();
 
     let mut spy = spy_events();
-    state.set_token_uri(SAMPLE_ID, TOKEN_URI());
+    state._set_token_uri(SAMPLE_ID, TOKEN_URI());
 
     spy.assert_only_event_uri(contract_address, TOKEN_URI(), SAMPLE_ID);
     assert_eq!(state.token_uri(SAMPLE_ID), TOKEN_URI());
@@ -102,8 +102,8 @@ fn test_token_uri_independent_of_contract_uri() {
     let mut state = COMPONENT_STATE();
 
     state.initializer();
-    state.set_contract_uri(CONTRACT_URI());
-    state.set_token_uri(SAMPLE_ID, TOKEN_URI());
+    state._set_contract_uri(CONTRACT_URI());
+    state._set_token_uri(SAMPLE_ID, TOKEN_URI());
 
     // Token URI is independent of contract URI
     assert_eq!(state.contract_uri(), CONTRACT_URI());
@@ -119,8 +119,8 @@ fn test_different_token_ids_have_different_uris() {
     let uri_1: ByteArray = "ipfs://token/1";
     let uri_2: ByteArray = "ipfs://token/2";
 
-    state.set_token_uri(1, uri_1.clone());
-    state.set_token_uri(2, uri_2.clone());
+    state._set_token_uri(1, uri_1.clone());
+    state._set_token_uri(2, uri_2.clone());
 
     assert_eq!(state.token_uri(1), uri_1);
     assert_eq!(state.token_uri(2), uri_2);

--- a/packages/token/src/tests/erc6909/test_erc6909_content_uri.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_content_uri.cairo
@@ -1,8 +1,9 @@
 use openzeppelin_interfaces::erc6909::IERC6909_CONTENT_URI_ID;
 use openzeppelin_interfaces::introspection::ISRC5_ID;
 use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
+use openzeppelin_test_common::erc6909::ERC6909ContentURISpyHelpers;
 use openzeppelin_test_common::mocks::erc6909::ERC6909ContentURIMock;
-use openzeppelin_testing::{EventSpyExt, EventSpyQueue as EventSpy, ExpectedEvent, spy_events};
+use openzeppelin_testing::spy_events;
 use snforge_std::test_address;
 use crate::erc6909::extensions::erc6909_content_uri::ERC6909ContentURIComponent;
 use crate::erc6909::extensions::erc6909_content_uri::ERC6909ContentURIComponent::{
@@ -126,21 +127,3 @@ fn test_different_token_ids_have_different_uris() {
     assert_eq!(state.token_uri(2), uri_2);
 }
 
-#[generate_trait]
-impl ERC6909ContentURISpyHelpersImpl of ERC6909ContentURISpyHelpers {
-    fn assert_only_event_contract_uri_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress,
-    ) {
-        let expected = ExpectedEvent::new().key(selector!("ContractURIUpdated"));
-        self.assert_emitted_single(contract, expected);
-        self.assert_no_events_left_from(contract);
-    }
-
-    fn assert_only_event_uri(
-        ref self: EventSpy, contract: starknet::ContractAddress, value: ByteArray, id: u256,
-    ) {
-        let expected = ExpectedEvent::new().key(selector!("URI")).key(id).data(value);
-        self.assert_emitted_single(contract, expected);
-        self.assert_no_events_left_from(contract);
-    }
-}

--- a/packages/token/src/tests/erc6909/test_erc6909_content_uri_accesscontrol.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_content_uri_accesscontrol.cairo
@@ -1,0 +1,164 @@
+use openzeppelin_access::accesscontrol::AccessControlComponent::InternalImpl as AccessControlInternalImpl;
+use openzeppelin_access::accesscontrol::{AccessControlComponent, DEFAULT_ADMIN_ROLE};
+use openzeppelin_test_common::mocks::erc6909::ERC6909ContentURIAccessControlMock;
+use openzeppelin_testing::constants::{ADMIN, OTHER, OTHER_ADMIN, OTHER_ROLE};
+use openzeppelin_testing::{EventSpyExt, EventSpyQueue as EventSpy, ExpectedEvent, spy_events};
+use snforge_std::{start_cheat_caller_address, test_address};
+use starknet::ContractAddress;
+use crate::erc6909::extensions::erc6909_content_uri::ERC6909ContentURIComponent;
+use crate::erc6909::extensions::erc6909_content_uri::ERC6909ContentURIComponent::{
+    CONTENT_URI_ADMIN_ROLE, ERC6909ContentURIAdminAccessControlImpl, ERC6909ContentURIImpl,
+    InternalImpl,
+};
+
+type MockState = ERC6909ContentURIAccessControlMock::ContractState;
+type ComponentState = ERC6909ContentURIComponent::ComponentState<MockState>;
+type AccessControlComponentState = AccessControlComponent::ComponentState<MockState>;
+
+fn CONTRACT_URI() -> ByteArray {
+    "ipfs://contract/"
+}
+
+fn TOKEN_URI() -> ByteArray {
+    "ipfs://token/1234"
+}
+
+const SAMPLE_ID: u256 = 1234;
+
+fn COMPONENT_STATE() -> ComponentState {
+    ERC6909ContentURIComponent::component_state_for_testing()
+}
+
+fn ACCESS_CONTROL_STATE() -> AccessControlComponentState {
+    AccessControlComponent::component_state_for_testing()
+}
+
+fn setup() -> ComponentState {
+    let mut state = COMPONENT_STATE();
+    state.initializer();
+
+    let mut access_control_state = ACCESS_CONTROL_STATE();
+    access_control_state.initializer();
+    grant_accesscontrol_role(DEFAULT_ADMIN_ROLE, ADMIN);
+    grant_accesscontrol_role(CONTENT_URI_ADMIN_ROLE, ADMIN);
+
+    state
+}
+
+//
+// IERC6909ContentUriAdmin - AccessControl
+//
+
+#[test]
+fn test_set_contract_uri() {
+    let mut state = setup();
+    let contract_address = test_address();
+
+    let mut spy = spy_events();
+    start_cheat_caller_address(test_address(), ADMIN);
+    state.set_contract_uri(CONTRACT_URI());
+
+    spy.assert_only_event_contract_uri_updated(contract_address);
+    assert_eq!(state.contract_uri(), CONTRACT_URI());
+}
+
+#[test]
+fn test_set_contract_uri_other_admin() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(CONTENT_URI_ADMIN_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_contract_uri(CONTRACT_URI());
+
+    assert_eq!(state.contract_uri(), CONTRACT_URI());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_contract_uri_unauthorized() {
+    let mut state = setup();
+
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_contract_uri(CONTRACT_URI());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_contract_uri_invalid_role() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(OTHER_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_contract_uri(CONTRACT_URI());
+}
+
+#[test]
+fn test_set_token_uri() {
+    let mut state = setup();
+    let contract_address = test_address();
+
+    let mut spy = spy_events();
+    start_cheat_caller_address(test_address(), ADMIN);
+    state.set_token_uri(SAMPLE_ID, TOKEN_URI());
+
+    spy.assert_only_event_uri(contract_address, TOKEN_URI(), SAMPLE_ID);
+    assert_eq!(state.token_uri(SAMPLE_ID), TOKEN_URI());
+}
+
+#[test]
+fn test_set_token_uri_other_admin() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(CONTENT_URI_ADMIN_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_uri(SAMPLE_ID, TOKEN_URI());
+
+    assert_eq!(state.token_uri(SAMPLE_ID), TOKEN_URI());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_uri_unauthorized() {
+    let mut state = setup();
+
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_token_uri(SAMPLE_ID, TOKEN_URI());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_uri_invalid_role() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(OTHER_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_uri(SAMPLE_ID, TOKEN_URI());
+}
+
+//
+// Helpers
+//
+
+fn grant_accesscontrol_role(role: felt252, admin: ContractAddress) {
+    let mut state = ACCESS_CONTROL_STATE();
+    state._grant_role(role, admin);
+}
+
+#[generate_trait]
+impl ERC6909ContentURISpyHelpersImpl of ERC6909ContentURISpyHelpers {
+    fn assert_only_event_contract_uri_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress,
+    ) {
+        let expected = ExpectedEvent::new().key(selector!("ContractURIUpdated"));
+        self.assert_emitted_single(contract, expected);
+        self.assert_no_events_left_from(contract);
+    }
+
+    fn assert_only_event_uri(
+        ref self: EventSpy, contract: starknet::ContractAddress, value: ByteArray, id: u256,
+    ) {
+        let expected = ExpectedEvent::new().key(selector!("URI")).key(id).data(value);
+        self.assert_emitted_single(contract, expected);
+        self.assert_no_events_left_from(contract);
+    }
+}

--- a/packages/token/src/tests/erc6909/test_erc6909_content_uri_accesscontrol.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_content_uri_accesscontrol.cairo
@@ -1,8 +1,9 @@
 use openzeppelin_access::accesscontrol::AccessControlComponent::InternalImpl as AccessControlInternalImpl;
 use openzeppelin_access::accesscontrol::{AccessControlComponent, DEFAULT_ADMIN_ROLE};
+use openzeppelin_test_common::erc6909::ERC6909ContentURISpyHelpers;
 use openzeppelin_test_common::mocks::erc6909::ERC6909ContentURIAccessControlMock;
 use openzeppelin_testing::constants::{ADMIN, OTHER, OTHER_ADMIN, OTHER_ROLE};
-use openzeppelin_testing::{EventSpyExt, EventSpyQueue as EventSpy, ExpectedEvent, spy_events};
+use openzeppelin_testing::spy_events;
 use snforge_std::{start_cheat_caller_address, test_address};
 use starknet::ContractAddress;
 use crate::erc6909::extensions::erc6909_content_uri::ERC6909ContentURIComponent;
@@ -142,23 +143,4 @@ fn test_set_token_uri_invalid_role() {
 fn grant_accesscontrol_role(role: felt252, admin: ContractAddress) {
     let mut state = ACCESS_CONTROL_STATE();
     state._grant_role(role, admin);
-}
-
-#[generate_trait]
-impl ERC6909ContentURISpyHelpersImpl of ERC6909ContentURISpyHelpers {
-    fn assert_only_event_contract_uri_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress,
-    ) {
-        let expected = ExpectedEvent::new().key(selector!("ContractURIUpdated"));
-        self.assert_emitted_single(contract, expected);
-        self.assert_no_events_left_from(contract);
-    }
-
-    fn assert_only_event_uri(
-        ref self: EventSpy, contract: starknet::ContractAddress, value: ByteArray, id: u256,
-    ) {
-        let expected = ExpectedEvent::new().key(selector!("URI")).key(id).data(value);
-        self.assert_emitted_single(contract, expected);
-        self.assert_no_events_left_from(contract);
-    }
 }

--- a/packages/token/src/tests/erc6909/test_erc6909_content_uri_accesscontrol_default_admin_rules.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_content_uri_accesscontrol_default_admin_rules.cairo
@@ -1,0 +1,168 @@
+use openzeppelin_access::accesscontrol::extensions::AccessControlDefaultAdminRulesComponent::InternalImpl as AccessControlInternalImpl;
+use openzeppelin_access::accesscontrol::extensions::{
+    AccessControlDefaultAdminRulesComponent, DefaultConfig as AccessControlDARDefaultConfig,
+};
+use openzeppelin_test_common::mocks::erc6909::ERC6909ContentURIAccessControlDefaultAdminRulesMock;
+use openzeppelin_testing::constants::{ADMIN, OTHER, OTHER_ADMIN, OTHER_ROLE};
+use openzeppelin_testing::{EventSpyExt, EventSpyQueue as EventSpy, ExpectedEvent, spy_events};
+use snforge_std::{start_cheat_caller_address, test_address};
+use starknet::ContractAddress;
+use crate::erc6909::extensions::erc6909_content_uri::ERC6909ContentURIComponent;
+use crate::erc6909::extensions::erc6909_content_uri::ERC6909ContentURIComponent::{
+    CONTENT_URI_ADMIN_ROLE, ERC6909ContentURIAdminAccessControlDefaultAdminRulesImpl,
+    ERC6909ContentURIImpl, InternalImpl,
+};
+
+type MockState = ERC6909ContentURIAccessControlDefaultAdminRulesMock::ContractState;
+type ComponentState = ERC6909ContentURIComponent::ComponentState<MockState>;
+type AccessControlComponentState =
+    AccessControlDefaultAdminRulesComponent::ComponentState<MockState>;
+
+const DEFAULT_INITIAL_DELAY: u64 = 3600; // 1 hour
+
+fn CONTRACT_URI() -> ByteArray {
+    "ipfs://contract/"
+}
+
+fn TOKEN_URI() -> ByteArray {
+    "ipfs://token/1234"
+}
+
+const SAMPLE_ID: u256 = 1234;
+
+fn COMPONENT_STATE() -> ComponentState {
+    ERC6909ContentURIComponent::component_state_for_testing()
+}
+
+fn ACCESS_CONTROL_STATE() -> AccessControlComponentState {
+    AccessControlDefaultAdminRulesComponent::component_state_for_testing()
+}
+
+fn setup() -> ComponentState {
+    let mut state = COMPONENT_STATE();
+    state.initializer();
+
+    let mut access_control_state = ACCESS_CONTROL_STATE();
+    access_control_state.initializer(DEFAULT_INITIAL_DELAY, ADMIN);
+    grant_accesscontrol_role(CONTENT_URI_ADMIN_ROLE, ADMIN);
+
+    state
+}
+
+//
+// IERC6909ContentUriAdmin - AccessControlDefaultAdminRules
+//
+
+#[test]
+fn test_set_contract_uri() {
+    let mut state = setup();
+    let contract_address = test_address();
+
+    let mut spy = spy_events();
+    start_cheat_caller_address(test_address(), ADMIN);
+    state.set_contract_uri(CONTRACT_URI());
+
+    spy.assert_only_event_contract_uri_updated(contract_address);
+    assert_eq!(state.contract_uri(), CONTRACT_URI());
+}
+
+#[test]
+fn test_set_contract_uri_other_admin() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(CONTENT_URI_ADMIN_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_contract_uri(CONTRACT_URI());
+
+    assert_eq!(state.contract_uri(), CONTRACT_URI());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_contract_uri_unauthorized() {
+    let mut state = setup();
+
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_contract_uri(CONTRACT_URI());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_contract_uri_invalid_role() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(OTHER_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_contract_uri(CONTRACT_URI());
+}
+
+#[test]
+fn test_set_token_uri() {
+    let mut state = setup();
+    let contract_address = test_address();
+
+    let mut spy = spy_events();
+    start_cheat_caller_address(test_address(), ADMIN);
+    state.set_token_uri(SAMPLE_ID, TOKEN_URI());
+
+    spy.assert_only_event_uri(contract_address, TOKEN_URI(), SAMPLE_ID);
+    assert_eq!(state.token_uri(SAMPLE_ID), TOKEN_URI());
+}
+
+#[test]
+fn test_set_token_uri_other_admin() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(CONTENT_URI_ADMIN_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_uri(SAMPLE_ID, TOKEN_URI());
+
+    assert_eq!(state.token_uri(SAMPLE_ID), TOKEN_URI());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_uri_unauthorized() {
+    let mut state = setup();
+
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_token_uri(SAMPLE_ID, TOKEN_URI());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_uri_invalid_role() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(OTHER_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_uri(SAMPLE_ID, TOKEN_URI());
+}
+
+//
+// Helpers
+//
+
+fn grant_accesscontrol_role(role: felt252, admin: ContractAddress) {
+    let mut state = ACCESS_CONTROL_STATE();
+    state._grant_role(role, admin);
+}
+
+#[generate_trait]
+impl ERC6909ContentURISpyHelpersImpl of ERC6909ContentURISpyHelpers {
+    fn assert_only_event_contract_uri_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress,
+    ) {
+        let expected = ExpectedEvent::new().key(selector!("ContractURIUpdated"));
+        self.assert_emitted_single(contract, expected);
+        self.assert_no_events_left_from(contract);
+    }
+
+    fn assert_only_event_uri(
+        ref self: EventSpy, contract: starknet::ContractAddress, value: ByteArray, id: u256,
+    ) {
+        let expected = ExpectedEvent::new().key(selector!("URI")).key(id).data(value);
+        self.assert_emitted_single(contract, expected);
+        self.assert_no_events_left_from(contract);
+    }
+}

--- a/packages/token/src/tests/erc6909/test_erc6909_content_uri_accesscontrol_default_admin_rules.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_content_uri_accesscontrol_default_admin_rules.cairo
@@ -2,9 +2,10 @@ use openzeppelin_access::accesscontrol::extensions::AccessControlDefaultAdminRul
 use openzeppelin_access::accesscontrol::extensions::{
     AccessControlDefaultAdminRulesComponent, DefaultConfig as AccessControlDARDefaultConfig,
 };
+use openzeppelin_test_common::erc6909::ERC6909ContentURISpyHelpers;
 use openzeppelin_test_common::mocks::erc6909::ERC6909ContentURIAccessControlDefaultAdminRulesMock;
 use openzeppelin_testing::constants::{ADMIN, OTHER, OTHER_ADMIN, OTHER_ROLE};
-use openzeppelin_testing::{EventSpyExt, EventSpyQueue as EventSpy, ExpectedEvent, spy_events};
+use openzeppelin_testing::spy_events;
 use snforge_std::{start_cheat_caller_address, test_address};
 use starknet::ContractAddress;
 use crate::erc6909::extensions::erc6909_content_uri::ERC6909ContentURIComponent;
@@ -146,23 +147,4 @@ fn test_set_token_uri_invalid_role() {
 fn grant_accesscontrol_role(role: felt252, admin: ContractAddress) {
     let mut state = ACCESS_CONTROL_STATE();
     state._grant_role(role, admin);
-}
-
-#[generate_trait]
-impl ERC6909ContentURISpyHelpersImpl of ERC6909ContentURISpyHelpers {
-    fn assert_only_event_contract_uri_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress,
-    ) {
-        let expected = ExpectedEvent::new().key(selector!("ContractURIUpdated"));
-        self.assert_emitted_single(contract, expected);
-        self.assert_no_events_left_from(contract);
-    }
-
-    fn assert_only_event_uri(
-        ref self: EventSpy, contract: starknet::ContractAddress, value: ByteArray, id: u256,
-    ) {
-        let expected = ExpectedEvent::new().key(selector!("URI")).key(id).data(value);
-        self.assert_emitted_single(contract, expected);
-        self.assert_no_events_left_from(contract);
-    }
 }

--- a/packages/token/src/tests/erc6909/test_erc6909_content_uri_ownable.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_content_uri_ownable.cairo
@@ -1,8 +1,9 @@
 use openzeppelin_access::ownable::OwnableComponent;
 use openzeppelin_access::ownable::OwnableComponent::InternalImpl as OwnableInternalImpl;
+use openzeppelin_test_common::erc6909::ERC6909ContentURISpyHelpers;
 use openzeppelin_test_common::mocks::erc6909::ERC6909ContentURIOwnableMock;
 use openzeppelin_testing::constants::{OTHER, OWNER};
-use openzeppelin_testing::{EventSpyExt, EventSpyQueue as EventSpy, ExpectedEvent, spy_events};
+use openzeppelin_testing::spy_events;
 use snforge_std::{start_cheat_caller_address, test_address};
 use crate::erc6909::extensions::erc6909_content_uri::ERC6909ContentURIComponent;
 use crate::erc6909::extensions::erc6909_content_uri::ERC6909ContentURIComponent::{
@@ -85,25 +86,3 @@ fn test_set_token_uri_unauthorized() {
     state.set_token_uri(SAMPLE_ID, TOKEN_URI());
 }
 
-//
-// Helpers
-//
-
-#[generate_trait]
-impl ERC6909ContentURISpyHelpersImpl of ERC6909ContentURISpyHelpers {
-    fn assert_only_event_contract_uri_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress,
-    ) {
-        let expected = ExpectedEvent::new().key(selector!("ContractURIUpdated"));
-        self.assert_emitted_single(contract, expected);
-        self.assert_no_events_left_from(contract);
-    }
-
-    fn assert_only_event_uri(
-        ref self: EventSpy, contract: starknet::ContractAddress, value: ByteArray, id: u256,
-    ) {
-        let expected = ExpectedEvent::new().key(selector!("URI")).key(id).data(value);
-        self.assert_emitted_single(contract, expected);
-        self.assert_no_events_left_from(contract);
-    }
-}

--- a/packages/token/src/tests/erc6909/test_erc6909_content_uri_ownable.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_content_uri_ownable.cairo
@@ -1,0 +1,109 @@
+use openzeppelin_access::ownable::OwnableComponent;
+use openzeppelin_access::ownable::OwnableComponent::InternalImpl as OwnableInternalImpl;
+use openzeppelin_test_common::mocks::erc6909::ERC6909ContentURIOwnableMock;
+use openzeppelin_testing::constants::{OTHER, OWNER};
+use openzeppelin_testing::{EventSpyExt, EventSpyQueue as EventSpy, ExpectedEvent, spy_events};
+use snforge_std::{start_cheat_caller_address, test_address};
+use crate::erc6909::extensions::erc6909_content_uri::ERC6909ContentURIComponent;
+use crate::erc6909::extensions::erc6909_content_uri::ERC6909ContentURIComponent::{
+    ERC6909ContentURIAdminOwnableImpl, ERC6909ContentURIImpl, InternalImpl,
+};
+
+type MockState = ERC6909ContentURIOwnableMock::ContractState;
+type ComponentState = ERC6909ContentURIComponent::ComponentState<MockState>;
+type OwnableComponentState = OwnableComponent::ComponentState<MockState>;
+
+fn CONTRACT_URI() -> ByteArray {
+    "ipfs://contract/"
+}
+
+fn TOKEN_URI() -> ByteArray {
+    "ipfs://token/1234"
+}
+
+const SAMPLE_ID: u256 = 1234;
+
+fn COMPONENT_STATE() -> ComponentState {
+    ERC6909ContentURIComponent::component_state_for_testing()
+}
+
+fn setup() -> ComponentState {
+    let mut state = COMPONENT_STATE();
+    state.initializer();
+
+    let mut ownable_state: OwnableComponentState = OwnableComponent::component_state_for_testing();
+    ownable_state.initializer(OWNER);
+
+    state
+}
+
+//
+// IERC6909ContentUriAdmin - Ownable
+//
+
+#[test]
+fn test_set_contract_uri() {
+    let mut state = setup();
+    let contract_address = test_address();
+
+    let mut spy = spy_events();
+    start_cheat_caller_address(test_address(), OWNER);
+    state.set_contract_uri(CONTRACT_URI());
+
+    spy.assert_only_event_contract_uri_updated(contract_address);
+    assert_eq!(state.contract_uri(), CONTRACT_URI());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is not the owner')]
+fn test_set_contract_uri_unauthorized() {
+    let mut state = setup();
+
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_contract_uri(CONTRACT_URI());
+}
+
+#[test]
+fn test_set_token_uri() {
+    let mut state = setup();
+    let contract_address = test_address();
+
+    let mut spy = spy_events();
+    start_cheat_caller_address(test_address(), OWNER);
+    state.set_token_uri(SAMPLE_ID, TOKEN_URI());
+
+    spy.assert_only_event_uri(contract_address, TOKEN_URI(), SAMPLE_ID);
+    assert_eq!(state.token_uri(SAMPLE_ID), TOKEN_URI());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is not the owner')]
+fn test_set_token_uri_unauthorized() {
+    let mut state = setup();
+
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_token_uri(SAMPLE_ID, TOKEN_URI());
+}
+
+//
+// Helpers
+//
+
+#[generate_trait]
+impl ERC6909ContentURISpyHelpersImpl of ERC6909ContentURISpyHelpers {
+    fn assert_only_event_contract_uri_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress,
+    ) {
+        let expected = ExpectedEvent::new().key(selector!("ContractURIUpdated"));
+        self.assert_emitted_single(contract, expected);
+        self.assert_no_events_left_from(contract);
+    }
+
+    fn assert_only_event_uri(
+        ref self: EventSpy, contract: starknet::ContractAddress, value: ByteArray, id: u256,
+    ) {
+        let expected = ExpectedEvent::new().key(selector!("URI")).key(id).data(value);
+        self.assert_emitted_single(contract, expected);
+        self.assert_no_events_left_from(contract);
+    }
+}

--- a/packages/token/src/tests/erc6909/test_erc6909_metadata.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_metadata.cairo
@@ -21,27 +21,17 @@ fn COMPONENT_STATE() -> ComponentState {
 }
 
 #[test]
-fn test_initializer_registers_interface_and_sets_metadata() {
+fn test_initializer_registers_interface() {
     let mut state = COMPONENT_STATE();
     let mock_state = CONTRACT_STATE();
     let contract_address = test_address();
 
     let mut spy = spy_events();
-    state.initializer(TOKEN_ID, NAME(), SYMBOL(), DECIMALS);
+    state.initializer();
 
-    spy.assert_event_name_updated(contract_address, TOKEN_ID, NAME());
-    spy.assert_event_symbol_updated(contract_address, TOKEN_ID, SYMBOL());
-    spy.assert_only_event_decimals_updated(contract_address, TOKEN_ID, DECIMALS);
+    spy.assert_no_events_left_from(contract_address);
     assert!(mock_state.supports_interface(IERC6909_METADATA_ID));
     assert!(mock_state.supports_interface(ISRC5_ID));
-    assert_eq!(state.name(TOKEN_ID), NAME());
-    assert_eq!(state.symbol(TOKEN_ID), SYMBOL());
-    assert_eq!(state.decimals(TOKEN_ID), DECIMALS);
-}
-
-#[test]
-fn test_default_getters_are_empty_or_zero() {
-    let state = COMPONENT_STATE();
 
     let empty: ByteArray = "";
     assert_eq!(state.name(TOKEN_ID), empty);

--- a/packages/token/src/tests/erc6909/test_erc6909_metadata.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_metadata.cairo
@@ -1,9 +1,10 @@
 use openzeppelin_interfaces::erc6909::IERC6909_METADATA_ID;
 use openzeppelin_interfaces::introspection::ISRC5_ID;
 use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
+use openzeppelin_test_common::erc6909::ERC6909MetadataSpyHelpers;
 use openzeppelin_test_common::mocks::erc6909::ERC6909MetadataMock;
 use openzeppelin_testing::constants::{DECIMALS, NAME, SYMBOL, TOKEN_ID};
-use openzeppelin_testing::{EventSpyExt, EventSpyQueue as EventSpy, ExpectedEvent, spy_events};
+use openzeppelin_testing::{EventSpyExt, spy_events};
 use snforge_std::test_address;
 use crate::erc6909::extensions::erc6909_metadata::ERC6909MetadataComponent;
 use crate::erc6909::extensions::erc6909_metadata::ERC6909MetadataComponent::{
@@ -86,58 +87,4 @@ fn test_set_all_metadata_individually() {
     assert_eq!(state.name(TOKEN_ID), NAME());
     assert_eq!(state.symbol(TOKEN_ID), SYMBOL());
     assert_eq!(state.decimals(TOKEN_ID), DECIMALS);
-}
-
-#[generate_trait]
-impl ERC6909MetadataSpyHelpersImpl of ERC6909MetadataSpyHelpers {
-    fn assert_event_name_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_name: ByteArray,
-    ) {
-        let expected = ExpectedEvent::new()
-            .key(selector!("ERC6909NameUpdated"))
-            .key(id)
-            .data(new_name);
-        self.assert_emitted_single(contract, expected);
-    }
-
-    fn assert_only_event_name_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_name: ByteArray,
-    ) {
-        self.assert_event_name_updated(contract, id, new_name);
-        self.assert_no_events_left_from(contract);
-    }
-
-    fn assert_event_symbol_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_symbol: ByteArray,
-    ) {
-        let expected = ExpectedEvent::new()
-            .key(selector!("ERC6909SymbolUpdated"))
-            .key(id)
-            .data(new_symbol);
-        self.assert_emitted_single(contract, expected);
-    }
-
-    fn assert_only_event_symbol_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_symbol: ByteArray,
-    ) {
-        self.assert_event_symbol_updated(contract, id, new_symbol);
-        self.assert_no_events_left_from(contract);
-    }
-
-    fn assert_event_decimals_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_decimals: u8,
-    ) {
-        let expected = ExpectedEvent::new()
-            .key(selector!("ERC6909DecimalsUpdated"))
-            .key(id)
-            .data(new_decimals);
-        self.assert_emitted_single(contract, expected);
-    }
-
-    fn assert_only_event_decimals_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_decimals: u8,
-    ) {
-        self.assert_event_decimals_updated(contract, id, new_decimals);
-        self.assert_no_events_left_from(contract);
-    }
 }

--- a/packages/token/src/tests/erc6909/test_erc6909_metadata_accesscontrol.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_metadata_accesscontrol.cairo
@@ -1,0 +1,233 @@
+use openzeppelin_access::accesscontrol::AccessControlComponent::InternalImpl as AccessControlInternalImpl;
+use openzeppelin_access::accesscontrol::{AccessControlComponent, DEFAULT_ADMIN_ROLE};
+use openzeppelin_test_common::mocks::erc6909::ERC6909MetadataAccessControlMock;
+use openzeppelin_testing::constants::{
+    ADMIN, DECIMALS, NAME, OTHER, OTHER_ADMIN, OTHER_ROLE, SYMBOL, TOKEN_ID,
+};
+use openzeppelin_testing::{EventSpyExt, EventSpyQueue as EventSpy, ExpectedEvent, spy_events};
+use snforge_std::{start_cheat_caller_address, test_address};
+use starknet::ContractAddress;
+use crate::erc6909::extensions::erc6909_metadata::ERC6909MetadataComponent;
+use crate::erc6909::extensions::erc6909_metadata::ERC6909MetadataComponent::{
+    ERC6909MetadataAdminAccessControlImpl, ERC6909MetadataImpl, InternalImpl, METADATA_ADMIN_ROLE,
+};
+
+type MockState = ERC6909MetadataAccessControlMock::ContractState;
+type ComponentState = ERC6909MetadataComponent::ComponentState<MockState>;
+type AccessControlComponentState = AccessControlComponent::ComponentState<MockState>;
+
+fn COMPONENT_STATE() -> ComponentState {
+    ERC6909MetadataComponent::component_state_for_testing()
+}
+
+fn ACCESS_CONTROL_STATE() -> AccessControlComponentState {
+    AccessControlComponent::component_state_for_testing()
+}
+
+fn setup() -> ComponentState {
+    let mut state = COMPONENT_STATE();
+    state.initializer();
+
+    let mut access_control_state = ACCESS_CONTROL_STATE();
+    access_control_state.initializer();
+    grant_accesscontrol_role(DEFAULT_ADMIN_ROLE, ADMIN);
+    grant_accesscontrol_role(METADATA_ADMIN_ROLE, ADMIN);
+
+    state
+}
+
+//
+// IERC6909MetadataAdmin - AccessControl
+//
+
+#[test]
+fn test_set_token_name() {
+    let mut state = setup();
+    let contract_address = test_address();
+
+    let mut spy = spy_events();
+    start_cheat_caller_address(test_address(), ADMIN);
+    state.set_token_name(TOKEN_ID, NAME());
+
+    spy.assert_only_event_name_updated(contract_address, TOKEN_ID, NAME());
+    assert_eq!(state.name(TOKEN_ID), NAME());
+}
+
+#[test]
+fn test_set_token_name_other_admin() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(METADATA_ADMIN_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_name(TOKEN_ID, NAME());
+
+    assert_eq!(state.name(TOKEN_ID), NAME());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_name_unauthorized() {
+    let mut state = setup();
+
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_token_name(TOKEN_ID, NAME());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_name_invalid_role() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(OTHER_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_name(TOKEN_ID, NAME());
+}
+
+#[test]
+fn test_set_token_symbol() {
+    let mut state = setup();
+    let contract_address = test_address();
+
+    let mut spy = spy_events();
+    start_cheat_caller_address(test_address(), ADMIN);
+    state.set_token_symbol(TOKEN_ID, SYMBOL());
+
+    spy.assert_only_event_symbol_updated(contract_address, TOKEN_ID, SYMBOL());
+    assert_eq!(state.symbol(TOKEN_ID), SYMBOL());
+}
+
+#[test]
+fn test_set_token_symbol_other_admin() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(METADATA_ADMIN_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_symbol(TOKEN_ID, SYMBOL());
+
+    assert_eq!(state.symbol(TOKEN_ID), SYMBOL());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_symbol_unauthorized() {
+    let mut state = setup();
+
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_token_symbol(TOKEN_ID, SYMBOL());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_symbol_invalid_role() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(OTHER_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_symbol(TOKEN_ID, SYMBOL());
+}
+
+#[test]
+fn test_set_token_decimals() {
+    let mut state = setup();
+    let contract_address = test_address();
+
+    let mut spy = spy_events();
+    start_cheat_caller_address(test_address(), ADMIN);
+    state.set_token_decimals(TOKEN_ID, DECIMALS);
+
+    spy.assert_only_event_decimals_updated(contract_address, TOKEN_ID, DECIMALS);
+    assert_eq!(state.decimals(TOKEN_ID), DECIMALS);
+}
+
+#[test]
+fn test_set_token_decimals_other_admin() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(METADATA_ADMIN_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_decimals(TOKEN_ID, DECIMALS);
+
+    assert_eq!(state.decimals(TOKEN_ID), DECIMALS);
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_decimals_unauthorized() {
+    let mut state = setup();
+
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_token_decimals(TOKEN_ID, DECIMALS);
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_decimals_invalid_role() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(OTHER_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_decimals(TOKEN_ID, DECIMALS);
+}
+
+//
+// Helpers
+//
+
+fn grant_accesscontrol_role(role: felt252, admin: ContractAddress) {
+    let mut state = ACCESS_CONTROL_STATE();
+    state._grant_role(role, admin);
+}
+
+#[generate_trait]
+impl ERC6909MetadataSpyHelpersImpl of ERC6909MetadataSpyHelpers {
+    fn assert_event_name_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_name: ByteArray,
+    ) {
+        let expected = ExpectedEvent::new()
+            .key(selector!("ERC6909NameUpdated"))
+            .key(id)
+            .data(new_name);
+        self.assert_emitted_single(contract, expected);
+    }
+
+    fn assert_only_event_name_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_name: ByteArray,
+    ) {
+        self.assert_event_name_updated(contract, id, new_name);
+        self.assert_no_events_left_from(contract);
+    }
+
+    fn assert_event_symbol_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_symbol: ByteArray,
+    ) {
+        let expected = ExpectedEvent::new()
+            .key(selector!("ERC6909SymbolUpdated"))
+            .key(id)
+            .data(new_symbol);
+        self.assert_emitted_single(contract, expected);
+    }
+
+    fn assert_only_event_symbol_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_symbol: ByteArray,
+    ) {
+        self.assert_event_symbol_updated(contract, id, new_symbol);
+        self.assert_no_events_left_from(contract);
+    }
+
+    fn assert_event_decimals_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_decimals: u8,
+    ) {
+        let expected = ExpectedEvent::new()
+            .key(selector!("ERC6909DecimalsUpdated"))
+            .key(id)
+            .data(new_decimals);
+        self.assert_emitted_single(contract, expected);
+    }
+
+    fn assert_only_event_decimals_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_decimals: u8,
+    ) {
+        self.assert_event_decimals_updated(contract, id, new_decimals);
+        self.assert_no_events_left_from(contract);
+    }
+}

--- a/packages/token/src/tests/erc6909/test_erc6909_metadata_accesscontrol.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_metadata_accesscontrol.cairo
@@ -1,10 +1,11 @@
 use openzeppelin_access::accesscontrol::AccessControlComponent::InternalImpl as AccessControlInternalImpl;
 use openzeppelin_access::accesscontrol::{AccessControlComponent, DEFAULT_ADMIN_ROLE};
+use openzeppelin_test_common::erc6909::ERC6909MetadataSpyHelpers;
 use openzeppelin_test_common::mocks::erc6909::ERC6909MetadataAccessControlMock;
 use openzeppelin_testing::constants::{
     ADMIN, DECIMALS, NAME, OTHER, OTHER_ADMIN, OTHER_ROLE, SYMBOL, TOKEN_ID,
 };
-use openzeppelin_testing::{EventSpyExt, EventSpyQueue as EventSpy, ExpectedEvent, spy_events};
+use openzeppelin_testing::spy_events;
 use snforge_std::{start_cheat_caller_address, test_address};
 use starknet::ContractAddress;
 use crate::erc6909::extensions::erc6909_metadata::ERC6909MetadataComponent;
@@ -176,58 +177,4 @@ fn test_set_token_decimals_invalid_role() {
 fn grant_accesscontrol_role(role: felt252, admin: ContractAddress) {
     let mut state = ACCESS_CONTROL_STATE();
     state._grant_role(role, admin);
-}
-
-#[generate_trait]
-impl ERC6909MetadataSpyHelpersImpl of ERC6909MetadataSpyHelpers {
-    fn assert_event_name_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_name: ByteArray,
-    ) {
-        let expected = ExpectedEvent::new()
-            .key(selector!("ERC6909NameUpdated"))
-            .key(id)
-            .data(new_name);
-        self.assert_emitted_single(contract, expected);
-    }
-
-    fn assert_only_event_name_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_name: ByteArray,
-    ) {
-        self.assert_event_name_updated(contract, id, new_name);
-        self.assert_no_events_left_from(contract);
-    }
-
-    fn assert_event_symbol_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_symbol: ByteArray,
-    ) {
-        let expected = ExpectedEvent::new()
-            .key(selector!("ERC6909SymbolUpdated"))
-            .key(id)
-            .data(new_symbol);
-        self.assert_emitted_single(contract, expected);
-    }
-
-    fn assert_only_event_symbol_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_symbol: ByteArray,
-    ) {
-        self.assert_event_symbol_updated(contract, id, new_symbol);
-        self.assert_no_events_left_from(contract);
-    }
-
-    fn assert_event_decimals_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_decimals: u8,
-    ) {
-        let expected = ExpectedEvent::new()
-            .key(selector!("ERC6909DecimalsUpdated"))
-            .key(id)
-            .data(new_decimals);
-        self.assert_emitted_single(contract, expected);
-    }
-
-    fn assert_only_event_decimals_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_decimals: u8,
-    ) {
-        self.assert_event_decimals_updated(contract, id, new_decimals);
-        self.assert_no_events_left_from(contract);
-    }
 }

--- a/packages/token/src/tests/erc6909/test_erc6909_metadata_accesscontrol_default_admin_rules.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_metadata_accesscontrol_default_admin_rules.cairo
@@ -2,11 +2,12 @@ use openzeppelin_access::accesscontrol::extensions::AccessControlDefaultAdminRul
 use openzeppelin_access::accesscontrol::extensions::{
     AccessControlDefaultAdminRulesComponent, DefaultConfig as AccessControlDARDefaultConfig,
 };
+use openzeppelin_test_common::erc6909::ERC6909MetadataSpyHelpers;
 use openzeppelin_test_common::mocks::erc6909::ERC6909MetadataAccessControlDefaultAdminRulesMock;
 use openzeppelin_testing::constants::{
     ADMIN, DECIMALS, NAME, OTHER, OTHER_ADMIN, OTHER_ROLE, SYMBOL, TOKEN_ID,
 };
-use openzeppelin_testing::{EventSpyExt, EventSpyQueue as EventSpy, ExpectedEvent, spy_events};
+use openzeppelin_testing::spy_events;
 use snforge_std::{start_cheat_caller_address, test_address};
 use starknet::ContractAddress;
 use crate::erc6909::extensions::erc6909_metadata::ERC6909MetadataComponent;
@@ -181,58 +182,4 @@ fn test_set_token_decimals_invalid_role() {
 fn grant_accesscontrol_role(role: felt252, admin: ContractAddress) {
     let mut state = ACCESS_CONTROL_STATE();
     state._grant_role(role, admin);
-}
-
-#[generate_trait]
-impl ERC6909MetadataSpyHelpersImpl of ERC6909MetadataSpyHelpers {
-    fn assert_event_name_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_name: ByteArray,
-    ) {
-        let expected = ExpectedEvent::new()
-            .key(selector!("ERC6909NameUpdated"))
-            .key(id)
-            .data(new_name);
-        self.assert_emitted_single(contract, expected);
-    }
-
-    fn assert_only_event_name_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_name: ByteArray,
-    ) {
-        self.assert_event_name_updated(contract, id, new_name);
-        self.assert_no_events_left_from(contract);
-    }
-
-    fn assert_event_symbol_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_symbol: ByteArray,
-    ) {
-        let expected = ExpectedEvent::new()
-            .key(selector!("ERC6909SymbolUpdated"))
-            .key(id)
-            .data(new_symbol);
-        self.assert_emitted_single(contract, expected);
-    }
-
-    fn assert_only_event_symbol_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_symbol: ByteArray,
-    ) {
-        self.assert_event_symbol_updated(contract, id, new_symbol);
-        self.assert_no_events_left_from(contract);
-    }
-
-    fn assert_event_decimals_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_decimals: u8,
-    ) {
-        let expected = ExpectedEvent::new()
-            .key(selector!("ERC6909DecimalsUpdated"))
-            .key(id)
-            .data(new_decimals);
-        self.assert_emitted_single(contract, expected);
-    }
-
-    fn assert_only_event_decimals_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_decimals: u8,
-    ) {
-        self.assert_event_decimals_updated(contract, id, new_decimals);
-        self.assert_no_events_left_from(contract);
-    }
 }

--- a/packages/token/src/tests/erc6909/test_erc6909_metadata_accesscontrol_default_admin_rules.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_metadata_accesscontrol_default_admin_rules.cairo
@@ -1,0 +1,238 @@
+use openzeppelin_access::accesscontrol::extensions::AccessControlDefaultAdminRulesComponent::InternalImpl as AccessControlInternalImpl;
+use openzeppelin_access::accesscontrol::extensions::{
+    AccessControlDefaultAdminRulesComponent, DefaultConfig as AccessControlDARDefaultConfig,
+};
+use openzeppelin_test_common::mocks::erc6909::ERC6909MetadataAccessControlDefaultAdminRulesMock;
+use openzeppelin_testing::constants::{
+    ADMIN, DECIMALS, NAME, OTHER, OTHER_ADMIN, OTHER_ROLE, SYMBOL, TOKEN_ID,
+};
+use openzeppelin_testing::{EventSpyExt, EventSpyQueue as EventSpy, ExpectedEvent, spy_events};
+use snforge_std::{start_cheat_caller_address, test_address};
+use starknet::ContractAddress;
+use crate::erc6909::extensions::erc6909_metadata::ERC6909MetadataComponent;
+use crate::erc6909::extensions::erc6909_metadata::ERC6909MetadataComponent::{
+    ERC6909MetadataAdminAccessControlDefaultAdminRulesImpl, ERC6909MetadataImpl, InternalImpl,
+    METADATA_ADMIN_ROLE,
+};
+
+type MockState = ERC6909MetadataAccessControlDefaultAdminRulesMock::ContractState;
+type ComponentState = ERC6909MetadataComponent::ComponentState<MockState>;
+type AccessControlComponentState =
+    AccessControlDefaultAdminRulesComponent::ComponentState<MockState>;
+
+const DEFAULT_INITIAL_DELAY: u64 = 3600; // 1 hour
+
+fn COMPONENT_STATE() -> ComponentState {
+    ERC6909MetadataComponent::component_state_for_testing()
+}
+
+fn ACCESS_CONTROL_STATE() -> AccessControlComponentState {
+    AccessControlDefaultAdminRulesComponent::component_state_for_testing()
+}
+
+fn setup() -> ComponentState {
+    let mut state = COMPONENT_STATE();
+    state.initializer();
+
+    let mut access_control_state = ACCESS_CONTROL_STATE();
+    access_control_state.initializer(DEFAULT_INITIAL_DELAY, ADMIN);
+    grant_accesscontrol_role(METADATA_ADMIN_ROLE, ADMIN);
+
+    state
+}
+
+//
+// IERC6909MetadataAdmin - AccessControlDefaultAdminRules
+//
+
+#[test]
+fn test_set_token_name() {
+    let mut state = setup();
+    let contract_address = test_address();
+
+    let mut spy = spy_events();
+    start_cheat_caller_address(test_address(), ADMIN);
+    state.set_token_name(TOKEN_ID, NAME());
+
+    spy.assert_only_event_name_updated(contract_address, TOKEN_ID, NAME());
+    assert_eq!(state.name(TOKEN_ID), NAME());
+}
+
+#[test]
+fn test_set_token_name_other_admin() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(METADATA_ADMIN_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_name(TOKEN_ID, NAME());
+
+    assert_eq!(state.name(TOKEN_ID), NAME());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_name_unauthorized() {
+    let mut state = setup();
+
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_token_name(TOKEN_ID, NAME());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_name_invalid_role() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(OTHER_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_name(TOKEN_ID, NAME());
+}
+
+#[test]
+fn test_set_token_symbol() {
+    let mut state = setup();
+    let contract_address = test_address();
+
+    let mut spy = spy_events();
+    start_cheat_caller_address(test_address(), ADMIN);
+    state.set_token_symbol(TOKEN_ID, SYMBOL());
+
+    spy.assert_only_event_symbol_updated(contract_address, TOKEN_ID, SYMBOL());
+    assert_eq!(state.symbol(TOKEN_ID), SYMBOL());
+}
+
+#[test]
+fn test_set_token_symbol_other_admin() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(METADATA_ADMIN_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_symbol(TOKEN_ID, SYMBOL());
+
+    assert_eq!(state.symbol(TOKEN_ID), SYMBOL());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_symbol_unauthorized() {
+    let mut state = setup();
+
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_token_symbol(TOKEN_ID, SYMBOL());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_symbol_invalid_role() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(OTHER_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_symbol(TOKEN_ID, SYMBOL());
+}
+
+#[test]
+fn test_set_token_decimals() {
+    let mut state = setup();
+    let contract_address = test_address();
+
+    let mut spy = spy_events();
+    start_cheat_caller_address(test_address(), ADMIN);
+    state.set_token_decimals(TOKEN_ID, DECIMALS);
+
+    spy.assert_only_event_decimals_updated(contract_address, TOKEN_ID, DECIMALS);
+    assert_eq!(state.decimals(TOKEN_ID), DECIMALS);
+}
+
+#[test]
+fn test_set_token_decimals_other_admin() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(METADATA_ADMIN_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_decimals(TOKEN_ID, DECIMALS);
+
+    assert_eq!(state.decimals(TOKEN_ID), DECIMALS);
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_decimals_unauthorized() {
+    let mut state = setup();
+
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_token_decimals(TOKEN_ID, DECIMALS);
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_token_decimals_invalid_role() {
+    let mut state = setup();
+
+    grant_accesscontrol_role(OTHER_ROLE, OTHER_ADMIN);
+    start_cheat_caller_address(test_address(), OTHER_ADMIN);
+    state.set_token_decimals(TOKEN_ID, DECIMALS);
+}
+
+//
+// Helpers
+//
+
+fn grant_accesscontrol_role(role: felt252, admin: ContractAddress) {
+    let mut state = ACCESS_CONTROL_STATE();
+    state._grant_role(role, admin);
+}
+
+#[generate_trait]
+impl ERC6909MetadataSpyHelpersImpl of ERC6909MetadataSpyHelpers {
+    fn assert_event_name_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_name: ByteArray,
+    ) {
+        let expected = ExpectedEvent::new()
+            .key(selector!("ERC6909NameUpdated"))
+            .key(id)
+            .data(new_name);
+        self.assert_emitted_single(contract, expected);
+    }
+
+    fn assert_only_event_name_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_name: ByteArray,
+    ) {
+        self.assert_event_name_updated(contract, id, new_name);
+        self.assert_no_events_left_from(contract);
+    }
+
+    fn assert_event_symbol_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_symbol: ByteArray,
+    ) {
+        let expected = ExpectedEvent::new()
+            .key(selector!("ERC6909SymbolUpdated"))
+            .key(id)
+            .data(new_symbol);
+        self.assert_emitted_single(contract, expected);
+    }
+
+    fn assert_only_event_symbol_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_symbol: ByteArray,
+    ) {
+        self.assert_event_symbol_updated(contract, id, new_symbol);
+        self.assert_no_events_left_from(contract);
+    }
+
+    fn assert_event_decimals_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_decimals: u8,
+    ) {
+        let expected = ExpectedEvent::new()
+            .key(selector!("ERC6909DecimalsUpdated"))
+            .key(id)
+            .data(new_decimals);
+        self.assert_emitted_single(contract, expected);
+    }
+
+    fn assert_only_event_decimals_updated(
+        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_decimals: u8,
+    ) {
+        self.assert_event_decimals_updated(contract, id, new_decimals);
+        self.assert_no_events_left_from(contract);
+    }
+}

--- a/packages/token/src/tests/erc6909/test_erc6909_metadata_ownable.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_metadata_ownable.cairo
@@ -1,92 +1,105 @@
-use openzeppelin_interfaces::erc6909::IERC6909_METADATA_ID;
-use openzeppelin_interfaces::introspection::ISRC5_ID;
-use openzeppelin_introspection::src5::SRC5Component::SRC5Impl;
-use openzeppelin_test_common::mocks::erc6909::ERC6909MetadataMock;
-use openzeppelin_testing::constants::{DECIMALS, NAME, SYMBOL, TOKEN_ID};
+use openzeppelin_access::ownable::OwnableComponent;
+use openzeppelin_access::ownable::OwnableComponent::InternalImpl as OwnableInternalImpl;
+use openzeppelin_test_common::mocks::erc6909::ERC6909MetadataOwnableMock;
+use openzeppelin_testing::constants::{DECIMALS, NAME, OTHER, OWNER, SYMBOL, TOKEN_ID};
 use openzeppelin_testing::{EventSpyExt, EventSpyQueue as EventSpy, ExpectedEvent, spy_events};
-use snforge_std::test_address;
+use snforge_std::{start_cheat_caller_address, test_address};
 use crate::erc6909::extensions::erc6909_metadata::ERC6909MetadataComponent;
 use crate::erc6909::extensions::erc6909_metadata::ERC6909MetadataComponent::{
-    ERC6909MetadataImpl, InternalImpl,
+    ERC6909MetadataAdminOwnableImpl, ERC6909MetadataImpl, InternalImpl,
 };
 
-type ComponentState = ERC6909MetadataComponent::ComponentState<ERC6909MetadataMock::ContractState>;
-
-fn CONTRACT_STATE() -> ERC6909MetadataMock::ContractState {
-    ERC6909MetadataMock::contract_state_for_testing()
-}
+type MockState = ERC6909MetadataOwnableMock::ContractState;
+type ComponentState = ERC6909MetadataComponent::ComponentState<MockState>;
+type OwnableComponentState = OwnableComponent::ComponentState<MockState>;
 
 fn COMPONENT_STATE() -> ComponentState {
     ERC6909MetadataComponent::component_state_for_testing()
 }
 
-#[test]
-fn test_initializer_registers_interface() {
+fn setup() -> ComponentState {
     let mut state = COMPONENT_STATE();
-    let mock_state = CONTRACT_STATE();
-    let contract_address = test_address();
-
-    let mut spy = spy_events();
     state.initializer();
 
-    spy.assert_no_events_left_from(contract_address);
-    assert!(mock_state.supports_interface(IERC6909_METADATA_ID));
-    assert!(mock_state.supports_interface(ISRC5_ID));
+    let mut ownable_state: OwnableComponentState = OwnableComponent::component_state_for_testing();
+    ownable_state.initializer(OWNER);
 
-    let empty: ByteArray = "";
-    assert_eq!(state.name(TOKEN_ID), empty);
-    assert_eq!(state.symbol(TOKEN_ID), empty);
-    assert_eq!(state.decimals(TOKEN_ID), 0);
+    state
 }
 
+//
+// IERC6909MetadataAdmin - Ownable
+//
+
 #[test]
-fn test__set_token_name() {
-    let mut state = COMPONENT_STATE();
+fn test_set_token_name() {
+    let mut state = setup();
     let contract_address = test_address();
 
     let mut spy = spy_events();
-    state._set_token_name(TOKEN_ID, NAME());
+    start_cheat_caller_address(test_address(), OWNER);
+    state.set_token_name(TOKEN_ID, NAME());
 
     spy.assert_only_event_name_updated(contract_address, TOKEN_ID, NAME());
     assert_eq!(state.name(TOKEN_ID), NAME());
 }
 
 #[test]
-fn test__set_token_symbol() {
-    let mut state = COMPONENT_STATE();
+#[should_panic(expected: 'Caller is not the owner')]
+fn test_set_token_name_unauthorized() {
+    let mut state = setup();
+
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_token_name(TOKEN_ID, NAME());
+}
+
+#[test]
+fn test_set_token_symbol() {
+    let mut state = setup();
     let contract_address = test_address();
 
     let mut spy = spy_events();
-    state._set_token_symbol(TOKEN_ID, SYMBOL());
+    start_cheat_caller_address(test_address(), OWNER);
+    state.set_token_symbol(TOKEN_ID, SYMBOL());
 
     spy.assert_only_event_symbol_updated(contract_address, TOKEN_ID, SYMBOL());
     assert_eq!(state.symbol(TOKEN_ID), SYMBOL());
 }
 
 #[test]
-fn test__set_token_decimals() {
-    let mut state = COMPONENT_STATE();
+#[should_panic(expected: 'Caller is not the owner')]
+fn test_set_token_symbol_unauthorized() {
+    let mut state = setup();
+
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_token_symbol(TOKEN_ID, SYMBOL());
+}
+
+#[test]
+fn test_set_token_decimals() {
+    let mut state = setup();
     let contract_address = test_address();
 
     let mut spy = spy_events();
-    state._set_token_decimals(TOKEN_ID, DECIMALS);
+    start_cheat_caller_address(test_address(), OWNER);
+    state.set_token_decimals(TOKEN_ID, DECIMALS);
 
     spy.assert_only_event_decimals_updated(contract_address, TOKEN_ID, DECIMALS);
     assert_eq!(state.decimals(TOKEN_ID), DECIMALS);
 }
 
 #[test]
-fn test_set_all_metadata_individually() {
-    let mut state = COMPONENT_STATE();
+#[should_panic(expected: 'Caller is not the owner')]
+fn test_set_token_decimals_unauthorized() {
+    let mut state = setup();
 
-    state._set_token_name(TOKEN_ID, NAME());
-    state._set_token_symbol(TOKEN_ID, SYMBOL());
-    state._set_token_decimals(TOKEN_ID, DECIMALS);
-
-    assert_eq!(state.name(TOKEN_ID), NAME());
-    assert_eq!(state.symbol(TOKEN_ID), SYMBOL());
-    assert_eq!(state.decimals(TOKEN_ID), DECIMALS);
+    start_cheat_caller_address(test_address(), OTHER);
+    state.set_token_decimals(TOKEN_ID, DECIMALS);
 }
+
+//
+// Helpers
+//
 
 #[generate_trait]
 impl ERC6909MetadataSpyHelpersImpl of ERC6909MetadataSpyHelpers {

--- a/packages/token/src/tests/erc6909/test_erc6909_metadata_ownable.cairo
+++ b/packages/token/src/tests/erc6909/test_erc6909_metadata_ownable.cairo
@@ -1,8 +1,9 @@
 use openzeppelin_access::ownable::OwnableComponent;
 use openzeppelin_access::ownable::OwnableComponent::InternalImpl as OwnableInternalImpl;
+use openzeppelin_test_common::erc6909::ERC6909MetadataSpyHelpers;
 use openzeppelin_test_common::mocks::erc6909::ERC6909MetadataOwnableMock;
 use openzeppelin_testing::constants::{DECIMALS, NAME, OTHER, OWNER, SYMBOL, TOKEN_ID};
-use openzeppelin_testing::{EventSpyExt, EventSpyQueue as EventSpy, ExpectedEvent, spy_events};
+use openzeppelin_testing::spy_events;
 use snforge_std::{start_cheat_caller_address, test_address};
 use crate::erc6909::extensions::erc6909_metadata::ERC6909MetadataComponent;
 use crate::erc6909::extensions::erc6909_metadata::ERC6909MetadataComponent::{
@@ -95,62 +96,4 @@ fn test_set_token_decimals_unauthorized() {
 
     start_cheat_caller_address(test_address(), OTHER);
     state.set_token_decimals(TOKEN_ID, DECIMALS);
-}
-
-//
-// Helpers
-//
-
-#[generate_trait]
-impl ERC6909MetadataSpyHelpersImpl of ERC6909MetadataSpyHelpers {
-    fn assert_event_name_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_name: ByteArray,
-    ) {
-        let expected = ExpectedEvent::new()
-            .key(selector!("ERC6909NameUpdated"))
-            .key(id)
-            .data(new_name);
-        self.assert_emitted_single(contract, expected);
-    }
-
-    fn assert_only_event_name_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_name: ByteArray,
-    ) {
-        self.assert_event_name_updated(contract, id, new_name);
-        self.assert_no_events_left_from(contract);
-    }
-
-    fn assert_event_symbol_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_symbol: ByteArray,
-    ) {
-        let expected = ExpectedEvent::new()
-            .key(selector!("ERC6909SymbolUpdated"))
-            .key(id)
-            .data(new_symbol);
-        self.assert_emitted_single(contract, expected);
-    }
-
-    fn assert_only_event_symbol_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_symbol: ByteArray,
-    ) {
-        self.assert_event_symbol_updated(contract, id, new_symbol);
-        self.assert_no_events_left_from(contract);
-    }
-
-    fn assert_event_decimals_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_decimals: u8,
-    ) {
-        let expected = ExpectedEvent::new()
-            .key(selector!("ERC6909DecimalsUpdated"))
-            .key(id)
-            .data(new_decimals);
-        self.assert_emitted_single(contract, expected);
-    }
-
-    fn assert_only_event_decimals_updated(
-        ref self: EventSpy, contract: starknet::ContractAddress, id: u256, new_decimals: u8,
-    ) {
-        self.assert_event_decimals_updated(contract, id, new_decimals);
-        self.assert_no_events_left_from(contract);
-    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin interfaces for managing ERC-6909 token metadata and content URIs.
  * Three admin implementations: Ownable, AccessControl, and AccessControl with DefaultAdminRules.

* **Breaking Changes**
  * Metadata initializer now only registers the interface; metadata must be initialized via admin setters.
  * Internal setters converted to private/internal variants (setter calls adjusted accordingly).

* **Tests**
  * Added comprehensive tests and event-assertion helpers for metadata and content-URI admin flows.

* **Documentation**
  * Changelog updated with these entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->