### PR TITLE
Bump Scarb to `2.18`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Run tests
         run: snforge test --workspace --features fuzzing --fuzzer-runs 200
 
-      # TODO: Uncomment once a cairo-coverage version compatible with Scarb 2.17.0 is released.
-      # The latest cairo-coverage (0.6.0) does not support Scarb 2.17.0.
+      # TODO: Uncomment once a cairo-coverage version compatible with Scarb 2.18.0 is released.
+      # The latest cairo-coverage (0.6.0) does not support Scarb 2.18.0.
       # - name: Run tests and generate coverage report
       #   run: snforge test --workspace --coverage
       #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ERC-3156 standard interfaces and `ERC20FlashMintComponent` extension (#1608)
 
-## Changed
+### Changed
 
-- Bump scarb to v2.17.0 (#1672)
+- Bump scarb to v2.18.0 (#1677)
 
 ## 4.0.0-alpha.0 (2026-01-31)
 

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -27,8 +27,8 @@ edition.workspace = true
 [workspace.package]
 version = "4.0.0-alpha.0"
 edition = "2024_07"
-cairo-version = "2.17.0"
-scarb-version = "2.17.0"
+cairo-version = "2.18.0"
+scarb-version = "2.18.0"
 authors = ["OpenZeppelin Community <maintainers@openzeppelin.org>"]
 description = "OpenZeppelin Contracts written in Cairo for Starknet, a decentralized ZK Rollup"
 documentation = "https://docs.openzeppelin.com/contracts-cairo"
@@ -43,8 +43,8 @@ keywords = [
 ]
 
 [workspace.dependencies]
-assert_macros = "2.17.0"
-starknet = "2.17.0"
+assert_macros = "2.18.0"
+starknet = "2.18.0"
 snforge_std = "0.59.0"
 
 [dependencies]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cairo and Scarb toolchain versions from 2.17.0 to 2.18.0
  * Bumped compatible dependencies to align with the new toolchain versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->