### PR TITLE
[L-05] M3 Audit

### DIFF
--- a/packages/macros/src/attribute/type_hash/diagnostics.rs
+++ b/packages/macros/src/attribute/type_hash/diagnostics.rs
@@ -24,4 +24,8 @@ pub mod errors {
     pub fn INVALID_SNIP12_TYPE(ty: &str) -> String {
         format!("Invalid SNIP-12 type: {ty}.\n")
     }
+    /// Error when a user-defined primary type reuses a SNIP-12 reserved name.
+    pub fn RESERVED_SNIP12_TYPE_NAME(name: &str) -> String {
+        format!("SNIP-12 type name `{name}` is reserved and cannot be used as a primary type.\n")
+    }
 }

--- a/packages/macros/src/attribute/type_hash/parser.rs
+++ b/packages/macros/src/attribute/type_hash/parser.rs
@@ -11,7 +11,7 @@ use crate::attribute::common::args::split_top_level_args;
 
 use super::definition::TypeHashArgs;
 use super::diagnostics::errors;
-use super::types::{split_types, InnerType, S12Type};
+use super::types::{is_reserved_type_name, split_types, InnerType, S12Type};
 
 const SNIP12_TYPE_ATTRIBUTE: &str = "snip12";
 
@@ -47,6 +47,17 @@ impl<'db, 'a> TypeHashParser<'db, 'a> {
         db: &'db dyn SyntaxGroup,
         args: &TypeHashArgs,
     ) -> Result<String, Diagnostic> {
+        let primary_type_name = if args.name.is_empty() {
+            self.plugin_type_info.name
+        } else {
+            &args.name
+        };
+        if is_reserved_type_name(primary_type_name) {
+            return Err(Diagnostic::error(errors::RESERVED_SNIP12_TYPE_NAME(
+                primary_type_name,
+            )));
+        }
+
         // 1. Get the members types real values from mapping and attributes
         let members_types = self
             .plugin_type_info
@@ -69,7 +80,11 @@ impl<'db, 'a> TypeHashParser<'db, 'a> {
                 } else {
                     member.ty.to_string()
                 };
-                let s12_type = S12Type::from_str(&type_input);
+                let s12_type = if attr_type.is_empty() {
+                    S12Type::from_cairo_type(&type_input)
+                } else {
+                    S12Type::from_str(&type_input)
+                };
 
                 // If there is an attribute, use it, otherwise use the name from the member
                 let s12_name = if !attr_name.is_empty() {
@@ -87,11 +102,7 @@ impl<'db, 'a> TypeHashParser<'db, 'a> {
             .collect::<Vec<Result<(String, S12Type), Diagnostic>>>();
 
         // 2. Build the string representation
-        let mut encoded_type = if args.name.is_empty() {
-            format!("\"{}\"(", self.plugin_type_info.name)
-        } else {
-            format!("\"{}\"(", args.name)
-        };
+        let mut encoded_type = format!("\"{primary_type_name}\"(");
         for result in members_types {
             let (name, s12_type) = result?;
             let type_name = s12_type.get_snip12_type_name()?;

--- a/packages/macros/src/attribute/type_hash/types.rs
+++ b/packages/macros/src/attribute/type_hash/types.rs
@@ -69,6 +69,18 @@ pub struct InnerType {
 impl S12Type {
     /// Creates a S12Type from a String
     pub fn from_str(s: &str) -> Option<S12Type> {
+        Self::parse(s, true)
+    }
+
+    /// Creates a S12Type from a Cairo type.
+    ///
+    /// SNIP-12-only schema aliases are treated as user-defined types unless they are selected
+    /// explicitly through a `#[snip12(kind: ...)]` override.
+    pub fn from_cairo_type(s: &str) -> Option<S12Type> {
+        Self::parse(s, false)
+    }
+
+    fn parse(s: &str, allow_schema_only_aliases: bool) -> Option<S12Type> {
         let s = s.trim();
 
         if s.is_empty() {
@@ -79,7 +91,7 @@ impl S12Type {
         if let Some(inner) = s.strip_prefix('(').and_then(|s| s.strip_suffix(')')) {
             let types = try_split_types(inner)?
                 .into_iter()
-                .map(S12Type::from_str)
+                .map(|ty| Self::parse(ty, allow_schema_only_aliases))
                 .collect::<Option<Vec<_>>>()?;
             return Some(S12Type::Collection(CollectionType::Tuple(types)));
         } else if s.starts_with('(') || s.ends_with(')') {
@@ -89,8 +101,14 @@ impl S12Type {
         // Check if the type is an array/span
         if let Some(inner) = s.strip_prefix("Array<").or_else(|| s.strip_prefix("Span<")) {
             let inner = inner.strip_suffix('>')?;
-            let array_type = Box::new(S12Type::from_str(inner)?);
+            let array_type = Box::new(Self::parse(inner, allow_schema_only_aliases)?);
             return Some(S12Type::Collection(CollectionType::Array(array_type)));
+        }
+
+        // These names exist in the SNIP-12 schema but are not unambiguous Cairo types. Without an
+        // explicit kind override they may instead refer to user-defined types with the same name.
+        if !allow_schema_only_aliases && is_schema_only_alias(s) {
+            return Some(S12Type::UserDefined(UserDefinedType::Custom(s.to_string())));
         }
 
         Some(match s {
@@ -154,6 +172,41 @@ impl S12Type {
             S12Type::UserDefined(user_defined_type) => user_defined_type.get_encoded_ref_type(),
         }
     }
+}
+
+/// Returns whether a name is a SNIP-12 schema alias rather than an unambiguous Cairo type.
+fn is_schema_only_alias(name: &str) -> bool {
+    matches!(
+        name,
+        "shortstring"
+            | "timestamp"
+            | "selector"
+            | "merkletree"
+            | "string"
+            | "TokenAmount"
+            | "NftId"
+    )
+}
+
+/// Returns whether a name is reserved for a SNIP-12 basic or preset type.
+pub fn is_reserved_type_name(name: &str) -> bool {
+    matches!(
+        name,
+        "felt"
+            | "bool"
+            | "string"
+            | "shortstring"
+            | "ClassHash"
+            | "ContractAddress"
+            | "timestamp"
+            | "selector"
+            | "merkletree"
+            | "u128"
+            | "i128"
+            | "TokenAmount"
+            | "NftId"
+            | "u256"
+    )
 }
 
 impl BasicType {

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__complex_enum_type.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__complex_enum_type.snap
@@ -6,7 +6,9 @@ snapshot_kind: text
 TokenStream:
 
 pub enum MyEnum {
+    #[snip12(kind: "TokenAmount")]
     Variant1: TokenAmount,
+    #[snip12(kind: "TokenAmount")]
     Variant2: TokenAmount,
     Variant3: u256,
     #[snip12(kind: "shortstring")]

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__complex_enum_with_collection_types.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__complex_enum_with_collection_types.snap
@@ -6,18 +6,25 @@ snapshot_kind: text
 TokenStream:
 
 pub enum MyEnum {
+    #[snip12(kind: "(felt252, felt252, ClassHash, NftId)")]
     Variant1: (felt252, felt252, ClassHash, NftId),
+    #[snip12(kind: "Array<TokenAmount>")]
     Variant2: Array<TokenAmount>,
     Variant3: Span<ClassHash>,
+    #[snip12(kind: "(ContractAddress, TokenAmount)")]
     Variant4: (ContractAddress, TokenAmount),
     Variant5: Array<ContractAddress>,
     Variant6: (),
     #[snip12(kind: "(timestamp, shortstring)")]
     Variant7: (u128, felt252),
     Variant8: (ContractAddress,),
+    #[snip12(kind: "(TokenAmount, (felt252, ClassHash), NftId)")]
     Variant9: (TokenAmount, (felt252, ClassHash), NftId),
+    #[snip12(kind: "(Array<TokenAmount>, Array<ContractAddress>)")]
     Variant10: (Array<TokenAmount>, Array<ContractAddress>),
+    #[snip12(kind: "Array<(TokenAmount, ContractAddress, Array<felt252>)>")]
     Variant11: Array<(TokenAmount, ContractAddress, Array<felt252>)>,
+    #[snip12(kind: "Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>")]
     Variant12: Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>,
 }
 pub fn __MY_ENUM_encoded_type() {

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__complex_enum_with_collection_types_custom_names.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__complex_enum_with_collection_types_custom_names.snap
@@ -6,13 +6,13 @@ snapshot_kind: text
 TokenStream:
 
 pub enum MyEnum {
-    #[snip12(name: "Variant 1")]
+    #[snip12(name: "Variant 1", kind: "(felt252, felt252, ClassHash, NftId)")]
     Variant1: (felt252, felt252, ClassHash, NftId),
-    #[snip12(name: "Variant 2")]
+    #[snip12(name: "Variant 2", kind: "Array<TokenAmount>")]
     Variant2: Array<TokenAmount>,
     #[snip12(name: "Variant 3")]
     Variant3: Span<ClassHash>,
-    #[snip12(name: "Variant 4")]
+    #[snip12(name: "Variant 4", kind: "(ContractAddress, TokenAmount)")]
     Variant4: (ContractAddress, TokenAmount),
     #[snip12(name: "Variant 5")]
     Variant5: Array<ContractAddress>,
@@ -22,13 +22,16 @@ pub enum MyEnum {
     Variant7: (u128, felt252),
     #[snip12(name: "Variant 8")]
     Variant8: (ContractAddress,),
-    #[snip12(name: "Variant 9")]
+    #[snip12(name: "Variant 9", kind: "(TokenAmount, (felt252, ClassHash), NftId)")]
     Variant9: (TokenAmount, (felt252, ClassHash), NftId),
-    #[snip12(name: "Variant 10")]
+    #[snip12(name: "Variant 10", kind: "(Array<TokenAmount>, Array<ContractAddress>)")]
     Variant10: (Array<TokenAmount>, Array<ContractAddress>),
-    #[snip12(name: "Variant 11")]
+    #[snip12(name: "Variant 11", kind: "Array<(TokenAmount, ContractAddress, Array<felt252>)>")]
     Variant11: Array<(TokenAmount, ContractAddress, Array<felt252>)>,
-    #[snip12(name: "Variant 12")]
+    #[snip12(
+        name: "Variant 12",
+        kind: "Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>",
+    )]
     Variant12: Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>,
 }
 pub fn __MY_ENUM_encoded_type() {

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__complex_struct_type.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__complex_struct_type.snap
@@ -6,7 +6,9 @@ snapshot_kind: text
 TokenStream:
 
 pub struct MyType {
+    #[snip12(kind: "TokenAmount")]
     pub token_amount: TokenAmount,
+    #[snip12(kind: "TokenAmount")]
     pub token_amount_2: TokenAmount,
     pub number: u256,
     #[snip12(kind: "shortstring")]

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__complex_struct_with_collection_types.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__complex_struct_with_collection_types.snap
@@ -6,18 +6,25 @@ snapshot_kind: text
 TokenStream:
 
 pub struct MyType {
+    #[snip12(kind: "(felt252, felt252, ClassHash, NftId)")]
     pub member1: (felt252, felt252, ClassHash, NftId),
+    #[snip12(kind: "Array<TokenAmount>")]
     pub member2: Array<TokenAmount>,
     pub member3: Span<ClassHash>,
+    #[snip12(kind: "(ContractAddress, TokenAmount)")]
     pub member4: (ContractAddress, TokenAmount),
     pub member5: Array<ContractAddress>,
     pub member6: (),
     #[snip12(kind: "(timestamp, shortstring)")]
     pub member7: (u128, felt252),
     pub member8: (ContractAddress,),
+    #[snip12(kind: "(TokenAmount, (felt252, ClassHash), NftId)")]
     pub member9: (TokenAmount, (felt252, ClassHash), NftId),
+    #[snip12(kind: "(Array<TokenAmount>, Array<ContractAddress>)")]
     pub member10: (Array<TokenAmount>, Array<ContractAddress>),
+    #[snip12(kind: "Array<(TokenAmount, ContractAddress, Array<felt252>)>")]
     pub member11: Array<(TokenAmount, ContractAddress, Array<felt252>)>,
+    #[snip12(kind: "Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>")]
     pub member12: Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>,
 }
 pub fn __MY_TYPE_encoded_type() {

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__complex_struct_with_collection_types_custom_names.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__complex_struct_with_collection_types_custom_names.snap
@@ -6,13 +6,13 @@ snapshot_kind: text
 TokenStream:
 
 pub struct MyType {
-    #[snip12(name: "Member 1")]
+    #[snip12(name: "Member 1", kind: "(felt252, felt252, ClassHash, NftId)")]
     pub member1: (felt252, felt252, ClassHash, NftId),
-    #[snip12(name: "Member 2")]
+    #[snip12(name: "Member 2", kind: "Array<TokenAmount>")]
     pub member2: Array<TokenAmount>,
     #[snip12(name: "Member 3")]
     pub member3: Span<ClassHash>,
-    #[snip12(name: "Member 4")]
+    #[snip12(name: "Member 4", kind: "(ContractAddress, TokenAmount)")]
     pub member4: (ContractAddress, TokenAmount),
     #[snip12(name: "Member 5")]
     pub member5: Array<ContractAddress>,
@@ -22,13 +22,16 @@ pub struct MyType {
     pub member7: (u128, felt252),
     #[snip12(name: "Member 8")]
     pub member8: (ContractAddress,),
-    #[snip12(name: "Member 9")]
+    #[snip12(name: "Member 9", kind: "(TokenAmount, (felt252, ClassHash), NftId)")]
     pub member9: (TokenAmount, (felt252, ClassHash), NftId),
-    #[snip12(name: "Member 10")]
+    #[snip12(name: "Member 10", kind: "(Array<TokenAmount>, Array<ContractAddress>)")]
     pub member10: (Array<TokenAmount>, Array<ContractAddress>),
-    #[snip12(name: "Member 11")]
+    #[snip12(name: "Member 11", kind: "Array<(TokenAmount, ContractAddress, Array<felt252>)>")]
     pub member11: Array<(TokenAmount, ContractAddress, Array<felt252>)>,
-    #[snip12(name: "Member 12")]
+    #[snip12(
+        name: "Member 12",
+        kind: "Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>",
+    )]
     pub member12: Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>,
 }
 pub fn __MY_TYPE_encoded_type() {

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__doc_example_6.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__doc_example_6.snap
@@ -6,9 +6,9 @@ snapshot_kind: text
 TokenStream:
 
 pub struct MyStruct {
-    #[snip12(name: "Token Amount")]
+    #[snip12(name: "Token Amount", kind: "TokenAmount")]
     pub token_amount: TokenAmount,
-    #[snip12(name: "NFT ID")]
+    #[snip12(name: "NFT ID", kind: "NftId")]
     pub nft_id: NftId,
     #[snip12(name: "Number")]
     pub number: u256,

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__doc_example_7.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__doc_example_7.snap
@@ -6,9 +6,9 @@ snapshot_kind: text
 TokenStream:
 
 pub enum MyEnum {
-    #[snip12(name: "Token Amount")]
+    #[snip12(name: "Token Amount", kind: "TokenAmount")]
     TokenAmount: TokenAmount,
-    #[snip12(name: "NFT ID")]
+    #[snip12(name: "NFT ID", kind: "NftId")]
     NftId: NftId,
     #[snip12(name: "Number")]
     Number: u256,

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__name_attribute.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__name_attribute.snap
@@ -6,13 +6,13 @@ snapshot_kind: text
 TokenStream:
 
 pub enum MyEnum {
-    #[snip12(name: "Variant 1")]
+    #[snip12(name: "Variant 1", kind: "(felt252, felt252, ClassHash, NftId)")]
     Variant1: (felt252, felt252, ClassHash, NftId),
-    #[snip12(name: "Variant 2")]
+    #[snip12(name: "Variant 2", kind: "Array<TokenAmount>")]
     Variant2: Array<TokenAmount>,
     #[snip12(name: "Variant 3")]
     Variant3: Span<ClassHash>,
-    #[snip12(name: "Variant 4")]
+    #[snip12(name: "Variant 4", kind: "(ContractAddress, TokenAmount)")]
     Variant4: (ContractAddress, TokenAmount),
     #[snip12(name: "Variant 5")]
     Variant5: Array<ContractAddress>,

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__potential_duplicate_types.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__potential_duplicate_types.snap
@@ -6,7 +6,9 @@ snapshot_kind: text
 TokenStream:
 
 pub struct MyType {
+    #[snip12(kind: "TokenAmount")]
     pub token_amount: TokenAmount,
+    #[snip12(kind: "TokenAmount")]
     pub token_amount_2: TokenAmount,
     pub number: u256,
 }

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__potential_duplicate_types_enum.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__potential_duplicate_types_enum.snap
@@ -6,7 +6,9 @@ snapshot_kind: text
 TokenStream:
 
 pub enum MyEnum {
+    #[snip12(kind: "TokenAmount")]
     Variant1: TokenAmount,
+    #[snip12(kind: "TokenAmount")]
     Variant2: TokenAmount,
     Variant3: u256,
 }

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__preset_types.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__preset_types.snap
@@ -6,7 +6,9 @@ snapshot_kind: text
 TokenStream:
 
 pub struct MyType {
+    #[snip12(kind: "TokenAmount")]
     pub token_amount: TokenAmount,
+    #[snip12(kind: "NftId")]
     pub nft_id: NftId,
     pub u256: u256,
 }

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__preset_types_enum.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__preset_types_enum.snap
@@ -6,7 +6,9 @@ snapshot_kind: text
 TokenStream:
 
 pub enum MyEnum {
+    #[snip12(kind: "TokenAmount")]
     Variant1: TokenAmount,
+    #[snip12(kind: "NftId")]
     Variant2: NftId,
     Variant3: u256,
 }

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__raw_schema_only_basic_is_rejected.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__raw_schema_only_basic_is_rejected.snap
@@ -1,0 +1,20 @@
+---
+source: src/tests/test_type_hash.rs
+expression: result
+---
+TokenStream:
+
+pub struct MyType {
+    pub version: shortstring,
+}
+
+
+Diagnostics:
+
+====
+Error: Inner custom types are not supported yet.
+====
+
+AuxData:
+
+None

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__raw_schema_only_preset_is_rejected.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__raw_schema_only_preset_is_rejected.snap
@@ -1,0 +1,20 @@
+---
+source: src/tests/test_type_hash.rs
+expression: result
+---
+TokenStream:
+
+pub struct MyType {
+    pub nft_id: NftId,
+}
+
+
+Diagnostics:
+
+====
+Error: Inner custom types are not supported yet.
+====
+
+AuxData:
+
+None

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__reserved_primary_type_name_is_rejected.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__reserved_primary_type_name_is_rejected.snap
@@ -1,0 +1,20 @@
+---
+source: src/tests/test_type_hash.rs
+expression: result
+---
+TokenStream:
+
+pub struct MyType {
+    pub value: u256,
+}
+
+
+Diagnostics:
+
+====
+Error: SNIP-12 type name `u256` is reserved and cannot be used as a primary type.
+====
+
+AuxData:
+
+None

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__with_array.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__with_array.snap
@@ -7,6 +7,7 @@ TokenStream:
 
 pub struct MyType {
     pub member1: Array<felt252>,
+    #[snip12(kind: "Array<TokenAmount>")]
     pub member2: Array<TokenAmount>,
     pub member3: Array<ClassHash>,
     pub member4: Array<ContractAddress>,

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__with_empty_tuple_enum.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__with_empty_tuple_enum.snap
@@ -6,6 +6,7 @@ snapshot_kind: text
 TokenStream:
 
 pub enum MyEnum {
+    #[snip12(kind: "TokenAmount")]
     Variant1: TokenAmount,
     Variant2: (),
 }

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__with_inner_u256_type.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__with_inner_u256_type.snap
@@ -6,6 +6,7 @@ snapshot_kind: text
 TokenStream:
 
 pub struct MyType {
+    #[snip12(kind: "TokenAmount")]
     pub token_amount: TokenAmount,
 }
 pub fn __MY_TYPE_encoded_type() {

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__with_inner_u256_type_enum.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__with_inner_u256_type_enum.snap
@@ -6,6 +6,7 @@ snapshot_kind: text
 TokenStream:
 
 pub enum MyEnum {
+    #[snip12(kind: "TokenAmount")]
     Variant1: TokenAmount,
 }
 pub fn __MY_ENUM_encoded_type() {

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__with_span.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__with_span.snap
@@ -7,6 +7,7 @@ TokenStream:
 
 pub struct MyType {
     pub member1: Span<felt252>,
+    #[snip12(kind: "Span<TokenAmount>")]
     pub member2: Span<TokenAmount>,
     pub member3: Span<ClassHash>,
     pub member4: Span<ContractAddress>,

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__with_tuple.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__with_tuple.snap
@@ -6,6 +6,7 @@ snapshot_kind: text
 TokenStream:
 
 pub struct MyType {
+    #[snip12(kind: "(felt252, felt252, ClassHash, NftId)")]
     pub member: (felt252, felt252, ClassHash, NftId),
 }
 pub fn __MY_TYPE_encoded_type() {

--- a/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__with_tuple_enum.snap
+++ b/packages/macros/src/tests/snapshots/openzeppelin_macros__tests__test_type_hash__with_tuple_enum.snap
@@ -6,7 +6,9 @@ snapshot_kind: text
 TokenStream:
 
 pub enum MyEnum {
+    #[snip12(kind: "(felt252, felt252, ClassHash, NftId)")]
     Variant1: (felt252, felt252, ClassHash, NftId),
+    #[snip12(kind: "TokenAmount")]
     Variant2: TokenAmount,
     Variant3: (ContractAddress,),
 }

--- a/packages/macros/src/tests/test_type_hash.rs
+++ b/packages/macros/src/tests/test_type_hash.rs
@@ -134,7 +134,9 @@ fn test_preset_types() {
     // - U256
     let item = quote! {
         pub struct MyType {
+            #[snip12(kind: "TokenAmount")]
             pub token_amount: TokenAmount,
+            #[snip12(kind: "NftId")]
             pub nft_id: NftId,
             pub u256: u256,
         }
@@ -148,12 +150,50 @@ fn test_preset_types() {
 fn test_preset_types_enum() {
     let item = quote! {
         pub enum MyEnum {
+            #[snip12(kind: "TokenAmount")]
             Variant1: TokenAmount,
+            #[snip12(kind: "NftId")]
             Variant2: NftId,
             Variant3: u256,
         }
     };
     let attr_stream = quote! { (debug: true) };
+    let result = get_string_result(attr_stream, item);
+    assert_snapshot!(result);
+}
+
+#[test]
+fn test_raw_schema_only_preset_is_rejected() {
+    let item = quote! {
+        pub struct MyType {
+            pub nft_id: NftId,
+        }
+    };
+    let attr_stream = quote! { (debug: true) };
+    let result = get_string_result(attr_stream, item);
+    assert_snapshot!(result);
+}
+
+#[test]
+fn test_raw_schema_only_basic_is_rejected() {
+    let item = quote! {
+        pub struct MyType {
+            pub version: shortstring,
+        }
+    };
+    let attr_stream = quote! { (debug: true) };
+    let result = get_string_result(attr_stream, item);
+    assert_snapshot!(result);
+}
+
+#[test]
+fn test_reserved_primary_type_name_is_rejected() {
+    let item = quote! {
+        pub struct MyType {
+            pub value: u256,
+        }
+    };
+    let attr_stream = quote! { (name: "u256", debug: true) };
     let result = get_string_result(attr_stream, item);
     assert_snapshot!(result);
 }
@@ -175,6 +215,7 @@ fn test_with_inner_u256_type() {
         pub struct MyType {
             // TokenAmount type contains u256, which should be resolved
             // and appended to the final type hash.
+            #[snip12(kind: "TokenAmount")]
             pub token_amount: TokenAmount,
         }
     };
@@ -189,6 +230,7 @@ fn test_with_inner_u256_type_enum() {
         pub enum MyEnum {
             // TokenAmount type contains u256, which should be resolved
             // and appended to the final type hash.
+            #[snip12(kind: "TokenAmount")]
             Variant1: TokenAmount,
         }
     };
@@ -203,7 +245,9 @@ fn test_potential_duplicate_types() {
         pub struct MyType {
             // TokenAmount type contains u256, which should be resolved
             // and appended to the final type hash.
+            #[snip12(kind: "TokenAmount")]
             pub token_amount: TokenAmount,
+            #[snip12(kind: "TokenAmount")]
             pub token_amount_2: TokenAmount,
             pub number: u256,
         }
@@ -219,7 +263,9 @@ fn test_potential_duplicate_types_enum() {
         pub enum MyEnum {
             // TokenAmount type contains u256, which should be resolved
             // and appended to the final type hash.
+            #[snip12(kind: "TokenAmount")]
             Variant1: TokenAmount,
+            #[snip12(kind: "TokenAmount")]
             Variant2: TokenAmount,
             Variant3: u256,
         }
@@ -233,7 +279,9 @@ fn test_potential_duplicate_types_enum() {
 fn test_complex_struct_type() {
     let item = quote! {
         pub struct MyType {
+            #[snip12(kind: "TokenAmount")]
             pub token_amount: TokenAmount,
+            #[snip12(kind: "TokenAmount")]
             pub token_amount_2: TokenAmount,
             pub number: u256,
             #[snip12(kind: "shortstring")]
@@ -257,7 +305,9 @@ fn test_complex_struct_type() {
 fn test_complex_enum_type() {
     let item = quote! {
         pub enum MyEnum {
+            #[snip12(kind: "TokenAmount")]
             Variant1: TokenAmount,
+            #[snip12(kind: "TokenAmount")]
             Variant2: TokenAmount,
             Variant3: u256,
             #[snip12(kind: "shortstring")]
@@ -297,6 +347,7 @@ fn test_with_inner_custom_type() {
 fn test_with_tuple() {
     let item = quote! {
         pub struct MyType {
+            #[snip12(kind: "(felt252, felt252, ClassHash, NftId)")]
             pub member: (felt252, felt252, ClassHash, NftId),
         }
     };
@@ -309,7 +360,9 @@ fn test_with_tuple() {
 fn test_with_tuple_enum() {
     let item = quote! {
         pub enum MyEnum {
+            #[snip12(kind: "(felt252, felt252, ClassHash, NftId)")]
             Variant1: (felt252, felt252, ClassHash, NftId),
+            #[snip12(kind: "TokenAmount")]
             Variant2: TokenAmount,
             Variant3: (ContractAddress,),
         }
@@ -336,6 +389,7 @@ fn test_with_empty_tuple() {
 fn test_with_empty_tuple_enum() {
     let item = quote! {
         pub enum MyEnum {
+            #[snip12(kind: "TokenAmount")]
             Variant1: TokenAmount,
             Variant2: (),
         }
@@ -350,6 +404,7 @@ fn test_with_array() {
     let item = quote! {
         pub struct MyType {
             pub member1: Array<felt252>,
+            #[snip12(kind: "Array<TokenAmount>")]
             pub member2: Array<TokenAmount>,
             pub member3: Array<ClassHash>,
             pub member4: Array<ContractAddress>,
@@ -367,6 +422,7 @@ fn test_with_span() {
     let item = quote! {
         pub struct MyType {
             pub member1: Span<felt252>,
+            #[snip12(kind: "Span<TokenAmount>")]
             pub member2: Span<TokenAmount>,
             pub member3: Span<ClassHash>,
             pub member4: Span<ContractAddress>,
@@ -415,18 +471,25 @@ fn test_starknet_domain() {
 fn test_complex_struct_with_collection_types() {
     let item = quote! {
         pub struct MyType {
+            #[snip12(kind: "(felt252, felt252, ClassHash, NftId)")]
             pub member1: (felt252, felt252, ClassHash, NftId),
+            #[snip12(kind: "Array<TokenAmount>")]
             pub member2: Array<TokenAmount>,
             pub member3: Span<ClassHash>,
+            #[snip12(kind: "(ContractAddress, TokenAmount)")]
             pub member4: (ContractAddress, TokenAmount),
             pub member5: Array<ContractAddress>,
             pub member6: (),
             #[snip12(kind: "(timestamp, shortstring)")]
             pub member7: (u128, felt252),
             pub member8: (ContractAddress,),
+            #[snip12(kind: "(TokenAmount, (felt252, ClassHash), NftId)")]
             pub member9: (TokenAmount, (felt252, ClassHash), NftId),
+            #[snip12(kind: "(Array<TokenAmount>, Array<ContractAddress>)")]
             pub member10: (Array<TokenAmount>, Array<ContractAddress>),
+            #[snip12(kind: "Array<(TokenAmount, ContractAddress, Array<felt252>)>")]
             pub member11: Array<(TokenAmount, ContractAddress, Array<felt252>)>,
+            #[snip12(kind: "Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>")]
             pub member12: Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>,
         }
     };
@@ -439,13 +502,13 @@ fn test_complex_struct_with_collection_types() {
 fn test_complex_struct_with_collection_types_custom_names() {
     let item = quote! {
         pub struct MyType {
-            #[snip12(name: "Member 1")]
+            #[snip12(name: "Member 1", kind: "(felt252, felt252, ClassHash, NftId)")]
             pub member1: (felt252, felt252, ClassHash, NftId),
-            #[snip12(name: "Member 2")]
+            #[snip12(name: "Member 2", kind: "Array<TokenAmount>")]
             pub member2: Array<TokenAmount>,
             #[snip12(name: "Member 3")]
             pub member3: Span<ClassHash>,
-            #[snip12(name: "Member 4")]
+            #[snip12(name: "Member 4", kind: "(ContractAddress, TokenAmount)")]
             pub member4: (ContractAddress, TokenAmount),
             #[snip12(name: "Member 5")]
             pub member5: Array<ContractAddress>,
@@ -455,13 +518,13 @@ fn test_complex_struct_with_collection_types_custom_names() {
             pub member7: (u128, felt252),
             #[snip12(name: "Member 8")]
             pub member8: (ContractAddress,),
-            #[snip12(name: "Member 9")]
+            #[snip12(name: "Member 9", kind: "(TokenAmount, (felt252, ClassHash), NftId)")]
             pub member9: (TokenAmount, (felt252, ClassHash), NftId),
-            #[snip12(name: "Member 10")]
+            #[snip12(name: "Member 10", kind: "(Array<TokenAmount>, Array<ContractAddress>)")]
             pub member10: (Array<TokenAmount>, Array<ContractAddress>),
-            #[snip12(name: "Member 11")]
+            #[snip12(name: "Member 11", kind: "Array<(TokenAmount, ContractAddress, Array<felt252>)>")]
             pub member11: Array<(TokenAmount, ContractAddress, Array<felt252>)>,
-            #[snip12(name: "Member 12")]
+            #[snip12(name: "Member 12", kind: "Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>")]
             pub member12: Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>,
         }
     };
@@ -474,18 +537,25 @@ fn test_complex_struct_with_collection_types_custom_names() {
 fn test_complex_enum_with_collection_types() {
     let item = quote! {
         pub enum MyEnum {
+            #[snip12(kind: "(felt252, felt252, ClassHash, NftId)")]
             Variant1: (felt252, felt252, ClassHash, NftId),
+            #[snip12(kind: "Array<TokenAmount>")]
             Variant2: Array<TokenAmount>,
             Variant3: Span<ClassHash>,
+            #[snip12(kind: "(ContractAddress, TokenAmount)")]
             Variant4: (ContractAddress, TokenAmount),
             Variant5: Array<ContractAddress>,
             Variant6: (),
             #[snip12(kind: "(timestamp, shortstring)")]
             Variant7: (u128, felt252),
             Variant8: (ContractAddress,),
+            #[snip12(kind: "(TokenAmount, (felt252, ClassHash), NftId)")]
             Variant9: (TokenAmount, (felt252, ClassHash), NftId),
+            #[snip12(kind: "(Array<TokenAmount>, Array<ContractAddress>)")]
             Variant10: (Array<TokenAmount>, Array<ContractAddress>),
+            #[snip12(kind: "Array<(TokenAmount, ContractAddress, Array<felt252>)>")]
             Variant11: Array<(TokenAmount, ContractAddress, Array<felt252>)>,
+            #[snip12(kind: "Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>")]
             Variant12: Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>,
         }
     };
@@ -498,13 +568,13 @@ fn test_complex_enum_with_collection_types() {
 fn test_complex_enum_with_collection_types_custom_names() {
     let item = quote! {
         pub enum MyEnum {
-            #[snip12(name: "Variant 1")]
+            #[snip12(name: "Variant 1", kind: "(felt252, felt252, ClassHash, NftId)")]
             Variant1: (felt252, felt252, ClassHash, NftId),
-            #[snip12(name: "Variant 2")]
+            #[snip12(name: "Variant 2", kind: "Array<TokenAmount>")]
             Variant2: Array<TokenAmount>,
             #[snip12(name: "Variant 3")]
             Variant3: Span<ClassHash>,
-            #[snip12(name: "Variant 4")]
+            #[snip12(name: "Variant 4", kind: "(ContractAddress, TokenAmount)")]
             Variant4: (ContractAddress, TokenAmount),
             #[snip12(name: "Variant 5")]
             Variant5: Array<ContractAddress>,
@@ -514,13 +584,13 @@ fn test_complex_enum_with_collection_types_custom_names() {
             Variant7: (u128, felt252),
             #[snip12(name: "Variant 8")]
             Variant8: (ContractAddress,),
-            #[snip12(name: "Variant 9")]
+            #[snip12(name: "Variant 9", kind: "(TokenAmount, (felt252, ClassHash), NftId)")]
             Variant9: (TokenAmount, (felt252, ClassHash), NftId),
-            #[snip12(name: "Variant 10")]
+            #[snip12(name: "Variant 10", kind: "(Array<TokenAmount>, Array<ContractAddress>)")]
             Variant10: (Array<TokenAmount>, Array<ContractAddress>),
-            #[snip12(name: "Variant 11")]
+            #[snip12(name: "Variant 11", kind: "Array<(TokenAmount, ContractAddress, Array<felt252>)>")]
             Variant11: Array<(TokenAmount, ContractAddress, Array<felt252>)>,
-            #[snip12(name: "Variant 12")]
+            #[snip12(name: "Variant 12", kind: "Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>")]
             Variant12: Array<Array<(Array<TokenAmount>, Array<ContractAddress>, Array<felt252>)>>,
         }
     };
@@ -533,13 +603,13 @@ fn test_complex_enum_with_collection_types_custom_names() {
 fn test_name_attribute() {
     let item = quote! {
         pub enum MyEnum {
-            #[snip12(name: "Variant 1")]
+            #[snip12(name: "Variant 1", kind: "(felt252, felt252, ClassHash, NftId)")]
             Variant1: (felt252, felt252, ClassHash, NftId),
-            #[snip12(name: "Variant 2")]
+            #[snip12(name: "Variant 2", kind: "Array<TokenAmount>")]
             Variant2: Array<TokenAmount>,
             #[snip12(name: "Variant 3")]
             Variant3: Span<ClassHash>,
-            #[snip12(name: "Variant 4")]
+            #[snip12(name: "Variant 4", kind: "(ContractAddress, TokenAmount)")]
             Variant4: (ContractAddress, TokenAmount),
             #[snip12(name: "Variant 5")]
             Variant5: Array<ContractAddress>,
@@ -699,9 +769,9 @@ fn test_doc_example_5() {
 fn test_doc_example_6() {
     let item = quote! {
         pub struct MyStruct {
-            #[snip12(name: "Token Amount")]
+            #[snip12(name: "Token Amount", kind: "TokenAmount")]
             pub token_amount: TokenAmount,
-            #[snip12(name: "NFT ID")]
+            #[snip12(name: "NFT ID", kind: "NftId")]
             pub nft_id: NftId,
             #[snip12(name: "Number")]
             pub number: u256,
@@ -716,9 +786,9 @@ fn test_doc_example_6() {
 fn test_doc_example_7() {
     let item_stream = quote! {
         pub enum MyEnum {
-            #[snip12(name: "Token Amount")]
+            #[snip12(name: "Token Amount", kind: "TokenAmount")]
             TokenAmount: TokenAmount,
-            #[snip12(name: "NFT ID")]
+            #[snip12(name: "NFT ID", kind: "NftId")]
             NftId: NftId,
             #[snip12(name: "Number")]
             Number: u256,


### PR DESCRIPTION
Rejects reserved SNIP-12 primary type names and distinguishes schema-only aliases from user-defined Cairo types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved SNIP-12 type handling for nested, tuple, array, and span types.
  * Supports custom type names while preserving recognition of supported built-in aliases.

* **Bug Fixes**
  * Prevents reserved SNIP-12 names from being used as user-defined primary types.
  * Rejects ambiguous type declarations that lack explicit type annotations.

* **Documentation**
  * Updated type-hash examples to include explicit `snip12(kind: ...)` annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->