### PR TITLE
[L-06] M3 Audit

### DIFF
--- a/packages/macros/src/attribute/type_hash/diagnostics.rs
+++ b/packages/macros/src/attribute/type_hash/diagnostics.rs
@@ -14,6 +14,9 @@ pub mod errors {
     /// Error when the format of the snip12 attribute is invalid.
     pub const INVALID_SNIP12_ATTRIBUTE_FORMAT: &str =
         "Invalid format for the snip12 attribute. The only valid arguments are: name, kind.\n";
+    /// Error when a member has more than one snip12 attribute.
+    pub const MULTIPLE_SNIP12_ATTRIBUTES: &str =
+        "Only one snip12 attribute can be applied to a member.\n";
     /// Error when the string argument is invalid.
     pub const INVALID_STRING_ARGUMENT: &str =
         "Invalid string argument. Expected a non-empty string between double quotes.\n";

--- a/packages/macros/src/attribute/type_hash/parser.rs
+++ b/packages/macros/src/attribute/type_hash/parser.rs
@@ -160,17 +160,21 @@ fn get_name_and_type_from_attributes(
     db: &dyn SyntaxGroup,
     attributes: &[Attribute],
 ) -> Result<Snip12Args, Diagnostic> {
+    let mut snip12_args = None;
     for attribute in attributes {
         let attribute_text = attribute.as_syntax_node().get_text_without_trivia(db);
         let Some(arguments) = snip12_attribute_arguments(attribute_text.long(db).as_str()) else {
             continue;
         };
-        return parse_snip12_args(arguments);
+        if snip12_args.is_some() {
+            return Err(Diagnostic::error(errors::MULTIPLE_SNIP12_ATTRIBUTES));
+        }
+        snip12_args = Some(parse_snip12_args(arguments)?);
     }
-    Ok(Snip12Args {
+    Ok(snip12_args.unwrap_or(Snip12Args {
         name: String::new(),
         kind: String::new(),
-    })
+    }))
 }
 
 /// Extracts the argument section from a `#[snip12(...)]` attribute.
@@ -218,7 +222,10 @@ pub(crate) fn parse_snip12_args(s: &str) -> Result<Snip12Args, Diagnostic> {
 
     // If the attribute is empty, return the default args
     let s = s.trim();
-    if s.is_empty() || s == "()" {
+    if s.is_empty() {
+        return Err(Diagnostic::error(errors::INVALID_SNIP12_ATTRIBUTE_FORMAT));
+    }
+    if s == "()" {
         return Ok(args);
     }
 

--- a/packages/macros/src/attribute/type_hash/parser.rs
+++ b/packages/macros/src/attribute/type_hash/parser.rs
@@ -220,7 +220,7 @@ pub(crate) fn parse_snip12_args(s: &str) -> Result<Snip12Args, Diagnostic> {
         kind: String::new(),
     };
 
-    // If the attribute is empty, return the default args
+    // Reject empty arguments; explicit `()` uses the default args.
     let s = s.trim();
     if s.is_empty() {
         return Err(Diagnostic::error(errors::INVALID_SNIP12_ATTRIBUTE_FORMAT));

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__multiple_snip12_attributes.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__multiple_snip12_attributes.snap
@@ -1,0 +1,22 @@
+---
+source: src/tests/test_type_hash.rs
+expression: result
+---
+TokenStream:
+
+pub struct MyType {
+    #[snip12(name: "ts")]
+    #[snip12(kind: "timestamp")]
+    pub timestamp: u128,
+}
+
+
+Diagnostics:
+
+====
+Error: Only one snip12 attribute can be applied to a member.
+====
+
+AuxData:
+
+None

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__snip12_attribute_bare.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__snip12_attribute_bare.snap
@@ -1,0 +1,21 @@
+---
+source: src/tests/test_type_hash.rs
+expression: result
+---
+TokenStream:
+
+pub struct MyType {
+    #[snip12]
+    pub name: felt252,
+}
+
+
+Diagnostics:
+
+====
+Error: Invalid format for the snip12 attribute. The only valid arguments are: name, kind.
+====
+
+AuxData:
+
+None

--- a/packages/macros/src/tests/test_type_hash.rs
+++ b/packages/macros/src/tests/test_type_hash.rs
@@ -47,6 +47,33 @@ fn test_snip12_attribute_empty() {
 }
 
 #[test]
+fn test_snip12_attribute_bare() {
+    let item = quote! {
+        pub struct MyType {
+            #[snip12]
+            pub name: felt252,
+        }
+    };
+    let attr_stream = quote! { (debug: true) };
+    let result = get_string_result(attr_stream, item);
+    assert_snapshot!(result);
+}
+
+#[test]
+fn test_multiple_snip12_attributes() {
+    let item = quote! {
+        pub struct MyType {
+            #[snip12(name: "ts")]
+            #[snip12(kind: "timestamp")]
+            pub timestamp: u128,
+        }
+    };
+    let attr_stream = quote! { (debug: true) };
+    let result = get_string_result(attr_stream, item);
+    assert_snapshot!(result);
+}
+
+#[test]
 fn test_basic_types() {
     // Basic types list:
     // - Felt


### PR DESCRIPTION
Rejects bare or repeated snip12 attributes and adds regression coverage for invalid attribute forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for `snip12` attributes during compilation.
  * Multiple `snip12` attributes now produce a clear diagnostic instead of silently selecting one.
  * Empty attribute input is rejected, while the explicitly empty `()` form remains supported.
  * Added clearer error reporting for conflicting attribute declarations.

* **Tests**
  * Added coverage for bare attributes and combinations of multiple attributes, including custom names and kinds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->