### PR TITLE
[L-04] M3 Audit

### DIFF
--- a/packages/macros/src/attribute/with_components/parser.rs
+++ b/packages/macros/src/attribute/with_components/parser.rs
@@ -485,7 +485,17 @@ fn validate_contract_module<'db>(
         if !components_with_initializer.is_empty() {
             let mut components_with_initializer_missing = vec![];
             for component in components_with_initializer.iter() {
-                if !facts.has_constructor_call(&["self", component.storage, "initializer"]) {
+                let initializer_called =
+                    facts.has_constructor_call(&["self", component.storage, "initializer"]);
+                let no_metadata_initializer_called = matches!(
+                    component.kind(),
+                    AllowedComponents::ERC721 | AllowedComponents::ERC1155
+                ) && facts.has_constructor_call(&[
+                    "self",
+                    component.storage,
+                    "initializer_no_metadata",
+                ]);
+                if !initializer_called && !no_metadata_initializer_called {
                     components_with_initializer_missing.push(component.short_name());
                 }
             }

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_with_components__with_erc1155_no_metadata_initializer.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_with_components__with_erc1155_no_metadata_initializer.snap
@@ -1,0 +1,40 @@
+---
+source: src/tests/test_with_components.rs
+expression: result
+---
+TokenStream:
+
+#[starknet::contract]
+pub mod MyContract {
+    use openzeppelin_token::erc1155::ERC1155HooksEmptyImpl;
+    #[storage]
+    pub struct Storage {
+        #[substorage(v0)]
+        pub erc1155: ERC1155Component::Storage,
+    }
+    #[constructor]
+    fn constructor(ref self: ContractState) {
+        self.erc1155.initializer_no_metadata();
+    }
+    use openzeppelin_token::erc1155::ERC1155Component;
+
+    component!(path: ERC1155Component, storage: erc1155, event: ERC1155Event);
+
+    impl ERC1155InternalImpl = ERC1155Component::InternalImpl<ContractState>;
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        ERC1155Event: ERC1155Component::Event,
+    }
+}
+
+
+Diagnostics:
+
+None
+
+AuxData:
+
+None

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_with_components__with_erc721_no_metadata_initializer.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_with_components__with_erc721_no_metadata_initializer.snap
@@ -1,0 +1,40 @@
+---
+source: src/tests/test_with_components.rs
+expression: result
+---
+TokenStream:
+
+#[starknet::contract]
+pub mod MyContract {
+    use openzeppelin_token::erc721::ERC721HooksEmptyImpl;
+    #[storage]
+    pub struct Storage {
+        #[substorage(v0)]
+        pub erc721: ERC721Component::Storage,
+    }
+    #[constructor]
+    fn constructor(ref self: ContractState) {
+        self.erc721.initializer_no_metadata();
+    }
+    use openzeppelin_token::erc721::ERC721Component;
+
+    component!(path: ERC721Component, storage: erc721, event: ERC721Event);
+
+    impl ERC721InternalImpl = ERC721Component::InternalImpl<ContractState>;
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        ERC721Event: ERC721Component::Event,
+    }
+}
+
+
+Diagnostics:
+
+None
+
+AuxData:
+
+None

--- a/packages/macros/src/tests/test_with_components.rs
+++ b/packages/macros/src/tests/test_with_components.rs
@@ -870,6 +870,27 @@ fn test_with_erc721() {
 }
 
 #[test]
+fn test_with_erc721_no_metadata_initializer() {
+    let attribute = quote! { (ERC721) };
+    let item = quote! {
+        #[starknet::contract]
+        pub mod MyContract {
+            use openzeppelin_token::erc721::ERC721HooksEmptyImpl;
+
+            #[storage]
+            pub struct Storage {}
+
+            #[constructor]
+            fn constructor(ref self: ContractState) {
+                self.erc721.initializer_no_metadata();
+            }
+        }
+    };
+    let result = get_string_result(attribute, item);
+    assert_snapshot!(result);
+}
+
+#[test]
 fn test_with_erc721_no_initializer() {
     let attribute = quote! { (ERC721) };
     let item = quote! {
@@ -963,6 +984,27 @@ fn test_with_erc1155() {
             #[constructor]
             fn constructor(ref self: ContractState) {
                 self.erc1155.initializer("");
+            }
+        }
+    };
+    let result = get_string_result(attribute, item);
+    assert_snapshot!(result);
+}
+
+#[test]
+fn test_with_erc1155_no_metadata_initializer() {
+    let attribute = quote! { (ERC1155) };
+    let item = quote! {
+        #[starknet::contract]
+        pub mod MyContract {
+            use openzeppelin_token::erc1155::ERC1155HooksEmptyImpl;
+
+            #[storage]
+            pub struct Storage {}
+
+            #[constructor]
+            fn constructor(ref self: ContractState) {
+                self.erc1155.initializer_no_metadata();
             }
         }
     };


### PR DESCRIPTION
Accepts initializer_no_metadata for ERC721 and ERC1155 component initialization and adds regression coverage.