### PR TITLE
Reuse `snforge_std` functions in `testing` package

### DIFF
--- a/packages/testing/src/deployment.cairo
+++ b/packages/testing/src/deployment.cairo
@@ -1,4 +1,4 @@
-use snforge_std::{ContractClass, ContractClassTrait, DeclareResult};
+use snforge_std::{ContractClass, ContractClassTrait, DeclareResultTrait};
 use starknet::ContractAddress;
 use crate::panic_data_to_byte_array;
 
@@ -8,10 +8,7 @@ use crate::panic_data_to_byte_array;
 /// `DeclareResult::AlreadyDeclared`)
 pub fn declare_class(contract_name: ByteArray) -> ContractClass {
     match snforge_std::declare(contract_name) {
-        Result::Ok(declare_result) => match declare_result {
-            DeclareResult::Success(contract_class) => contract_class,
-            DeclareResult::AlreadyDeclared(contract_class) => contract_class,
-        },
+        Result::Ok(declare_result) => *declare_result.contract_class(),
         Result::Err(panic_data) => panic!("{}", panic_data_to_byte_array(panic_data)),
     }
 }

--- a/packages/testing/src/events.cairo
+++ b/packages/testing/src/events.cairo
@@ -1,6 +1,6 @@
 use core::fmt::{Debug, Error, Formatter};
 use snforge_std::cheatcodes::events::Events;
-use snforge_std::{Event, EventSpy, EventSpyTrait, EventsFilterTrait};
+use snforge_std::{Event, EventSpy, EventSpyTrait, EventsFilterTrait, IsEmitted};
 use starknet::ContractAddress;
 
 /// A wrapper around the `EventSpy` structure to allow treating the events as a queue.
@@ -233,7 +233,7 @@ impl EventSpyQueueAssertionsTraitImpl<
 
         while i != events.len() {
             let (from, event) = events.at(i);
-            let emitted = is_emitted(@received_events, from, event);
+            let emitted = received_events.is_emitted(*from, event);
 
             if !emitted {
                 let from: felt252 = (*from).into();
@@ -250,7 +250,7 @@ impl EventSpyQueueAssertionsTraitImpl<
 
         while i != events.len() {
             let (from, event) = events.at(i);
-            let emitted = is_emitted(@received_events, from, event);
+            let emitted = received_events.is_emitted(*from, event);
 
             if emitted {
                 let from: felt252 = (*from).into();
@@ -260,28 +260,4 @@ impl EventSpyQueueAssertionsTraitImpl<
             i += 1;
         };
     }
-}
-
-fn is_emitted<T, impl TEvent: starknet::Event<T>, impl TDrop: Drop<T>>(
-    self: @Events, expected_emitted_by: @ContractAddress, expected_event: @T,
-) -> bool {
-    let mut expected_keys = array![];
-    let mut expected_data = array![];
-    expected_event.append_keys_and_data(ref expected_keys, ref expected_data);
-
-    let mut i = 0;
-    let mut is_emitted = false;
-    while i != self.events.len() {
-        let (from, event) = self.events.at(i);
-
-        if from == expected_emitted_by
-            && event.keys == @expected_keys
-            && event.data == @expected_data {
-            is_emitted = true;
-            break;
-        }
-
-        i += 1;
-    }
-    return is_emitted;
 }


### PR DESCRIPTION
[Refactor only]

Replace duplicated code in the `testing` package with functions that exist in `snforge_std`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contract deployment handling for already-declared contracts.
  * Updated event assertions to reliably detect emitted and non-emitted events.
  * Preserved existing error reporting when deployment fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->